### PR TITLE
fix #660 link to forum from news post headings

### DIFF
--- a/TASVideos/Pages/Shared/Components/TopicFeed/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/TopicFeed/Default.cshtml
@@ -8,7 +8,7 @@
 		<div class="card">
 			<div class="card-body">
 				<h5 condition="!Model.HideContent" class="card-title">@post.Subject</h5>
-				<h5 condition="Model.HideContent"><a data-bs-toggle="collapse" href="#@collapseId" role="button" aria-expanded="false">@post.Subject</a></h5>
+				<h5 condition="Model.HideContent"><a data-bs-toggle="collapse" href="/Forum/Posts/@(post.Id)#@(post.Id)" data-bs-target="#@collapseId" role="button" aria-expanded="false">@post.Subject</a></h5>
 				<h6 class="card-subtitle mb-2 text-muted">
 					<small>
 						posted by @post.PosterName <timezone-convert asp-for="@post.CreateTimestamp" in-line="true" />

--- a/TASVideos/Pages/Shared/Components/TopicFeed/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/TopicFeed/Default.cshtml
@@ -11,7 +11,7 @@
 				<h5 condition="Model.HideContent"><a data-bs-toggle="collapse" href="/Forum/Posts/@(post.Id)#@(post.Id)" data-bs-target="#@collapseId" role="button" aria-expanded="false">@post.Subject</a></h5>
 				<h6 class="card-subtitle mb-2 text-muted">
 					<small>
-						posted by @post.PosterName <timezone-convert asp-for="@post.CreateTimestamp" in-line="true" />
+						posted by <a href="/@post.PosterName">@post.PosterName</a> <timezone-convert asp-for="@post.CreateTimestamp" in-line="true" />
 					</small>
 				</h6>
 				<div condition="Model.HideContent" class="collapse card-text" id="collapse-content-@post.Id">

--- a/TASVideos/wwwroot/js/site.js
+++ b/TASVideos/wwwroot/js/site.js
@@ -74,7 +74,13 @@ if (localStorage.getItem("style-dark") !== null) {
 	}
 }
 
-if (location.hash != null && location.hash != "") {
-	document.querySelector(`[href='${location.hash}']`).setAttribute("aria-expanded", "true");
-	document.querySelector(location.hash + '.collapse').classList.add("show");
+if (location.hash) {
+	let expandButton = document.querySelector(`[href='${location.hash}']`);
+	if (expandButton) {
+		expandButton.setAttribute("aria-expanded", "true");
+	}
+	let expandedContent = document.querySelector(location.hash + '.collapse');
+	if (expandedContent) {
+		expandedContent.classList.add("show");
+	}
 }

--- a/TASVideos/wwwroot/js/site.js
+++ b/TASVideos/wwwroot/js/site.js
@@ -73,3 +73,8 @@ if (localStorage.getItem("style-dark") !== null) {
 		forceDarkMode();
 	}
 }
+
+if (location.hash != null && location.hash != "") {
+	document.querySelector(`[href='${location.hash}']`).setAttribute("aria-expanded", "true");
+	document.querySelector(location.hash + '.collapse').classList.add("show");
+}


### PR DESCRIPTION
fixes #660 
Points news post header links to the forum post while preserving toggle behavior for basic clicks
Wires script to auto-open dropdowns for any other cases where this is used
Adds back link to author in news post