### PR TITLE
Prototype improvement for watching options

### DIFF
--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -85,10 +85,10 @@
 				<div>
 					@foreach (var url in Model.OnlineWatchingUrls)
 					{
-						YouTube: <a>Embed here</a><a href="@url" class="btn btn-primary btn-sm mt-1" target="_blank"><i class="fa fa-external-link"></i> New tab</a>
+						YouTube: <a>Watch here</a><a href="@url" class="btn btn-primary btn-sm mt-1" target="_blank"><i class="fa fa-external-link"></i> New tab</a>
 					}
 				</div>
-				<div>Video .mp4: <a>Embed here</a><a condition="@(!string.IsNullOrWhiteSpace(Model.MirrorSiteUrl))" href="@Model.MirrorSiteUrl" class="ms-2"> Video file via Mirror<br /></a>
+				<div>Video .mp4: <a>Watch here</a><a condition="@(!string.IsNullOrWhiteSpace(Model.MirrorSiteUrl))" href="@Model.MirrorSiteUrl" class="ms-2"> Video file via Mirror<br /></a>
 				</div>
 				@foreach (var award in publicationAwards.OrderByDescending(a => a.Year))
 				{

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -1,4 +1,4 @@
-﻿@model TASVideos.Pages.Publications.Models.PublicationDisplayModel
+@model TASVideos.Pages.Publications.Models.PublicationDisplayModel
 @{
 	var classIconPath2X = "";
 	var classIconPath4X = "";
@@ -79,28 +79,40 @@
 						 class="w-100 pixelart-image"
 						 loading="lazy" />
 				</div>
+				<div align="center">Watching options</div>
+				<div>Movie file: <a asp-page="/Publications/View" asp-page-handler="Download" asp-route-id="@Model.Id" class="btn btn-primary btn-sm mt-1"><i class="fa fa-download"></i> Download @System.IO.Path.GetExtension(Model.MovieFileName)</a><a>Download @Model.EmulatorVersion</a>
+				</div>
 				<div>
 					@foreach (var url in Model.OnlineWatchingUrls)
 					{
-						<a href="@url" class="btn btn-primary btn-sm mt-1" target="_blank"><i class="fa fa-external-link"></i> Watch</a>
+						YouTube: <a>Embed here</a><a href="@url" class="btn btn-primary btn-sm mt-1" target="_blank"><i class="fa fa-external-link"></i> New tab</a>
 					}
-					<a asp-page="/Publications/View" asp-page-handler="Download" asp-route-id="@Model.Id" class="btn btn-primary btn-sm mt-1"><i class="fa fa-download"></i> Download (@System.IO.Path.GetExtension(Model.MovieFileName))</a>
 				</div>
-				<div>
-					<a asp-page="/Submissions/View" asp-route-id="@Model.SubmissionId" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-info-circle"></i> Submission</a>
-					<a condition="@Model.TopicId > 0"
-					   asp-page="/Forum/Topics/Index"
-					   asp-route-id="@Model.TopicId"
-					   class="btn btn-secondary btn-sm mt-1">
-						<i class="fa fa-comments-o"></i> Discuss
-					</a>
+				<div>Video .mp4: <a>Embed here</a><a condition="@(!string.IsNullOrWhiteSpace(Model.MirrorSiteUrl))" href="@Model.MirrorSiteUrl" class="ms-2"> Video file via Mirror<br /></a>
 				</div>
-				<div>
-					<a asp-page="/Publications/Rate" asp-route-id="@Model.Id" class="btn btn-warning btn-sm mt-1">
-						<i class="fa fa-star-o"></i> @Math.Round(Model.OverallRating ?? 0, 2, MidpointRounding.AwayFromZero) / 10
-					</a>
-					<a asp-page="/Ratings/Index" asp-route-id="@Model.Id" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-list-ul"></i> Votes: @Model.RatingCount</a>
-				</div>
+				@foreach (var award in publicationAwards.OrderByDescending(a => a.Year))
+				{
+					<partial name="_Award" model="award" />
+				}
+			</div>
+			<div class="col-md">
+				<fullrow>
+					<div>
+						<small>Published on @Model.CreateTimestamp.Date.ToShortDateString() </small>
+						<a asp-page="/Submissions/View" asp-route-id="@Model.SubmissionId" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-info-circle"></i> Submission</a>
+						<a condition="@Model.TopicId > 0"
+						   asp-page="/Forum/Topics/Index"
+						   asp-route-id="@Model.TopicId"
+						   class="btn btn-secondary btn-sm mt-1">
+							<i class="fa fa-comments-o"></i> Discuss
+						</a>
+						<a asp-page="/Publications/Rate" asp-route-id="@Model.Id" class="btn btn-warning btn-sm mt-1">
+							<i class="fa fa-star-o"></i> @Math.Round(Model.OverallRating ?? 0, 2, MidpointRounding.AwayFromZero) / 10
+						</a>
+						<a asp-page="/Ratings/Index" asp-route-id="@Model.Id" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-list-ul"></i> Votes: @Model.RatingCount</a>
+					</div>
+					@await Component.RenderWiki(LinkConstants.PublicationWikiPage + Model.Id)
+				</fullrow>
 				<div>
 					<a permission="EditPublicationMetaData"
 					   asp-page="Edit"
@@ -116,16 +128,6 @@
 						<i class="fa fa-history"></i> Logs
 					</a>
 				</div>
-				@foreach (var award in publicationAwards.OrderByDescending(a => a.Year))
-				{
-					<partial name="_Award" model="award" />
-				}
-			</div>
-			<div class="col-md">
-				<fullrow>
-					<div><small>@Model.CreateTimestamp.Date.ToShortDateString()</small></div>
-					@await Component.RenderWiki(LinkConstants.PublicationWikiPage + Model.Id)
-				</fullrow>
 			</div>
 		</row>
 		<row condition="Model.ObsoletedMovies.Any()" class="my-2 gx-3">
@@ -173,12 +175,12 @@
 			</div>
 			<div class="col-auto">
 				<small condition="!string.IsNullOrWhiteSpace(Model.MirrorSiteUrl) || Model.TorrentLinks.Any()">
-					A/V files:<br />
-					<a condition="@(!string.IsNullOrWhiteSpace(Model.MirrorSiteUrl))" href="@Model.MirrorSiteUrl" class="ms-2">A/V file via Mirror<br /></a>
+					Video files download:<br />
+					<a condition="@(!string.IsNullOrWhiteSpace(Model.MirrorSiteUrl))" href="@Model.MirrorSiteUrl" class="ms-2">Video file via Mirror<br /></a>
 					<span condition="Model.TorrentLinks.Any()">
 						@foreach (var torrent in Model.TorrentLinks)
 						{
-							<a href="~/torrent/@torrent.Path" class="ms-2">A/V file via BitTorrent @TorrentRemark(torrent.Path, torrent.Id)</a>
+							<a href="~/torrent/@torrent.Path" class="ms-2">Video file via BitTorrent @TorrentRemark(torrent.Path, torrent.Id)</a>
 							<br />
 						}
 					</span>


### PR DESCRIPTION
Hopefully I didn't submit a completely nonsensical code... here goes nothing. Note that the aesthetic and the logic will need to be properly adjusted.

As promised, I've made a very rough draft of my [idea](http://tasvideos.org/forum/viewtopic.php?p=509570#509570) of grouping all the available watching options under the movie screenshot and making the wording more intuitive. More in detail:
- Putting a link to the relative emulator page by the side of the movie url (logic not coded yet)
- Putting the javascript button for enabling the YouTube embed (logic not coded yet) before the external link
- Putting the javascript button for enabling the Archive.org embed (logic not coded yet) before the external link (currently [broken](https://github.com/TASVideos/tasvideos/issues/646))

I've also moved the link to Submission, Discussion, Ratings, to the upper right. This is just temporary, I just needed to move away those buttons from the watching options; feel free to adjust these to your liking.
Oh, and I also moved the three wiki edit-related buttons under the movie description, instead than at the bottom left. (The "Catalog" button didn't appear because I don't have the privilege)

Have here a comparison through screenshots. The first image is a screen of the current page at https://staging.tasvideos.org/4271M while the second image is a rough mockup I made in Paint:
![1](https://user-images.githubusercontent.com/36802254/145265427-141902f5-1bf7-473e-8808-418ea61dc8fa.png)
![2](https://user-images.githubusercontent.com/36802254/145266968-f97db1e0-ebe8-4407-a320-eb9a7845f9a5.png)
(Please ignore the fact that the screenshot is distorted in the second screenshot, I have no idea how but something happened in Opera while I was playing around with the debugger.)