### PR TITLE
Subforum: Speedup by using max instead of sort when getting last post

### DIFF
--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
@@ -63,7 +63,7 @@ namespace TASVideos.Pages.Forum.Subforum
 					CreateTimestamp = ft.CreateTimestamp,
 					Type = ft.Type,
 					PostCount = ft.ForumPosts.Count,
-					LastPost = ft.ForumPosts.OrderByDescending(fp => fp.CreateTimestamp).First()
+					LastPost = ft.ForumPosts.SingleOrDefault(fp => fp.CreateTimestamp == ft.ForumPosts.Max(fp => fp.CreateTimestamp))
 				})
 				.OrderByDescending(ft => ft.Type == ForumTopicType.Announcement)
 				.ThenByDescending(ft => ft.Type == ForumTopicType.Sticky)


### PR DESCRIPTION
This speeds up all subforums. E.g. the Workbench loading goes from 3s to 0.4s.
Instead of sorting the posts and then getting the first one in O(n*logn), it just calculates the maximum and then receives that one in O(n).
Even faster would be to use an ArgMax function, but it doesn't exist. I'm not sure if it's optimized to one. If not, it's possible this still takes twice as long as it needs to.