### PR TITLE
Make hidden userfiles return to "unlisted" functionality

### DIFF
--- a/TASVideos.Core/Services/ExternalMediaPublisher/ExternalMediaPublisher.cs
+++ b/TASVideos.Core/Services/ExternalMediaPublisher/ExternalMediaPublisher.cs
@@ -45,12 +45,14 @@ namespace TASVideos.Core.Services.ExternalMediaPublisher
 
 	public static class ExternalMediaPublisherExtensions
 	{
-		public static async Task SendUserFile(this ExternalMediaPublisher publisher, string title, string relativeLink, string body = "", string user = "")
+		public static async Task SendUserFile(this ExternalMediaPublisher publisher, bool unlisted, string title, string relativeLink, string body = "", string user = "")
 		{
 			await publisher.Send(new Post
 			{
 				Announcement = "New User File",
-				Type = PostType.General,
+				Type = unlisted
+					? PostType.Administrative
+					: PostType.General,
 				Group = PostGroups.UserFiles,
 				Title = title,
 				Body = body,

--- a/TASVideos/Pages/UserFiles/Index.cshtml.cs
+++ b/TASVideos/Pages/UserFiles/Index.cshtml.cs
@@ -97,6 +97,7 @@ namespace TASVideos.Pages.UserFiles
 
 					await _db.SaveChangesAsync();
 					await _publisher.SendUserFile(
+						userFile.Hidden,
 						$"New comment by {User.Name()} on ({userFile.Title} (WIP))",
 						$"UserFiles/Info/{fileId}",
 						comment,
@@ -124,6 +125,7 @@ namespace TASVideos.Pages.UserFiles
 					if (result)
 					{
 						await _publisher.SendUserFile(
+							fileComment.UserFile!.Hidden,
 							$"Comment edited by {User.Name()} on ({fileComment.UserFile!.Title} (WIP))",
 							$"UserFiles/Info/{fileComment.UserFile.Id}",
 							comment,
@@ -151,6 +153,7 @@ namespace TASVideos.Pages.UserFiles
 					if (result)
 					{
 						await _publisher.SendUserFile(
+							fileComment.UserFile!.Hidden,
 							$"Comment by {fileComment.User!.UserName} on ({fileComment.UserFile!.Title} (WIP)) deleted by {User.Name()}",
 							$"UserFiles/Info/{fileComment.UserFile.Id}",
 							"",

--- a/TASVideos/Pages/UserFiles/Info.cshtml.cs
+++ b/TASVideos/Pages/UserFiles/Info.cshtml.cs
@@ -35,12 +35,6 @@ namespace TASVideos.Pages.UserFiles
 
 		public UserFileModel UserFile { get; set; } = new ();
 
-		private bool ShouldFileBeHidden([NotNullWhen(returnValue: false)]UserFile? file)
-		{
-			return file == null
-				|| file.Hidden && (!User.IsLoggedIn() || file.AuthorId != User.GetUserId() && !User.Has(PermissionTo.EditUserFiles));
-		}
-
 		public async Task<IActionResult> OnGet()
 		{
 			var file = await _db.UserFiles
@@ -53,7 +47,7 @@ namespace TASVideos.Pages.UserFiles
 				.Where(userFile => userFile.Id == Id)
 				.SingleOrDefaultAsync();
 
-			if (ShouldFileBeHidden(file))
+			if (file == null)
 			{
 				return NotFound();
 			}
@@ -78,7 +72,7 @@ namespace TASVideos.Pages.UserFiles
 				.Where(userFile => userFile.Id == Id)
 				.SingleOrDefaultAsync();
 
-			if (ShouldFileBeHidden(file))
+			if (file == null)
 			{
 				return NotFound();
 			}


### PR DESCRIPTION
This also makes sure to send comments on hidden userfiles only to staff.
Resolves #821.