### PR TITLE
Banish torrents

### DIFF
--- a/TASVideos.Core/Services/MediaFileUploader.cs
+++ b/TASVideos.Core/Services/MediaFileUploader.cs
@@ -81,7 +81,7 @@ namespace TASVideos.Core.Services
 
 			if (file is not null)
 			{
-				string path = Path.Combine(_env.WebRootPath, "torrent", file.Path);
+				string path = Path.Combine(_env.WebRootPath, file.Path);
 				File.Delete(path);
 
 				_db.PublicationFiles.Remove(file);

--- a/TASVideos.Core/Services/MediaFileUploader.cs
+++ b/TASVideos.Core/Services/MediaFileUploader.cs
@@ -14,7 +14,6 @@ namespace TASVideos.Core.Services
 	public interface IMediaFileUploader
 	{
 		Task<string> UploadScreenshot(int publicationId, IFormFile screenshot, string? description);
-		Task<string> UploadTorrent(int publicationId, IFormFile torrent);
 		Task<DeletedFile?> DeleteFile(int publicationFileId);
 	}
 
@@ -73,27 +72,6 @@ namespace TASVideos.Core.Services
 
 			await _db.SaveChangesAsync();
 			return screenshotFileName;
-		}
-
-		public async Task<string> UploadTorrent(int publicationId, IFormFile torrent)
-		{
-			await using var memoryStream = new MemoryStream();
-			await torrent.CopyToAsync(memoryStream);
-			var torrentBytes = memoryStream.ToArray();
-
-			string torrentFileName = torrent.FileName;
-			string torrentPath = Path.Combine(_env.WebRootPath, "torrent", torrentFileName);
-			await File.WriteAllBytesAsync(torrentPath, torrentBytes);
-
-			var torrentFile = new PublicationFile
-			{
-				PublicationId = publicationId,
-				Path = torrentFileName,
-				Type = FileType.Torrent
-			};
-			_db.PublicationFiles.Add(torrentFile);
-			await _db.SaveChangesAsync();
-			return torrentFileName;
 		}
 
 		public async Task<DeletedFile?> DeleteFile(int publicationFileId)

--- a/TASVideos.Data/Entity/PermissionTo.cs
+++ b/TASVideos.Data/Entity/PermissionTo.cs
@@ -143,7 +143,7 @@ namespace TASVideos.Data.Entity
 		EditRecommendation = 304,
 
 		[Group("Publication Maintenance")]
-		[Description("The ability to add/remove publication files such as screenshots and torrents")]
+		[Description("The ability to add/remove publication files such as screenshots")]
 		EditPublicationFiles = 305,
 
 		[Group("Publication Maintenance")]

--- a/TASVideos/Extensions/ApplicationBuilderExtensions.cs
+++ b/TASVideos/Extensions/ApplicationBuilderExtensions.cs
@@ -45,10 +45,9 @@ namespace TASVideos.Extensions
 			return app;
 		}
 
-		public static IApplicationBuilder UseStaticFilesWithTorrents(this IApplicationBuilder app)
+		public static IApplicationBuilder UseStaticFilesWithExtensionMapping(this IApplicationBuilder app)
 		{
 			var provider = new FileExtensionContentTypeProvider();
-			provider.Mappings[".torrent"] = "application/x-bittorrent";
 			provider.Mappings[".avif"] = "image/avif";
 			return app.UseStaticFiles(new StaticFileOptions { ContentTypeProvider = provider });
 		}

--- a/TASVideos/Extensions/HtmlExtensions.cs
+++ b/TASVideos/Extensions/HtmlExtensions.cs
@@ -149,10 +149,5 @@ namespace TASVideos.Extensions
 
 			return validImageTypes.Contains(formFile?.ContentType);
 		}
-
-		public static bool IsValidTorrent(this IFormFile? formFile)
-		{
-			return formFile is not null && formFile.FileName.EndsWith(".torrent");
-		}
 	}
 }

--- a/TASVideos/Pages/Publications/EditFiles.cshtml.cs
+++ b/TASVideos/Pages/Publications/EditFiles.cshtml.cs
@@ -98,14 +98,10 @@ namespace TASVideos.Pages.Publications
 				return Page();
 			}
 
-			string path;
+			string path = "";
 			if (Type == FileType.Screenshot)
 			{
 				path = await _uploader.UploadScreenshot(Id, NewFile!, Description);
-			}
-			else
-			{
-				path = await _uploader.UploadTorrent(Id, NewFile!);
 			}
 
 			string log = $"added {Type} file {path}";

--- a/TASVideos/Pages/Publications/Models/PublicationDisplayModel.cs
+++ b/TASVideos/Pages/Publications/Models/PublicationDisplayModel.cs
@@ -33,9 +33,6 @@ namespace TASVideos.Pages.Publications.Models
 
 		public FileModel Screenshot => Files.First(f => f.Type == FileType.Screenshot);
 
-		public IEnumerable<FileModel> TorrentLinks => Files
-			.Where(f => f.Type == FileType.Torrent);
-
 		public IEnumerable<FileModel> MovieFileLinks => Files
 			.Where(f => f.Type == FileType.MovieFile);
 

--- a/TASVideos/Pages/RssFeeds/Models/RssPublication.cs
+++ b/TASVideos/Pages/RssFeeds/Models/RssPublication.cs
@@ -44,10 +44,6 @@ namespace TASVideos.Pages.RssFeeds.Models
 			}
 		}
 
-		public IEnumerable<string> TorrentLinks => Files
-			.Where(f => f.Type == FileType.Torrent)
-			.Select(f => f.Path);
-
 		public ICollection<string> StreamingUrls { get; init; } = new List<string>();
 
 		internal ICollection<File> Files { get; init; } = new List<File>();

--- a/TASVideos/Pages/RssFeeds/_RssPublication.cshtml
+++ b/TASVideos/Pages/RssFeeds/_RssPublication.cshtml
@@ -3,7 +3,6 @@
 @{
 	var baseUrl = ViewData["BaseUrl"];
 	var movieUrl = $"{baseUrl}/{Model.Id}M";
-	var primaryTorrent = Model.TorrentLinks.FirstOrDefault(t => !t.Contains("_512kb.mp4"));
 
 	var primaryStreaming = Model.StreamingUrls.FirstOrDefault(u => u.Contains("youtube"));
 	var secondaryStreaming = Model.StreamingUrls.Where(u => u != primaryStreaming);
@@ -21,11 +20,6 @@
 	<media:group>
 		<media:content url="@(movieUrl)?handler=Download" fileSize="@Model.MovieFileSize" type="application/zip" medium="document" />
 		<media:thumbnail url="@(baseUrl)/@Model.ScreenshotPath" />
-		<media:content condition="primaryTorrent != null" url="@primaryTorrent" medium="video" isDefault="true" />
-		@foreach (var torrent in Model.TorrentLinks)
-		{
-			<media:peerLink type="application/x-bittorrent" href="@torrent" />
-		}
 		@foreach (var url in secondaryStreaming)
 		{
 			<media:content url="@url" type="video" medium="video" />
@@ -34,7 +28,6 @@
 		<media:community>
 			<media:starRating average="@Model.RatingAverage" count="@Model.RatingCount" min="@Model.RatingMin" max="@Model.RatingMax" />
 		</media:community>
-		<enclosure condition="@primaryTorrent != null" url="@primaryTorrent" type="application/x-bittorrent" />
 		<guid>@movieUrl</guid>
 		<pubDate>@Model.CreateTimestamp.ToString("u", CultureInfo.InvariantCulture)</pubDate>
 	</media:group>

--- a/TASVideos/Pages/Shared/Components/UnmirroredMovies/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/UnmirroredMovies/Default.cshtml
@@ -6,7 +6,6 @@ Total count: @Model.Count()
 		<thead>
 			<tr>
 				<th>Movie</th>
-				<th>Filename (if found)</th>
 			</tr>
 		</thead>
 		<tbody>
@@ -14,7 +13,6 @@ Total count: @Model.Count()
 			{
 				<tr>
 					<td><pub-link id="@entry.Id">@entry.Title</pub-link></td>
-					<td>@Html.Raw(string.Join("<br>", entry.EncodePaths))</td>
 				</tr>
 			}
 		</tbody>

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -159,19 +159,12 @@
 				</small>
 			</div>
 			<div class="col-auto">
-				<small condition="Model.MirrorSiteUrls.Any() || Model.TorrentLinks.Any()">
+				<small condition="Model.MirrorSiteUrls.Any()">
 					A/V files:<br />
 					<span condition="Model.MirrorSiteUrls.Any()">
 						@foreach (var url in Model.MirrorSiteUrls)
 						{
 							<a href="@url" class="ms-2">A/V file via Mirror<br /></a>
-						}
-					</span>
-					<span condition="Model.TorrentLinks.Any()">
-						@foreach (var torrent in Model.TorrentLinks)
-						{
-							<a href="~/torrent/@torrent.Path" class="ms-2">A/V file via BitTorrent @TorrentRemark(torrent.Path, torrent.Id)</a>
-							<br />
 						}
 					</span>
 				</small>

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -14,37 +14,6 @@
 	var publicationAwards = await Awards.ForPublication(Model.Id);
 }
 
-@functions {
-	string TorrentRemark(string? link, int id)
-	{
-		if (link == null)
-		{
-			return "";
-		}
-
-		if (link.Contains("_10bit444"))
-		{
-			return "(Modern HQ)";
-		}
-
-		if (link.Contains("_512kb"))
-		{
-			return "(Compatibility)";
-		}
-
-		if (link.Contains("_hq"))
-		{
-			return "(Very High Quality)";
-		}
-
-		if (id > 20200) // Shenanigans!!!
-		{
-			return "Modern HQ";
-		}
-
-		return "";
-	}
-}
 <card class="border border-primary">
 	<cardheader class="bg-cardprimary p-2">
 		<div class="gx-3 clearfix">

--- a/TASVideos/Pages/Submissions/Models/SubmissionPublishModel.cs
+++ b/TASVideos/Pages/Submissions/Models/SubmissionPublishModel.cs
@@ -44,10 +44,6 @@ namespace TASVideos.Pages.Submissions.Models
 		[Display(Name = "Description", Description = "Caption, describe what happens in the screenshot")]
 		public string? ScreenshotDescription { get; set; }
 
-		[Required]
-		[Display(Name = "Torrent file", Description = "(The tracker URL must be http://tracker.tasvideos.org:6969/announce.)")]
-		public IFormFile? TorrentFile { get; set; }
-
 		[Display(Name = "Submission description (for quoting, reference, etc)")]
 		public string? Markup { get; set; }
 

--- a/TASVideos/Pages/Submissions/Publish.cshtml
+++ b/TASVideos/Pages/Submissions/Publish.cshtml
@@ -101,12 +101,6 @@
 				<div>@Html.DescriptionFor(m => m.Submission.ScreenshotDescription)</div>
 				<span asp-validation-for="Submission.ScreenshotDescription" class="text-danger"></span>
 			</form-group>
-			<form-group>
-				<label asp-for="Submission.TorrentFile" class="form-control-label"></label>
-				<input type="file" asp-for="Submission.TorrentFile" class="form-control" />
-				<div>@Html.DescriptionFor(m => m.Submission.TorrentFile)</div>
-				<span asp-validation-for="Submission.TorrentFile" class="text-danger"></span>
-			</form-group>
 		</column>
 	</row>
 	<hr />

--- a/TASVideos/Pages/Submissions/Publish.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Publish.cshtml.cs
@@ -86,11 +86,6 @@ namespace TASVideos.Pages.Submissions
 				ModelState.AddModelError($"{nameof(Submission)}.{nameof(Submission.Screenshot)}", "Invalid file type. Must be .png or .jpg");
 			}
 
-			if (!Submission.TorrentFile.IsValidTorrent())
-			{
-				ModelState.AddModelError($"{nameof(Submission)}.{nameof(Submission.TorrentFile)}", "Invalid file type. Must be a .torrent file");
-			}
-
 			if (!ModelState.IsValid)
 			{
 				await PopulateAvailableMoviesToObsolete(Submission.SystemId);
@@ -157,7 +152,6 @@ namespace TASVideos.Pages.Submissions
 			publication.GenerateTitle();
 
 			await _uploader.UploadScreenshot(publication.Id, Submission.Screenshot!, Submission.ScreenshotDescription);
-			await _uploader.UploadTorrent(publication.Id, Submission.TorrentFile!);
 
 			// Create a wiki page corresponding to this submission
 			var wikiPage = new WikiPage

--- a/TASVideos/Startup.cs
+++ b/TASVideos/Startup.cs
@@ -71,7 +71,7 @@ namespace TASVideos
 				.UseExceptionHandlers(env)
 				.UseGzipCompression(Settings)
 				.UseWebOptimizer()
-				.UseStaticFilesWithTorrents()
+				.UseStaticFilesWithExtensionMapping()
 				.UseAuthorization()
 				.UseAuthentication()
 				.UseSwaggerUi(Environment)

--- a/TASVideos/TASVideos.csproj
+++ b/TASVideos/TASVideos.csproj
@@ -28,19 +28,15 @@
 		<Compile Remove="logs\**" />
 		<Compile Remove="wwwroot\lib\**" />
 		<Compile Remove="wwwroot\media\**" />
-		<Compile Remove="wwwroot\torrent\**" />
 		<Content Remove="logs\**" />
 		<Content Remove="wwwroot\lib\**" />
 		<Content Remove="wwwroot\media\**" />
-		<Content Remove="wwwroot\torrent\**" />
 		<EmbeddedResource Remove="logs\**" />
 		<EmbeddedResource Remove="wwwroot\lib\**" />
 		<EmbeddedResource Remove="wwwroot\media\**" />
-		<EmbeddedResource Remove="wwwroot\torrent\**" />
 		<None Remove="logs\**" />
 		<None Remove="wwwroot\lib\**" />
 		<None Remove="wwwroot\media\**" />
-		<None Remove="wwwroot\torrent\**" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/TASVideos/ViewComponents/AviEncodes.cs
+++ b/TASVideos/ViewComponents/AviEncodes.cs
@@ -1,8 +1,5 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using TASVideos.Data;
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewComponents;
 using TASVideos.WikiEngine;
 
 namespace TASVideos.ViewComponents
@@ -10,21 +7,9 @@ namespace TASVideos.ViewComponents
 	[WikiModule(WikiModules.AviEncodes)]
 	public class AviEncodes : ViewComponent
 	{
-		private readonly ApplicationDbContext _db;
-
-		public AviEncodes(ApplicationDbContext db)
+		public IViewComponentResult Invoke()
 		{
-			_db = db;
-		}
-
-		public async Task<IViewComponentResult> InvokeAsync()
-		{
-			var encodes = await _db.PublicationFiles
-				.Where(pf => pf.Path.EndsWith(".avi.torrent"))
-				.Select(pf => new AviEncodeResultModel(pf.PublicationId, pf.Publication!.Title, pf.Path))
-				.ToListAsync();
-
-			return View(encodes);
+			return new ContentViewComponentResult($"{WikiModules.AviEncodes} wiki module no longer supported");
 		}
 	}
 }

--- a/TASVideos/ViewComponents/Models/UnmirroredMovieEntry.cs
+++ b/TASVideos/ViewComponents/Models/UnmirroredMovieEntry.cs
@@ -1,11 +1,8 @@
-﻿using System.Collections.Generic;
-
-namespace TASVideos.ViewComponents
+﻿namespace TASVideos.ViewComponents
 {
 	public class UnmirroredMovieEntry
 	{
 		public int Id { get; init; }
 		public string Title { get; init; } = "";
-		public IEnumerable<string> EncodePaths { get; init; } = new List<string>();
 	}
 }

--- a/TASVideos/ViewComponents/UnmirroredMovies.cs
+++ b/TASVideos/ViewComponents/UnmirroredMovies.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 using TASVideos.Data;
-using TASVideos.Data.Entity;
 using TASVideos.WikiEngine;
 using static TASVideos.Data.Entity.PublicationUrlType;
 
@@ -74,11 +73,7 @@ namespace TASVideos.ViewComponents
 				.Select(p => new UnmirroredMovieEntry
 				{
 					Id = p.Id,
-					Title = p.Title,
-					EncodePaths = p.Files
-						.Where(f => f.Type == FileType.Torrent)
-						.Select(f => f.Path)
-						.ToList()
+					Title = p.Title
 				})
 				.ToListAsync();
 


### PR DESCRIPTION
This removes all code related to torrents except for the database enum value.  We would need to purge the database of these url types before making that enum change, so it will need to be a future PR.

I'm not looking for opinions on whether removing torrents is a good idea, discuss that here: https://tasvideos.org/Forum/Topics/23005

What I need is a careful eye on if I missed anything

