### PR TITLE
"Latest Posts" Page

### DIFF
--- a/TASVideos/Pages/Forum/Index.cshtml
+++ b/TASVideos/Pages/Forum/Index.cshtml
@@ -6,6 +6,9 @@
 <partial Name="_ForumHeader" />
 <fullrow class="pb-2 pt-2">
 	<div class="float-end">
+		<a asp-page="/Forum/Posts/Latest" class="btn btn-secondary btn-sm">
+			Latest Posts
+		</a>
 		<a asp-page="/Forum/Posts/New" condition="@User.IsLoggedIn()" class="btn btn-secondary btn-sm">
 			Posts since last visit
 		</a>

--- a/TASVideos/Pages/Forum/Posts/Latest.cshtml
+++ b/TASVideos/Pages/Forum/Posts/Latest.cshtml
@@ -1,0 +1,31 @@
+﻿@page
+@model LatestModel
+@{
+	ViewData["Title"] = "Latest Forum Posts";
+}
+
+<div condition="@Model.Posts.Any()">
+	<partial Name="_ForumHeader" />
+	<fullrow>
+		<partial name="_Pager" model="Model.Posts" />
+	</fullrow>
+	@foreach (var post in Model.Posts)
+	{
+		<fullrow class="pt-2">
+			<small>
+				<a asp-page="/Forum/Index">Forum</a> →
+				<a asp-page="/Forum/Subforum/Index" asp-route-id="@post.ForumId">@post.ForumName</a> →
+				<a asp-page="/Forum/Topics/Index" asp-route-id="@post.TopicId">@post.TopicTitle</a>
+			</small>
+		</fullrow>
+		<partial name="Forum/Topics/_TopicPost" model="post" />
+	}
+	<fullrow class="mt-2">
+		<partial name="_Pager" model="Model.Posts" />
+	</fullrow>
+</div>
+<div condition="!Model.Posts.Any()">
+	<div class="alert alert-info mt-3 text-center">
+		<h4>No posts since last visit</h4>
+	</div>
+</div>

--- a/TASVideos/Pages/Forum/Posts/Latest.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Latest.cshtml.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TASVideos.Core;
+using TASVideos.Core.Services;
+using TASVideos.Data;
+using TASVideos.Data.Entity;
+using TASVideos.Data.Entity.Forum;
+using TASVideos.Pages.Forum.Posts.Models;
+
+namespace TASVideos.Pages.Forum.Posts
+{
+	[AllowAnonymous]
+	public class LatestModel : BasePageModel
+	{
+		private readonly ApplicationDbContext _db;
+		private readonly IAwards _awards;
+
+		public LatestModel(
+			ApplicationDbContext db,
+			IAwards awards)
+		{
+			_db = db;
+			_awards = awards;
+		}
+
+		[FromQuery]
+		public PagingModel Search { get; set; } = new ();
+
+		public PageOf<LatestPostsModel> Posts { get; set; } = PageOf<LatestPostsModel>.Empty();
+
+		public async Task OnGet()
+		{
+			var allowRestricted = User.Has(PermissionTo.SeeRestrictedForums);
+			var numberOfPosts = 100;
+			Posts = await _db.ForumPosts
+				.ExcludeRestricted(allowRestricted)
+				.Select(p => new LatestPostsModel
+				{
+					Id = p.Id,
+					CreateTimestamp = p.CreateTimestamp,
+					LastUpdateTimestamp = p.LastUpdateTimestamp,
+					EnableBbCode = p.EnableBbCode,
+					EnableHtml = p.EnableHtml,
+					Text = p.Text,
+					Subject = p.Subject,
+					TopicId = p.TopicId ?? 0,
+					TopicTitle = p.Topic!.Title,
+					ForumId = p.Topic.ForumId,
+					ForumName = p.Topic!.Forum!.Name,
+					PosterId = p.PosterId,
+					PosterName = p.Poster!.UserName,
+					PosterRoles = p.Poster.UserRoles
+						.Where(ur => !ur.Role!.IsDefault)
+						.Select(ur => ur.Role!.Name)
+						.ToList(),
+					PosterLocation = p.Poster.From,
+					Signature = p.Poster.Signature,
+					PosterAvatar = p.Poster.Avatar,
+					PosterJoined = p.Poster.CreateTimestamp,
+					PosterPostCount = p.Poster.Posts.Count,
+					PosterMoodUrlBase = p.Poster.MoodAvatarUrlBase,
+					PosterMood = p.PosterMood,
+					PosterPronouns = p.Poster.PreferredPronouns
+				})
+				.OrderByDescending(p => p.CreateTimestamp)
+				.Take(numberOfPosts)
+				.PageOf(Search);
+
+			foreach (var post in Posts)
+			{
+				post.Awards = await _awards.ForUser(post.PosterId);
+			}
+		}
+	}
+}

--- a/TASVideos/Pages/Forum/Posts/Models/LatestPostsModel.cs
+++ b/TASVideos/Pages/Forum/Posts/Models/LatestPostsModel.cs
@@ -1,0 +1,9 @@
+﻿namespace TASVideos.Pages.Forum.Posts.Models
+{
+	public class LatestPostsModel : ForumPostEntry
+	{
+		public string TopicTitle { get; set; } = "";
+		public int ForumId { get; set; }
+		public string ForumName { get; set; } = "";
+	}
+}

--- a/TASVideos/TASVideos.csproj
+++ b/TASVideos/TASVideos.csproj
@@ -90,6 +90,9 @@
 	</Target>-->
 
 	<ItemGroup>
+		<Content Update="Pages\Forum\Posts\Latest.cshtml">
+		  <Pack>$(IncludeRazorContentInPack)</Pack>
+		</Content>
 		<Content Update="Pages\Forum\Topics\Merge.cshtml">
 			<Pack>$(IncludeRazorContentInPack)</Pack>
 		</Content>


### PR DESCRIPTION
This is a simple implementation of a page showing all latest forum posts. It currently shows the latest 100 posts (that you're allowed to see).
It should be quite useful to catch up on posts, and it's a nice fallback in case there are problems with the "Posts since last visit" page.

Some ideas I just came up with that maybe could make this even better are:
- Option to hide TVA posts?
- Hide or show only certain subforums?
Maybe a selection on top?
- Show more posts?
I don't know how much the database is hit with this.
- Reverse ordering...
It currently goes opposite, showing the most recent posts on top. This is to prevent having to scroll all the way to the bottom and to the last page, just to check if there were new posts.