### PR TITLE
Replace DateTime.Now with UtcNow

### DIFF
--- a/TASVideos.Common/Extensions/EnumerableExtensions.cs
+++ b/TASVideos.Common/Extensions/EnumerableExtensions.cs
@@ -38,7 +38,7 @@ namespace TASVideos.Extensions
 				throw new ArgumentNullException($"{nameof(collection)} can not be null");
 			}
 
-			var randomIndex = new Random(DateTime.Now.Millisecond).Next(0, collection.Count);
+			var randomIndex = new Random(DateTime.UtcNow.Millisecond).Next(0, collection.Count);
 			return collection.ElementAt(randomIndex);
 		}
 

--- a/TASVideos.Core/Services/TASVideosGrue.cs
+++ b/TASVideos.Core/Services/TASVideosGrue.cs
@@ -62,7 +62,7 @@ namespace TASVideos.Core.Services
 		private static string RejectionMessage(DateTime createTimeStamp)
 		{
 			string message = "om, nom, nom";
-			message += (DateTime.Now - createTimeStamp).TotalDays >= 365
+			message += (DateTime.UtcNow - createTimeStamp).TotalDays >= 365
 				? "... blech, stale!"
 				: RandomMessages.AtRandom();
 

--- a/TASVideos/Pages/Forum/Topics/AddEditPoll.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/AddEditPoll.cshtml.cs
@@ -63,7 +63,7 @@ namespace TASVideos.Pages.Forum.Topics
 					MultiSelect = topic.Poll.MultiSelect,
 					Question = topic.Poll.Question,
 					DaysOpen = topic.Poll.CloseDate.HasValue
-						? (int)(topic.Poll.CloseDate.Value - DateTime.Now).TotalDays
+						? (int)(topic.Poll.CloseDate.Value - DateTime.UtcNow).TotalDays
 						: null,
 					PollOptions = topic.Poll.PollOptions
 						.OrderBy(o => o.Ordinal)

--- a/TASVideos/Pages/RssFeeds/Publications.cshtml.cs
+++ b/TASVideos/Pages/RssFeeds/Publications.cshtml.cs
@@ -29,7 +29,7 @@ namespace TASVideos.Pages.RssFeeds
 		public string BaseUrl { get; set; }
 		public async Task<IActionResult> OnGet()
 		{
-			var minTimestamp = DateTime.Now.AddDays(-60);
+			var minTimestamp = DateTime.UtcNow.AddDays(-60);
 			Publications = await _db.Publications
 				.ByMostRecent()
 				.Where(p => p.CreateTimestamp >= minTimestamp)

--- a/TASVideos/ViewComponents/MediaPosts.cs
+++ b/TASVideos/ViewComponents/MediaPosts.cs
@@ -23,7 +23,7 @@ namespace TASVideos.ViewComponents
 
 		public async Task<IViewComponentResult> InvokeAsync(int? days, int? limit)
 		{
-			var startDate = DateTime.Now.AddDays(-(days ?? 7));
+			var startDate = DateTime.UtcNow.AddDays(-(days ?? 7));
 			var model = await GetPosts(startDate, limit ?? 50);
 
 			return View(model);

--- a/TASVideos/ViewComponents/MovieChangeLog.cs
+++ b/TASVideos/ViewComponents/MovieChangeLog.cs
@@ -71,7 +71,7 @@ namespace TASVideos.ViewComponents
 
 		private async Task<IList<MovieHistoryModel.MovieHistoryEntry>> GetRecentPublications(int maxDays)
 		{
-			var minTimestamp = DateTime.Now.AddDays(-maxDays);
+			var minTimestamp = DateTime.UtcNow.AddDays(-maxDays);
 			var results = await _db.Publications
 				.Where(p => p.CreateTimestamp >= minTimestamp)
 				.Select(p => new MovieHistoryModel.MovieHistoryEntry

--- a/TASVideos/ViewComponents/MovieStatistics.cs
+++ b/TASVideos/ViewComponents/MovieStatistics.cs
@@ -76,7 +76,7 @@ namespace TASVideos.ViewComponents
 			// these are only used for rating statistics
 			int minimumVotes = minVotes ?? 1;
 			int minimumAge = minAge ?? 0;
-			DateTime minimumAgeTime = DateTime.Now.AddDays(-minimumAge);
+			DateTime minimumAgeTime = DateTime.UtcNow.AddDays(-minimumAge);
 
 			bool reverse = comparisonParameter.StartsWith("-");
 			if (reverse)
@@ -172,7 +172,7 @@ namespace TASVideos.ViewComponents
 						{
 							Id = p.Id,
 							Title = p.Title,
-							IntValue = (int)Math.Round((DateTime.Now - p.CreateTimestamp).TotalDays)
+							IntValue = (int)Math.Round((DateTime.UtcNow - p.CreateTimestamp).TotalDays)
 						})
 						.ToListAsync();
 					break;

--- a/tests/TASVideos.Core.Tests/Services/TASVideosGrueTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/TASVideosGrueTests.cs
@@ -60,7 +60,7 @@ namespace TASVideos.Core.Tests.Services
 		{
 			var topic = _db.ForumTopics.Add(new ForumTopic
 			{
-				CreateTimestamp = DateTime.Now.AddYears(-1),
+				CreateTimestamp = DateTime.UtcNow.AddYears(-1),
 				Title = "Title",
 				SubmissionId = SubmissionId
 			});

--- a/tests/TASVideos.Data.Tests/Context/ApplicationDbContextTests.cs
+++ b/tests/TASVideos.Data.Tests/Context/ApplicationDbContextTests.cs
@@ -152,7 +152,7 @@ namespace TASVideos.Data.Tests.Context
 
 			await _db.SaveChangesAsync();
 
-			Assert.AreEqual(DateTime.Now.Year, flag.LastUpdateTimestamp.Year);
+			Assert.AreEqual(DateTime.UtcNow.Year, flag.LastUpdateTimestamp.Year);
 		}
 
 		[TestMethod]


### PR DESCRIPTION
I confirmed every of these instances is eventually compared or operated with a variable from a UtcNow instance.

The only two DateTime.Now instances I didn't change are in the logger. I wasn't sure whether to utc them or leave them as local times.