### PR TITLE
Enhance Social Media Embeds

### DIFF
--- a/TASVideos.Core/Services/ExternalMediaPublisher/Distributors/DiscordDistributor.cs
+++ b/TASVideos.Core/Services/ExternalMediaPublisher/Distributors/DiscordDistributor.cs
@@ -52,51 +52,14 @@ namespace TASVideos.Core.Services.ExternalMediaPublisher.Distributors
 
 		private class DiscordMessage
 		{
+			// Generate the Discord message letting Discord take care of the Embed from Open Graph Metadata
 			public DiscordMessage(IPostable post)
 			{
-				Content = GenerateContentMessage(post.Group, post.User);
-				Embed = new()
-				{
-					Title = post.Title,
-					Url = post.Link,
-					Description = post.Body
-				};
+				Content = $"{post.Announcement}\n{post.Link}";
 			}
 
 			[JsonProperty("content")]
 			public string Content { get; }
-
-			[JsonProperty("embed")]
-			public EmbedData Embed { get; }
-
-			public class EmbedData
-			{
-				[JsonProperty("title")]
-				public string Title { get; init; } = "";
-
-				[JsonProperty("description")]
-				public string Description { get; init; } = "";
-
-				[JsonProperty("url")]
-				public string Url { get; init; } = "";
-			}
-
-			private static string GenerateContentMessage(string? group, string? user)
-			{
-				string message = group switch
-				{
-					PostGroups.Forum => "Forum Update",
-					PostGroups.Submission => "Submission Update",
-					PostGroups.UserFiles => "Userfile Update",
-					PostGroups.UserManagement => "User Update",
-					PostGroups.Wiki => "Wiki Update",
-					_ => "Update"
-				};
-
-				return !string.IsNullOrWhiteSpace(user)
-					? message + $" from {user}"
-					: message;
-			}
 		}
 	}
 }

--- a/TASVideos.Core/Services/ExternalMediaPublisher/Distributors/TwitterDistributor.cs
+++ b/TASVideos.Core/Services/ExternalMediaPublisher/Distributors/TwitterDistributor.cs
@@ -37,7 +37,7 @@ namespace TASVideos.Core.Services.ExternalMediaPublisher.Distributors
 				return;
 			}
 
-			// Generate the Twitter message.  This can easily be configured later to better represent the way we want posts to look.
+			// Generate the Twitter message letting Twitter take care of the Embed from Open Graph Metadata
 			string twitterMessage = GenerateTwitterMessage(post);
 
 			string nonce = GenerateNonce();
@@ -70,7 +70,7 @@ namespace TASVideos.Core.Services.ExternalMediaPublisher.Distributors
 		{
 			return post.Group switch
 			{
-				PostGroups.Submission => $"{post.Title} - {post.Link}",
+				PostGroups.Submission => $"{post.Announcement}\n{post.Link}",
 				_ => ""
 			};
 		}

--- a/TASVideos.Core/Services/ExternalMediaPublisher/ExternalMediaPublisher.cs
+++ b/TASVideos.Core/Services/ExternalMediaPublisher/ExternalMediaPublisher.cs
@@ -49,6 +49,7 @@ namespace TASVideos.Core.Services.ExternalMediaPublisher
 		{
 			await publisher.Send(new Post
 			{
+				Announcement = "New User File",
 				Type = PostType.General,
 				Group = PostGroups.UserFiles,
 				Title = title,
@@ -62,6 +63,7 @@ namespace TASVideos.Core.Services.ExternalMediaPublisher
 		{
 			await publisher.Send(new Post
 			{
+				Announcement = "New Submission!",
 				Type = PostType.Announcement,
 				Group = PostGroups.Submission,
 				Title = $"New Submission! Go and see {title}",
@@ -75,6 +77,7 @@ namespace TASVideos.Core.Services.ExternalMediaPublisher
 		{
 			await publisher.Send(new Post
 			{
+				Announcement = "Submission Edited",
 				Type = PostType.General,
 				Group = PostGroups.Submission,
 				Title = title,
@@ -88,6 +91,7 @@ namespace TASVideos.Core.Services.ExternalMediaPublisher
 		{
 			await publisher.Send(new Post
 			{
+				Announcement = "New Movie Published!",
 				Type = PostType.Announcement,
 				Group = PostGroups.Submission,
 				Title = $"New movie published! Go and see {title}",
@@ -101,6 +105,7 @@ namespace TASVideos.Core.Services.ExternalMediaPublisher
 		{
 			await publisher.Send(new Post
 			{
+				Announcement = "Movie Edited",
 				Type = PostType.General,
 				Group = PostGroups.Publication,
 				Title = title,
@@ -110,10 +115,11 @@ namespace TASVideos.Core.Services.ExternalMediaPublisher
 			});
 		}
 
-		public static async Task SendForum(this ExternalMediaPublisher publisher, bool restricted, string title, string body, string relativeLink, string user = "")
+		public static async Task SendForum(this ExternalMediaPublisher publisher, bool restricted, string title, string body, string relativeLink, string user = "", string announcement = "")
 		{
 			await publisher.Send(new Post
 			{
+				Announcement = announcement,
 				Type = restricted
 					? PostType.Administrative
 					: PostType.General,

--- a/TASVideos.Core/Services/ExternalMediaPublisher/Post.cs
+++ b/TASVideos.Core/Services/ExternalMediaPublisher/Post.cs
@@ -7,6 +7,11 @@
 	public interface IPostable
 	{
 		/// <summary>
+		/// Gets the post announcement message
+		/// </summary>
+		string Announcement { get; }
+
+		/// <summary>
 		/// Gets the post title
 		/// </summary>
 		string Title { get; }
@@ -44,6 +49,7 @@
 	/// </summary>
 	public class Post : IPostable
 	{
+		public string Announcement { get; set; } = "";
 		public string Title { get; init; } = "";
 		public string Link { get; init; } = "";
 		public string Body { get; init; } = "";

--- a/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
@@ -139,7 +139,8 @@ namespace TASVideos.Pages.Forum.Posts
 				$"New reply by {user.UserName}{mood}",
 				$"({topic.Forum.ShortName}: {topic.Title}) ({Post.Subject})",
 				$"Forum/p/{id}#{id}",
-				$"{user.UserName}{mood}");
+				$"{user.UserName}{mood}",
+				"New Forum Post");
 
 			await _topicWatcher.NotifyNewPost(new TopicNotification(
 				id, topic.Id, topic.Title, user.Id));

--- a/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
@@ -138,7 +138,8 @@ namespace TASVideos.Pages.Forum.Posts
 					$"Post edited by {User.Name()} ({forumPost.Topic.Forum.ShortName}: {forumPost.Topic.Title})",
 					"",
 					$"Forum/p/{Id}#{Id}",
-					User.Name());
+					User.Name(),
+					$"Forum Post Edited by {User.Name()}");
 			}
 
 			return BaseRedirect($"/forum/p/{Id}#{Id}");
@@ -186,14 +187,17 @@ namespace TASVideos.Pages.Forum.Posts
 			}
 
 			var result = await ConcurrentSave(_db, $"Post {Id} deleted", $"Unable to delete post {Id}");
+
 			if (result)
 			{
+				var announcement = $"Post DELETED by {User.Name()} ({post.Topic!.Forum!.ShortName}: {post.Topic.Title})";
 				await _publisher.SendForum(
-					post.Topic!.Forum!.Restricted,
-					$"Post DELETED by {User.Name()} ({post.Topic.Forum.ShortName}: {post.Topic.Title})",
+					post.Topic.Forum.Restricted,
+					announcement,
 					"",
 					$"Forum/Topics/{post.Topic.Id}",
-					User.Name());
+					User.Name(),
+					announcement);
 			}
 
 			return topicDeleted

--- a/TASVideos/Pages/Forum/Topics/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Create.cshtml.cs
@@ -112,7 +112,8 @@ namespace TASVideos.Pages.Forum.Topics
 				$"New Topic by {User.Name()} ({forum.ShortName}: {Topic.Title})",
 				Topic.Post.CapAndEllipse(50),
 				$"Forum/Topics/{topic.Id}",
-				User.Name());
+				User.Name(),
+				"New Forum Topic");
 
 			var user = await _userManager.GetUserAsync(User);
 			await _userManager.AssignAutoAssignableRolesByPost(user);

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml
@@ -14,6 +14,7 @@
 	}
 	@section Header {
 		<meta property="og:type" content="website" />
+		<meta property="og:site_name" content="TASVideos" />
 		<meta property="og:title" content="@($"Forum Reply by {Model.HighlightedPost.PosterName}")" />
 		<meta property="og:description" content="@description" />
 		<meta property="og:url" content="@HttpContext.Request.ToUrl()" />
@@ -22,11 +23,17 @@
 } else
 {
 	@section Header {
+		@{
+			var firstPost = @Model.Topic.Posts.FirstOrDefault();
+			var ogTitle = firstPost is not null ? $"Forum Thread by {firstPost.PosterName}" : "Forum Thread";
+			var ogImage = firstPost is not null ? firstPost.PosterAvatar : $"{HttpContext.Request.ToBaseUrl()}/images/logo-light-4x.png";
+		}
 		<meta property="og:type" content="website" />
-		<meta property="og:title" content="TASVideos Forum Thread" />
+		<meta property="og:site_name" content="TASVideos" />
+		<meta property="og:title" content="@ogTitle" />
 		<meta property="og:description" content="@Model.Topic.Title" />
 		<meta property="og:url" content="@HttpContext.Request.ToUrl()" />
-		<meta property="og:image" content="@Model.Topic.Posts.FirstOrDefault()?.PosterAvatar" />
+		<meta property="og:image" content="@ogImage" />
 	}
 }
 

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
@@ -258,12 +258,14 @@ namespace TASVideos.Pages.Forum.Topics
 				var result = await ConcurrentSave(_db, $"Topic set to locked {lockedState}", $"Unable to set status of {lockedState}");
 				if (result)
 				{
+					var announcement = $"Topic {topicTitle} {lockedState} by {User.Name()}";
 					await _publisher.SendForum(
 						topic.Forum!.Restricted,
-						$"Topic {topicTitle} {lockedState} by {User.Name()}",
+						announcement,
 						"",
 						$"Forum/Topics/{Id}",
-						User.Name());
+						User.Name(),
+						announcement);
 				}
 			}
 

--- a/TASVideos/Pages/Forum/Topics/Merge.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Merge.cshtml.cs
@@ -108,12 +108,14 @@ namespace TASVideos.Pages.Forum.Topics
 			var result = await ConcurrentSave(_db, $"Topic merged into {destinationTopic.Title}", "Unable to merge topic");
 			if (result)
 			{
+				var announcement = $"Topic {originalTopic.Title} merged into {destinationTopic.Title} by {User.Name()}";
 				await _publisher.SendForum(
 					originalTopic.Forum!.Restricted || destinationTopic.Forum!.Restricted,
-					$"Topic {originalTopic.Title} merged into {destinationTopic.Title} by {User.Name()}",
+					announcement,
 					"",
 					$"Forum/Topics/{destinationTopic.Id}",
-					User.Name());
+					User.Name(),
+					announcement);
 			}
 
 			return RedirectToPage("Index", new { id = Topic.DestinationTopicId });

--- a/TASVideos/Pages/Forum/Topics/Move.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Move.cshtml.cs
@@ -102,12 +102,14 @@ namespace TASVideos.Pages.Forum.Topics
 
 			await _db.SaveChangesAsync();
 
+			var announcement = $"Topic {Topic.TopicTitle} moved by {User.Name()} from {Topic.ForumName} to {forum.Name}";
 			await _publisher.SendForum(
 				topicWasRestricted || forum.Restricted,
-				$"Topic {Topic.TopicTitle} moved by {User.Name()} from {Topic.ForumName} to {forum.Name}",
+				announcement,
 				"",
 				$"Forum/Topics/{Id}",
-				User.Name());
+				User.Name(),
+				announcement);
 
 			return RedirectToPage("Index", new { Id });
 		}

--- a/TASVideos/Pages/Forum/Topics/Split.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Split.cshtml.cs
@@ -137,12 +137,14 @@ namespace TASVideos.Pages.Forum.Topics
 
 			var newForum = await _db.Forums.SingleOrDefaultAsync(f => f.Id == topic.ForumId);
 
+			var announcement = $"Topic {newForum.Name}: {newTopic.Title} SPLIT by {User.Name()} from {Topic.ForumName}: {Topic.Title}";
 			await _publisher.SendForum(
 				destinationForum.Restricted || topic.Forum!.Restricted,
-				$"Topic {newForum.Name}: {newTopic.Title} SPLIT by {User.Name()} from {Topic.ForumName}: {Topic.Title}",
+				announcement,
 				"",
 				$"Forum/Topics/{newTopic.Id}",
-				User.Name());
+				User.Name(),
+				announcement);
 
 			return RedirectToPage("Index", new { id = newTopic.Id });
 		}

--- a/TASVideos/Pages/Publications/View.cshtml
+++ b/TASVideos/Pages/Publications/View.cshtml
@@ -6,8 +6,9 @@
 
 @section Header {
 	<meta property="og:type" content="website" />
-	<meta property="og:title" content="TASVideos" />
-	<meta property="og:description" content="@(ViewData["Title"])" />
+	<meta property="og:site_name" content="TASVideos" />
+	<meta property="og:title" content="@($"Movie #{Model.Id}")" />
+	<meta property="og:description" content="@Model.Publication.Title" />
 	<meta property="og:url" content="@HttpContext.Request.ToUrl()" />
 	<meta property="og:image" content="@($"{HttpContext.Request.ToBaseUrl()}/media/{Model.Publication.Screenshot.Path}")" />
 }

--- a/TASVideos/Pages/Shared/_WikiLayout.cshtml
+++ b/TASVideos/Pages/Shared/_WikiLayout.cshtml
@@ -15,6 +15,7 @@
 		}
 	}
 	<meta property="og:type" content="website" />
+	<meta property="og:site_name" content="TASVideos" />
 	<meta property="og:title" content="@pageData.PageName" />
 	<meta property="og:description" content="@description" />
 	<meta property="og:url" content="@Context.Request.ToUrl()" />

--- a/TASVideos/Pages/Submissions/View.cshtml
+++ b/TASVideos/Pages/Submissions/View.cshtml
@@ -46,8 +46,9 @@
 
 @section Header {
 	<meta property="og:type" content="website" />
-	<meta property="og:title" content="TASVideos" />
-	<meta property="og:description" content="@(ViewData["Title"])" />
+	<meta property="og:site_name" content="TASVideos" />
+	<meta property="og:title" content="@($"Submission #{Model.Id}")" />
+	<meta property="og:description" content="@(Model.Submission.Title)" />
 	<meta property="og:url" content="@HttpContext.Request.ToUrl()" />
 	<meta property="og:image" content="@($"{HttpContext.Request.ToBaseUrl()}/images/logo-light-4x.png")" />
 }

--- a/TASVideos/Pages/UserFiles/Info.cshtml
+++ b/TASVideos/Pages/UserFiles/Info.cshtml
@@ -2,7 +2,14 @@
 @model InfoModel
 
 @{
-	ViewData["Title"] = "User movie #" + Model.Id;
+	ViewData["Title"] = $"User movie #{Model.Id}";
 }
-
+@section Header {
+	<meta property="og:type" content="website" />
+	<meta property="og:site_name" content="TASVideos" />
+	<meta property="og:title" content="@ViewData["Title"]" />
+	<meta property="og:description" content="@(Model.UserFile.Title)" />
+	<meta property="og:url" content="@HttpContext.Request.ToUrl()" />
+	<meta property="og:image" content="@($"{HttpContext.Request.ToBaseUrl()}/images/logo-light-4x.png")" />
+}
 <partial name="_UserFileInfo" model="Model.UserFile" />


### PR DESCRIPTION
fixes #771 
Enhances the existing open graph tags by implementing the `site_name` tag
Implements open graph embeds for user files
Drops the custom discord update bot logic in favor of letting Discord build the embed from our open graph tags