### PR TITLE
Fix minimovie height on homepage

### DIFF
--- a/TASVideos/Pages/Shared/Components/DisplayMiniMovie/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/DisplayMiniMovie/Default.cshtml
@@ -1,6 +1,6 @@
 ﻿@model MiniMovieModel
 
-<div condition="Model != null">
+<div condition="Model != null" class="clearfix">
 	<div class="card minimovie">
 		<div class="card-header bg-cardprimary">
 			<h5><span class="float-end badge bg-info text-dark">Featured</span></h5>


### PR DESCRIPTION
(it makes the height of the element contain the height of the floated element eg the news)

fixes #794 