### PR TITLE
Monospace element background colors

### DIFF
--- a/TASVideos.WikiEngine/NewParser.cs
+++ b/TASVideos.WikiEngine/NewParser.cs
@@ -535,11 +535,11 @@ namespace TASVideos.WikiEngine
 			}
 			else if (Eat("{{"))
 			{
-				Push("tt");
+				Push("code");
 			}
 			else if (Eat("}}"))
 			{
-				if (!TryPop("tt"))
+				if (!TryPop("code"))
 				{
 					AddText("}}");
 				}

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -352,6 +352,13 @@ article.wiki, .postbody {
 	font-size: 28px;
 }
 
+tt {
+	font-family: var(--bs-font-monospace);
+	font-size: 1em;
+	direction: ltr;
+	unicode-bidi: bidi-override;
+}
+
 tt, code, kbd, pre, samp {
 	background: var(--bs-gray-400);
 	border-radius: 5px;

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -351,3 +351,10 @@ article.wiki, .postbody {
 #button-scrolltop {
 	font-size: 28px;
 }
+
+tt, code, kbd, pre, samp {
+	background: var(--bs-gray-400);
+	border-radius: 5px;
+	padding: 0.125rem 0.375rem;
+	font-size: 85%;
+}


### PR DESCRIPTION
fix #329 
Have the wiki render `{{}}` to `<code>` instead of `<tt>` so it isn't using deprecated elements and gets picked up by bootstrap's monospace font reboot
Also adds a background color that varies for dark mode.