### PR TITLE
Movie Parsers - account for windows style line endings

### DIFF
--- a/TASVideos.Parsers/Extensions/Extensions.cs
+++ b/TASVideos.Parsers/Extensions/Extensions.cs
@@ -17,9 +17,9 @@ namespace TASVideos.MovieParsers.Extensions
 				return Array.Empty<string>();
 			}
 
-			return str.Split(
-				new[] { '\n' },
-				StringSplitOptions.RemoveEmptyEntries);
+			return str.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries)
+				.Select(s => s.TrimEnd('\r'))
+				.ToArray();
 		}
 
 		/// <summary>

--- a/TASVideos.Parsers/Extensions/Extensions.cs
+++ b/TASVideos.Parsers/Extensions/Extensions.cs
@@ -17,8 +17,8 @@ namespace TASVideos.MovieParsers.Extensions
 				return Array.Empty<string>();
 			}
 
-			return str.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries)
-				.Select(s => s.TrimEnd('\r'))
+			return str
+				.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.RemoveEmptyEntries)
 				.ToArray();
 		}
 


### PR DESCRIPTION
For text formats such as .jrsr, .fm2, etc, account for the \r that might be in the movie file.

In particular this fixes .jrsr where that line feed can cause errors