### PR TITLE
Email Confirmation Overhaul, and allow resending of email confirmation

### DIFF
--- a/TASVideos.Core/Services/UserManager.cs
+++ b/TASVideos.Core/Services/UserManager.cs
@@ -163,6 +163,27 @@ namespace TASVideos.Core.Services
 			return model;
 		}
 
+		public async Task AddStandardRoles(int userId)
+		{
+			var user = await _db.Users.SingleAsync(u => u.Id == userId);
+			var roles = await _db.Roles
+				.ThatAreDefault()
+				.ToListAsync();
+
+			foreach (var role in roles)
+			{
+				var userRole = new UserRole
+				{
+					UserId = user.Id,
+					RoleId = role.Id
+				};
+				_db.UserRoles.Add(userRole);
+				user.UserRoles.Add(userRole);
+			}
+
+			await _db.SaveChangesAsync();
+		}
+
 		/// <summary>
 		/// Returns publicly available user profile information
 		/// for the <see cref="User"/> with the given <see cref="userName"/>

--- a/TASVideos/Extensions/ServiceCollectionExtensions.cs
+++ b/TASVideos/Extensions/ServiceCollectionExtensions.cs
@@ -141,7 +141,7 @@ namespace TASVideos.Extensions
 		{
 			services.AddIdentity<User, Role>(config =>
 				{
-					config.SignIn.RequireConfirmedEmail = !env.IsDevelopment();
+					config.SignIn.RequireConfirmedEmail = false;
 					config.Password.RequiredLength = 12;
 					config.Password.RequireDigit = false;
 					config.Password.RequireLowercase = false;

--- a/TASVideos/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/TASVideos/Pages/Account/ConfirmEmail.cshtml.cs
@@ -1,5 +1,4 @@
-﻿using System.Net;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TASVideos.Core.Services;

--- a/TASVideos/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/TASVideos/Pages/Account/ConfirmEmail.cshtml.cs
@@ -46,9 +46,11 @@ namespace TASVideos.Pages.Account
 				return RedirectToPage("/Error");
 			}
 
+			await _userManager.AddStandardRoles(user.Id);
+			await _userManager.AddUserPermissionsToClaims(user);
 			await _signInManager.SignInAsync(user, isPersistent: false);
-			await _publisher.SendUserManagement($"New User joined! {user.UserName}", "", $"Users/Profile/{user.UserName}", user.UserName);
-			await _userMaintenanceLogger.Log(user.Id, $"New registration from {IpAddress}");
+			await _publisher.SendUserManagement($"User {user.UserName} activated", "", $"Users/Profile/{user.UserName}", user.UserName);
+			await _userMaintenanceLogger.Log(user.Id, $"User activated from {IpAddress}");
 			return Page();
 		}
 	}

--- a/TASVideos/Pages/Account/Register.cshtml.cs
+++ b/TASVideos/Pages/Account/Register.cshtml.cs
@@ -133,8 +133,8 @@ namespace TASVideos.Pages.Account
 				var result = await _userManager.CreateAsync(user, Password);
 				if (result.Succeeded)
 				{
-					var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-					var callbackUrl = Url.EmailConfirmationLink(user.Id.ToString(), code, Request.Scheme);
+					var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+					var callbackUrl = Url.EmailConfirmationLink(user.Id.ToString(), token, Request.Scheme);
 					await _emailService.EmailConfirmation(Email, callbackUrl);
 
 					await _signInManager.SignInAsync(user, isPersistent: false);

--- a/TASVideos/Pages/Account/Register.cshtml.cs
+++ b/TASVideos/Pages/Account/Register.cshtml.cs
@@ -133,17 +133,9 @@ namespace TASVideos.Pages.Account
 				var result = await _userManager.CreateAsync(user, Password);
 				if (result.Succeeded)
 				{
-					if (_userManager.Options.SignIn.RequireConfirmedEmail)
-					{
-						var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-						var callbackUrl = Url.EmailConfirmationLink(user.Id.ToString(), code, Request.Scheme);
-						await _emailService.EmailConfirmation(Email, callbackUrl);
-					}
-					else
-					{
-						await _userManager.AddStandardRoles(user.Id);
-						await _userManager.AddUserPermissionsToClaims(user);
-					}
+					var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+					var callbackUrl = Url.EmailConfirmationLink(user.Id.ToString(), code, Request.Scheme);
+					await _emailService.EmailConfirmation(Email, callbackUrl);
 
 					await _signInManager.SignInAsync(user, isPersistent: false);
 					await _publisher.SendUserManagement($"New User joined! {user.UserName}", "", $"Users/Profile/{user.UserName}", user.UserName);

--- a/TASVideos/Pages/Account/SendConfirmationEmail.cshtml
+++ b/TASVideos/Pages/Account/SendConfirmationEmail.cshtml
@@ -1,0 +1,2 @@
+﻿@page
+@model SendConfirmationEmail

--- a/TASVideos/Pages/Account/SendConfirmationEmail.cshtml.cs
+++ b/TASVideos/Pages/Account/SendConfirmationEmail.cshtml.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TASVideos.Core.Services;
+using TASVideos.Core.Services.Email;
+
+namespace TASVideos.Pages.Account
+{
+	[Authorize]
+	[IpBanCheck]
+	public class SendConfirmationEmail : BasePageModel
+	{
+		private readonly UserManager _userManager;
+		private readonly IEmailService _emailService;
+
+		public SendConfirmationEmail(UserManager userManager, IEmailService emailService)
+		{
+			_userManager = userManager;
+			_emailService = emailService;
+		}
+
+		public async Task<IActionResult> OnPost()
+		{
+			var user = await _userManager.GetUserAsync(User);
+			var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+			var callbackUrl = Url.EmailConfirmationLink(user.Id.ToString(), code, Request.Scheme);
+			await _emailService.EmailConfirmation(user.Email, callbackUrl);
+
+			return RedirectToPage("EmailConfirmationSent");
+		}
+	}
+}

--- a/TASVideos/Pages/Account/SendConfirmationEmail.cshtml.cs
+++ b/TASVideos/Pages/Account/SendConfirmationEmail.cshtml.cs
@@ -22,8 +22,8 @@ namespace TASVideos.Pages.Account
 		public async Task<IActionResult> OnPost()
 		{
 			var user = await _userManager.GetUserAsync(User);
-			var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-			var callbackUrl = Url.EmailConfirmationLink(user.Id.ToString(), code, Request.Scheme);
+			var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+			var callbackUrl = Url.EmailConfirmationLink(user.Id.ToString(), token, Request.Scheme);
 			await _emailService.EmailConfirmation(user.Email, callbackUrl);
 
 			return RedirectToPage("EmailConfirmationSent");

--- a/TASVideos/Pages/Profile/Index.cshtml
+++ b/TASVideos/Pages/Profile/Index.cshtml
@@ -10,7 +10,7 @@
 		Until your email is confirmed, you will not have any roles associated with your account and will not be able to do things such as post on the forums, submit movies, or rate movies
 	</p>
 	<p>
-		You should have already received a confirmation email. If you did not recieve it, try checking your spam folder or you can resend the email confirmation
+		You should have already received a confirmation email. If you did not receive it, try checking your spam folder or you can resend the email confirmation
 		<br />
 	</p>
 	<form method="post" asp-page="/Account/SendConfirmationEmail">

--- a/TASVideos/Pages/Profile/Index.cshtml
+++ b/TASVideos/Pages/Profile/Index.cshtml
@@ -11,7 +11,10 @@
 	</p>
 	<p>
 		You should have already received a confirmation email. If you did not recieve it, try checking your spam folder or you can resend the email confirmation
-		<br /><a class="btn btn-warning">Resend Confirmation Email</a>
+		<br />
 	</p>
+	<form method="post" asp-page="/Account/SendConfirmationEmail">
+		<button type="submit" class="btn btn-warning">Resend Confirmation Email</button>
+	</form>
 </warning-alert>
 <partial name="_Profile" model="Model.Profile" />

--- a/TASVideos/Pages/Profile/Index.cshtml
+++ b/TASVideos/Pages/Profile/Index.cshtml
@@ -4,5 +4,14 @@
 	ViewData.AddActivePage(ProfileNavPages.Index);
 	ViewData["Title"] = "My Profile";
 }
-
+<warning-alert Condition="!Model.Profile.EmailConfirmed">
+	<h5>Your email is not confirmed!</h5>
+	<p>
+		Until your email is confirmed, you will not have any roles associated with your account and will not be able to do things such as post on the forums, submit movies, or rate movies
+	</p>
+	<p>
+		You should have already received a confirmation email. If you did not recieve it, try checking your spam folder or you can resend the email confirmation
+		<br /><a class="btn btn-warning">Resend Confirmation Email</a>
+	</p>
+</warning-alert>
 <partial name="_Profile" model="Model.Profile" />


### PR DESCRIPTION
Do not require email confirmation to sign in, but only assign permissions when email is confirmed.  Add a warning and a resend email confirmation link on profile.

Resolves #450

Note that in dev environments, more setup will be needed to register a new user and allow them to have permissions (by default it uses EmailLogger, so the link can be grabbed from logs)