### PR TITLE
use bootstrap's font stack

### DIFF
--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -10,7 +10,6 @@
 }
 
 body {
-	font-family: sans-serif;
 	font-size: 14px;
 	background: var(--tasvideos-bg) linear-gradient(var(--tasvideos-bg-gradient) 0, var(--tasvideos-bg) 250px) repeat-x;
 }


### PR DESCRIPTION
fixes #691 

As far as I can tell reading around, bootstrap's font stack is much better for accessibility than browser defaults, and can be overridden if really necessary