### PR TITLE
Fix double space in youtube titles

### DIFF
--- a/TASVideos.Core/Services/Youtube/YouTubeSync.cs
+++ b/TASVideos.Core/Services/Youtube/YouTubeSync.cs
@@ -80,7 +80,7 @@ namespace TASVideos.Core.Services.Youtube
 				VideoId = videoId,
 				Snippet = new ()
 				{
-					Title = $"[TAS] {(video.ObsoletedBy.HasValue ? "[Obsoleted]" : "")} {video.Title}",
+					Title = $"[TAS] {(video.ObsoletedBy.HasValue ? "[Obsoleted] " : "")}{video.Title}",
 					Description = descriptionBase + renderedDescription,
 					CategoryId = videoDetails.CategoryId,
 					Tags = BaseTags.Concat(video.Tags).ToList()


### PR DESCRIPTION
Resolves #843.

![image](https://user-images.githubusercontent.com/22375320/148497174-adc58d4e-f0aa-4286-ae4b-cfb31f1330a3.png)