### PR TITLE
Change latest posts page to show the past 3 days worth of posts

### DIFF
--- a/TASVideos/Pages/Forum/Posts/Latest.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Latest.cshtml.cs
@@ -34,9 +34,9 @@ namespace TASVideos.Pages.Forum.Posts
 		public async Task OnGet()
 		{
 			var allowRestricted = User.Has(PermissionTo.SeeRestrictedForums);
-			var numberOfPosts = 100;
 			Posts = await _db.ForumPosts
 				.ExcludeRestricted(allowRestricted)
+				.Where(p => p.CreateTimestamp > DateTime.UtcNow.AddDays(-3))
 				.Select(p => new LatestPostsModel
 				{
 					Id = p.Id,
@@ -66,7 +66,6 @@ namespace TASVideos.Pages.Forum.Posts
 					PosterPronouns = p.Poster.PreferredPronouns
 				})
 				.OrderByDescending(p => p.CreateTimestamp)
-				.Take(numberOfPosts)
 				.PageOf(Search);
 
 			foreach (var post in Posts)


### PR DESCRIPTION
Shows 3 days worth of posts instead of the latest 100 posts.
I'm not sure if this optimization works, but instead of sorting ~500000 posts and taking the first 100, it now first takes ~100 posts and then sorts only those.