### PR TITLE
Reorganize many things for space and simplicity

### DIFF
--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -14,6 +14,37 @@
 	var publicationAwards = await Awards.ForPublication(Model.Id);
 }
 
+@functions {
+	string TorrentRemark(string? link, int id)
+	{
+		if (link == null)
+		{
+			return "";
+		}
+
+		if (link.Contains("_10bit444"))
+		{
+			return "(Modern HQ)";
+		}
+
+		if (link.Contains("_512kb"))
+		{
+			return "(Compatibility)";
+		}
+
+		if (link.Contains("_hq"))
+		{
+			return "(Very High Quality)";
+		}
+
+		if (id > 20200) // Shenanigans!!!
+		{
+			return "Modern HQ";
+		}
+
+		return "";
+	}
+}
 <card class="border border-primary">
 	<cardheader class="bg-cardprimary p-2">
 		<row class="gx-3">
@@ -31,12 +62,6 @@
 				</a>
 			}
 			<a asp-page="View" asp-route-id="@Model.Id" class="text-decoration-none"><span class="text-dark">@Model.Title </span></a>
-			<a asp-page="/Publications/Rate" asp-route-id="@Model.Id" class="btn btn-warning btn-sm mt-1" style="vertical-align:18%">
-				<i class="fa fa-star-o"></i> @Math.Round(Model.OverallRating ?? 0, 2, MidpointRounding.AwayFromZero) / 10
-			</a>
-			<a asp-page="/Ratings/Index" asp-route-id="@Model.Id" class="btn btn-secondary btn-sm mt-1" style="vertical-align:18%">
-				<i class="fa fa-list-ul"></i> Votes: @Model.RatingCount
-			</a>
 			</h4>
 		</row>
 	</cardheader>
@@ -54,29 +79,14 @@
 						 class="w-100 pixelart-image"
 						 loading="lazy" />
 				</div>
-				<div style="text-align:center">
+				<div>
 					@foreach (var url in Model.OnlineWatchingUrls)
 					{
-						<a href="@url" class="btn btn-primary btn-sm mt-1" target="_blank"><i class="fa fa-external-link"></i> YouTube</a>
+						<a href="@url" class="btn btn-primary btn-sm mt-1" target="_blank"><i class="fa fa-external-link"></i> Watch</a>
 					}
-					@foreach (var url in Model.MirrorSiteUrls)
-					{
-						<a href="@url" class="btn btn-primary btn-sm mt-1" target="_blank"><i class="fa fa-download"></i> Download</a>
-					}
+					<a asp-page="/Publications/View" asp-page-handler="Download" asp-route-id="@Model.Id" class="btn btn-primary btn-sm mt-1"><i class="fa fa-download"></i> Download (@System.IO.Path.GetExtension(Model.MovieFileName))</a>
 				</div>
-			</div>
-			<div class="col-md">
-				<fullrow>
-					@await Component.RenderWiki(LinkConstants.PublicationWikiPage + Model.Id)
-				</fullrow>
-				<div style="float:left">
-					<br /><small>Published on @Model.CreateTimestamp.Date.ToShortDateString()</small>
-				</div>
-				<div style="text-align:right">
-					@foreach (var award in publicationAwards.OrderByDescending(a => a.Year))
-					{
-						<partial name="_Award" model="award" />
-					}
+				<div>
 					<a asp-page="/Submissions/View" asp-route-id="@Model.SubmissionId" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-info-circle"></i> Author notes</a>
 					<a condition="@Model.TopicId > 0"
 					   asp-page="/Forum/Topics/Index"
@@ -85,6 +95,22 @@
 						<i class="fa fa-comments-o"></i> Discuss
 					</a>
 				</div>
+				<div>
+					<a asp-page="/Publications/Rate" asp-route-id="@Model.Id" class="btn btn-warning btn-sm mt-1">
+						<i class="fa fa-star-o"></i> @Math.Round(Model.OverallRating ?? 0, 2, MidpointRounding.AwayFromZero) / 10
+					</a>
+					<a asp-page="/Ratings/Index" asp-route-id="@Model.Id" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-list-ul"></i> Votes: @Model.RatingCount</a>
+				</div>
+				@foreach (var award in publicationAwards.OrderByDescending(a => a.Year))
+				{
+					<partial name="_Award" model="award" />
+				}
+			</div>
+			<div class="col-md">
+				<fullrow>
+					<div><small>@Model.CreateTimestamp.Date.ToShortDateString()</small></div>
+					@await Component.RenderWiki(LinkConstants.PublicationWikiPage + Model.Id)
+				</fullrow>
 			</div>
 		</row>
 		<row condition="Model.ObsoletedMovies.Any()" class="my-2 gx-3">
@@ -131,34 +157,35 @@
 				</small>
 			</div>
 			<div class="col-auto">
-				<small condition="Model.MirrorSiteUrls.Any()">
+				<small condition="Model.MirrorSiteUrls.Any() || Model.TorrentLinks.Any()">
 					A/V files:<br />
 					<span condition="Model.MirrorSiteUrls.Any()">
 						@foreach (var url in Model.MirrorSiteUrls)
 						{
-							<a href="@url" class="ms-2">A/V file via Mirror</a><br />
+							<a href="@url" class="ms-2">A/V file via Mirror<br /></a>
+						}
+					</span>
+					<span condition="Model.TorrentLinks.Any()">
+						@foreach (var torrent in Model.TorrentLinks)
+						{
+							<a href="~/torrent/@torrent.Path" class="ms-2">A/V file via BitTorrent @TorrentRemark(torrent.Path, torrent.Id)</a>
+							<br />
 						}
 					</span>
 				</small>
 			</div>
 			<div class="col-auto">
+				<small condition="!string.IsNullOrWhiteSpace(Model.EmulatorVersion)">
+					Emulator Version:<br /><span class="ms-2">@Model.EmulatorVersion</span>
+				</small>
+			</div>
+			<div condition="Model.MovieFileLinks.Any()" class="col-auto">
 				<small>
-					<span condition="!string.IsNullOrWhiteSpace(Model.EmulatorVersion)">
-						Emulator Version:<br />
-							<span class="ms-2">@Model.EmulatorVersion</span>
-					</span>
-					<span>
-						<br />Movie file:<br />
-							<a href="?handler=Download" class="ms-2">Download @System.IO.Path.GetExtension(Model.MovieFileName)</a>
-						<a asp-page="/Publications/View" asp-page-handler="Download" asp-route-id="@Model.Id" class="btn btn-primary btn-sm mt-1"><i class="fa fa-download"></i> @System.IO.Path.GetExtension(Model.MovieFileName) file</a>
-					</span>
-					<span condition="Model.MovieFileLinks.Any()">
-						<br />Additional Downloads:<br />
-						@foreach (var file in Model.MovieFileLinks)
-						{
-							<a class="ms-2" title="@file.Path" asp-page="/Publications/View" asp-page-handler="DownloadAdditional" asp-route-fileId="@file.Id">(@file.Description)</a><br />
-						}
-					</span>
+					Additional Downloads:<br />
+					@foreach (var file in Model.MovieFileLinks)
+					{
+						<a class="ms-2" title="@file.Path" asp-page="/Publications/View" asp-page-handler="DownloadAdditional" asp-route-fileId="@file.Id">(@file.Description)</a>
+					}
 				</small>
 			</div>
 			<div class="col-auto">

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -14,55 +14,30 @@
 	var publicationAwards = await Awards.ForPublication(Model.Id);
 }
 
-@functions {
-	string TorrentRemark(string? link, int id)
-	{
-		if (link == null)
-		{
-			return "";
-		}
-
-		if (link.Contains("_10bit444"))
-		{
-			return "(Modern HQ)";
-		}
-
-		if (link.Contains("_512kb"))
-		{
-			return "(Compatibility)";
-		}
-
-		if (link.Contains("_hq"))
-		{
-			return "(Very High Quality)";
-		}
-
-		if (id > 20200) // Shenanigans!!!
-		{
-			return "Modern HQ";
-		}
-
-		return "";
-	}
-}
 <card class="border border-primary">
 	<cardheader class="bg-cardprimary p-2">
 		<row class="gx-3">
-			<div class="col-auto pe-0" condition="!string.IsNullOrWhiteSpace(Model.ClassIconPath)">
-				<img style="width: 18px" src="/@classIconPath2X"
-					 srcset="/@Model.ClassIconPath .5x,
-					 /@classIconPath2X 1x,
-					 /@classIconPath4X 2x" />
-			</div>
-			<h4 class="col m-0"><a asp-page="View" asp-route-id="@Model.Id" class="text-decoration-none"><span class="text-dark">@Model.Title</span></a></h4>
-			<div class="col-auto ps-0">
-				@foreach (var flag in Model.Flags.Where(f => !string.IsNullOrWhiteSpace(f.IconPath)))
-				{
-					<a href="@flag.LinkPath">
-						<img class="pixelart-image" title="@flag.Name" alt="[@flag.Name]" src="/@flag.IconPath" />
-					</a>
-				}
-			</div>
+			<h4>
+			<a href="Stars" condition="!string.IsNullOrWhiteSpace(Model.ClassIconPath)">
+			<img style="vertical-align:1%" width="18" src="/@classIconPath2X"
+				srcset="/@Model.ClassIconPath .5x,
+				/@classIconPath2X 1x,
+				/@classIconPath4X 2x" />
+			</a>
+			@foreach (var flag in Model.Flags.Where(f => !string.IsNullOrWhiteSpace(f.IconPath)))
+			{
+				<a href="@flag.LinkPath">
+					<img class="embedright" title="@flag.Name" alt="[@flag.Name]" src="/@flag.IconPath" />
+				</a>
+			}
+			<a asp-page="View" asp-route-id="@Model.Id" class="text-decoration-none"><span class="text-dark">@Model.Title </span></a>
+			<a asp-page="/Publications/Rate" asp-route-id="@Model.Id" class="btn btn-warning btn-sm mt-1" style="vertical-align:18%">
+				<i class="fa fa-star-o"></i> @Math.Round(Model.OverallRating ?? 0, 2, MidpointRounding.AwayFromZero) / 10
+			</a>
+			<a asp-page="/Ratings/Index" asp-route-id="@Model.Id" class="btn btn-secondary btn-sm mt-1" style="vertical-align:18%">
+				<i class="fa fa-list-ul"></i> Votes: @Model.RatingCount
+			</a>
+			</h4>
 		</row>
 	</cardheader>
 	<cardbody class="px-2 py-0">
@@ -79,15 +54,30 @@
 						 class="w-100 pixelart-image"
 						 loading="lazy" />
 				</div>
-				<div>
+				<div style="text-align:center">
 					@foreach (var url in Model.OnlineWatchingUrls)
 					{
-						<a href="@url" class="btn btn-primary btn-sm mt-1" target="_blank"><i class="fa fa-external-link"></i> Watch</a>
+						<a href="@url" class="btn btn-primary btn-sm mt-1" target="_blank"><i class="fa fa-external-link"></i> YouTube</a>
 					}
-					<a asp-page="/Publications/View" asp-page-handler="Download" asp-route-id="@Model.Id" class="btn btn-primary btn-sm mt-1"><i class="fa fa-download"></i> Download (@System.IO.Path.GetExtension(Model.MovieFileName))</a>
+					@foreach (var url in Model.MirrorSiteUrls)
+					{
+						<a href="@url" class="btn btn-primary btn-sm mt-1" target="_blank"><i class="fa fa-download"></i> Download</a>
+					}
 				</div>
-				<div>
-					<a asp-page="/Submissions/View" asp-route-id="@Model.SubmissionId" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-info-circle"></i> Submission</a>
+			</div>
+			<div class="col-md">
+				<fullrow>
+					@await Component.RenderWiki(LinkConstants.PublicationWikiPage + Model.Id)
+				</fullrow>
+				<div style="float:left">
+					<small>Published on @Model.CreateTimestamp.Date.ToShortDateString()</small>
+					@foreach (var award in publicationAwards.OrderByDescending(a => a.Year))
+					{
+						<partial name="_Award" model="award" />
+					}
+				</div>
+				<div style="text-align:right">
+					<a asp-page="/Submissions/View" asp-route-id="@Model.SubmissionId" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-info-circle"></i> Author notes</a>
 					<a condition="@Model.TopicId > 0"
 					   asp-page="/Forum/Topics/Index"
 					   asp-route-id="@Model.TopicId"
@@ -95,37 +85,6 @@
 						<i class="fa fa-comments-o"></i> Discuss
 					</a>
 				</div>
-				<div>
-					<a asp-page="/Publications/Rate" asp-route-id="@Model.Id" class="btn btn-warning btn-sm mt-1">
-						<i class="fa fa-star-o"></i> @Math.Round(Model.OverallRating ?? 0, 2, MidpointRounding.AwayFromZero) / 10
-					</a>
-					<a asp-page="/Ratings/Index" asp-route-id="@Model.Id" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-list-ul"></i> Votes: @Model.RatingCount</a>
-				</div>
-				<div>
-					<a permission="EditPublicationMetaData"
-					   asp-page="Edit"
-					   asp-route-id="@Model.Id"
-					   class="btn btn-secondary btn-sm border border-warning mt-1"><i class="fa fa-pencil"></i> Edit</a>
-					<a permission="CatalogMovies"
-					   asp-page="/Publications/Catalog"
-					   asp-route-id="@Model.Id"
-					   class="btn btn-secondary btn-sm border border-warning mt-1"><i class="fa fa-book"></i> Catalog</a>
-					<a permission="EditPublicationMetaData"
-					   href="/MovieMaintenanceLog?id=@Model.Id"
-					   class="btn btn-secondary btn-sm border border-warning mt-1">
-						<i class="fa fa-history"></i> Logs
-					</a>
-				</div>
-				@foreach (var award in publicationAwards.OrderByDescending(a => a.Year))
-				{
-					<partial name="_Award" model="award" />
-				}
-			</div>
-			<div class="col-md">
-				<fullrow>
-					<div><small>@Model.CreateTimestamp.Date.ToShortDateString()</small></div>
-					@await Component.RenderWiki(LinkConstants.PublicationWikiPage + Model.Id)
-				</fullrow>
 			</div>
 		</row>
 		<row condition="Model.ObsoletedMovies.Any()" class="my-2 gx-3">
@@ -172,36 +131,50 @@
 				</small>
 			</div>
 			<div class="col-auto">
-				<small condition="Model.MirrorSiteUrls.Any() || Model.TorrentLinks.Any()">
+				<small condition="Model.MirrorSiteUrls.Any()">
 					A/V files:<br />
 					<span condition="Model.MirrorSiteUrls.Any()">
 						@foreach (var url in Model.MirrorSiteUrls)
 						{
-							<a href="@url" class="ms-2">A/V file via Mirror<br /></a>
-						}
-					</span>
-					<span condition="Model.TorrentLinks.Any()">
-						@foreach (var torrent in Model.TorrentLinks)
-						{
-							<a href="~/torrent/@torrent.Path" class="ms-2">A/V file via BitTorrent @TorrentRemark(torrent.Path, torrent.Id)</a>
-							<br />
+							<a href="@url" class="ms-2">A/V file via Mirror</a><br />
 						}
 					</span>
 				</small>
 			</div>
 			<div class="col-auto">
-				<small condition="!string.IsNullOrWhiteSpace(Model.EmulatorVersion)">
-					Emulator Version:<br /><span class="ms-2">@Model.EmulatorVersion</span>
+				<small>
+					<span condition="!string.IsNullOrWhiteSpace(Model.EmulatorVersion)">
+						Emulator Version:<br />
+							<span class="ms-2">@Model.EmulatorVersion</span>
+					</span>
+					<span>
+						<br />Movie file:<br />
+							<a href="?handler=Download" class="ms-2">Download @System.IO.Path.GetExtension(Model.MovieFileName)</a>
+						<a asp-page="/Publications/View" asp-page-handler="Download" asp-route-id="@Model.Id" class="btn btn-primary btn-sm mt-1"><i class="fa fa-download"></i> @System.IO.Path.GetExtension(Model.MovieFileName) file</a>
+					</span>
+					<span condition="Model.MovieFileLinks.Any()">
+						<br />Additional Downloads:<br />
+						@foreach (var file in Model.MovieFileLinks)
+						{
+							<a class="ms-2" title="@file.Path" asp-page="/Publications/View" asp-page-handler="DownloadAdditional" asp-route-fileId="@file.Id">(@file.Description)</a><br />
+						}
+					</span>
 				</small>
 			</div>
-			<div condition="Model.MovieFileLinks.Any()" class="col-auto">
-				<small>
-					Additional Downloads:<br />
-					@foreach (var file in Model.MovieFileLinks)
-					{
-						<a class="ms-2" title="@file.Path" asp-page="/Publications/View" asp-page-handler="DownloadAdditional" asp-route-fileId="@file.Id">(@file.Description)</a>
-					}
-				</small>
+			<div class="col-auto">
+				<a permission="EditPublicationMetaData"
+				   asp-page="Edit"
+				   asp-route-id="@Model.Id"
+				   class="btn btn-secondary btn-sm border border-warning mt-1"><i class="fa fa-pencil"></i> Edit</a>
+				<a permission="CatalogMovies"
+				   asp-page="/Publications/Catalog"
+				   asp-route-id="@Model.Id"
+				   class="btn btn-secondary btn-sm border border-warning mt-1"><i class="fa fa-book"></i> Catalog</a>
+				<a permission="EditPublicationMetaData"
+				   href="/MovieMaintenanceLog?id=@Model.Id"
+				   class="btn btn-secondary btn-sm border border-warning mt-1">
+					<i class="fa fa-history"></i> Logs
+				</a>
 			</div>
 		</row>
 	</cardbody>

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -70,13 +70,13 @@
 					@await Component.RenderWiki(LinkConstants.PublicationWikiPage + Model.Id)
 				</fullrow>
 				<div style="float:left">
-					<small>Published on @Model.CreateTimestamp.Date.ToShortDateString()</small>
+					<br /><small>Published on @Model.CreateTimestamp.Date.ToShortDateString()</small>
+				</div>
+				<div style="text-align:right">
 					@foreach (var award in publicationAwards.OrderByDescending(a => a.Year))
 					{
 						<partial name="_Award" model="award" />
 					}
-				</div>
-				<div style="text-align:right">
 					<a asp-page="/Submissions/View" asp-route-id="@Model.SubmissionId" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-info-circle"></i> Author notes</a>
 					<a condition="@Model.TopicId > 0"
 					   asp-page="/Forum/Topics/Index"


### PR DESCRIPTION
I reorganized a lot of the movie page interface, in order to save space and make it easier to navigate through. Here is the current list of changes: (Edit: doing less stuff at once, as per adelikat's request)
1. Star icon links to the Stars page.
2. Star and flag icons don't occupy whole columns, saving space for the next lines of the title on mobile devices.
3. ~~Rating buttons are right after the movie title.~~
4. ~~Movie file download moved to the the bottom, under Emulator version.~~
5. ~~Movie file download button converted to a plain hypertext.~~
6. Submission button renamed to Author notes.
7. ~~Submission and Discuss buttons moved in the bottor right of the movie description.~~
8. Edit, Catalog, Logs buttons moved in the last row of the page.
9. ~~Publication date moved to the bottom left of the movie description.~~
10. ~~Award pics moved under the bottom center of the movie description.~~
11. ~~Torrent links obliterated.~~

Comparison between current and new, desktop mode:
![1](https://user-images.githubusercontent.com/36802254/147582679-02005c5d-e3b6-4427-8762-da2f4f66c2f7.png)
![2_2](https://user-images.githubusercontent.com/36802254/147641405-77201787-84e9-4dd8-8a3b-44388ef15092.png)

Comparison between current and new, mobile mode (top of page):
![3](https://user-images.githubusercontent.com/36802254/147582682-ab5171bb-14f0-49b7-b712-ae21db986714.png)

Comparison between current and new, mobile mode (bottom of page):
![4_2](https://user-images.githubusercontent.com/36802254/147641413-2dea07d9-3c2d-462f-9359-ca707993f854.png)