### PR TITLE
add a global filter that attempts to debounce duplicate POST requests

### DIFF
--- a/TASVideos.sln.DotSettings
+++ b/TASVideos.sln.DotSettings
@@ -144,6 +144,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Coleco/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Collapsable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COPPA/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Debouncer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=depcrecator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=deprecator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=difflib/@EntryIndexedValue">True</s:Boolean>

--- a/TASVideos/Extensions/ServiceCollectionExtensions.cs
+++ b/TASVideos/Extensions/ServiceCollectionExtensions.cs
@@ -88,6 +88,9 @@ namespace TASVideos.Extensions
 					options.Conventions.AddFolderApplicationModelConvention(
 						"/",
 						model => model.Filters.Add(new SetPageViewBagAttribute()));
+					options.Conventions.AddFolderApplicationModelConvention(
+						"/",
+						model => model.Filters.Add(new Debouncer()));
 					options.Conventions.AddPageRoute("/Games/Index", "{id:int}G");
 					options.Conventions.AddPageRoute("/Submissions/Index", "Subs-{query}");
 					options.Conventions.AddPageRoute("/Submissions/Index", "Subs-List");

--- a/TASVideos/Pages/Debouncer.cs
+++ b/TASVideos/Pages/Debouncer.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TASVideos.Core.Services;
+
+namespace TASVideos.Pages
+{
+	/// <summary>
+	/// Used to attempt to prevent double clicks on form submit buttons and other attempts to double post
+	/// Takes advantage of the anti-forgery token to block identical requests for a short time
+	/// </summary>
+	public class Debouncer : IAsyncPageFilter
+	{
+		public async Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context)
+		{
+			await Task.CompletedTask;
+		}
+
+		public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+		{
+			if (context.HandlerMethod?.HttpMethod == "Post")
+			{
+				var cache = context.HttpContext.RequestServices.GetRequiredService<ICacheService>();
+				var token = context.HttpContext.Request.Form["__RequestVerificationToken"].ToString();
+				if (cache.TryGetValue(token, out bool _))
+				{
+					// Block request as a duplicate
+					var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<Debouncer>>();
+					logger.LogWarning($"Blocked duplicate POST request {context.HttpContext.Request.Path}");
+					return;
+				}
+
+				cache.Set(token, true, Durations.OneMinuteInSeconds);
+			}
+
+			await next.Invoke();
+		}
+	}
+}

--- a/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -80,7 +79,6 @@ namespace TASVideos.Pages.Forum.Posts
 
 		public async Task<IActionResult> OnPost()
 		{
-			Thread.Sleep(10000);
 			var user = await _userManager.GetUserAsync(User);
 			if (!ModelState.IsValid)
 			{

--- a/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -79,6 +80,7 @@ namespace TASVideos.Pages.Forum.Posts
 
 		public async Task<IActionResult> OnPost()
 		{
+			Thread.Sleep(10000);
 			var user = await _userManager.GetUserAsync(User);
 			if (!ModelState.IsValid)
 			{


### PR DESCRIPTION
This should help prevent double clicks as well as any mysterious duplicate posts that seem to be happening when the server is under high load and the post either takes too long or times out