### PR TITLE
Forum font size BBCode unit-less number fix

### DIFF
--- a/TASVideos.ForumEngine/Node.cs
+++ b/TASVideos.ForumEngine/Node.cs
@@ -368,7 +368,17 @@ namespace TASVideos.ForumEngine
 					w.Write("<span style=");
 
 					// TODO: More fully featured anti-style injection
-					Helpers.WriteAttributeValue(w, "font-size: " + Options.Split(';')[0]);
+					var sizeStr = Options.Split(';')[0];
+					if (double.TryParse(sizeStr, out double sizeDouble))
+					{
+						// default font size of the old site was 12px, so if size was given without a unit, divide by 12 and use em
+						Helpers.WriteAttributeValue(w, "font-size: " + (sizeDouble / 12) + "em");
+					}
+					else
+					{
+						Helpers.WriteAttributeValue(w, "font-size: " + sizeStr);
+					}
+
 					w.Write('>');
 					await WriteChildren(w, h);
 					w.Write("</span>");


### PR DESCRIPTION
There are a lot of instances where `[size=9]text[/size]` was used.
The old site converted it to `font-size: 9px`.
The current demo site converts it to `font-size: 9` which isn't valid.

Just adding a px string would give wrong results, since the default font size was 12px but is now 14px, and might or might not change.
This PR instead converts `[size=9]` to `font-size: 0.75em` (9px/12px = 0.75) to give a proper representation regardless of default font size.