### PR TITLE
Make wiki code parse doubles with invariant culture

### DIFF
--- a/TASVideos/TagHelpers/WikiMarkupTagHelper.ParamConverters.cs
+++ b/TASVideos/TagHelpers/WikiMarkupTagHelper.ParamConverters.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using TASVideos.Services;
 
@@ -50,7 +51,7 @@ namespace TASVideos.TagHelpers
 		{
 			public override double? Convert(string? input)
 			{
-				return double.TryParse(input, out var tmp) ? tmp : null;
+				return double.TryParse(input, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var tmp) ? tmp : null;
 			}
 		}
 


### PR DESCRIPTION
Resolves #840.

Like basically every programming language out there, this makes our wiki code use invariant culture parsing for doubles.
In particular, decimal numbers will now only work when written with a dot separator, again, just like in basically every programming language.