### PR TITLE
Make posts catch email notify exceptions

### DIFF
--- a/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
@@ -157,7 +157,7 @@ namespace TASVideos.Pages.Forum.Posts
 			{
 				// emails are currently somewhat unstable
 				// we want to continue the request even if the email fails, so eat the exception
-				_logger.LogWarning($"Email notification failed on new reply creation");
+				_logger.LogWarning("Email notification failed on new reply creation");
 			}
 
 			return BaseRedirect($"/Forum/Posts/{id}#{id}");

--- a/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
@@ -157,7 +157,7 @@ namespace TASVideos.Pages.Forum.Posts
 			{
 				// emails are currently somewhat unstable
 				// we want to continue the request even if the email fails, so eat the exception
-				_logger.LogWarning("Email notification failed on new reply creation");
+				_logger.LogWarning($"Email notification failed on new reply creation");
 			}
 
 			return BaseRedirect($"/Forum/Posts/{id}#{id}");

--- a/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using TASVideos.Core.Services;
 using TASVideos.Core.Services.ExternalMediaPublisher;
 using TASVideos.Data;
@@ -19,18 +20,21 @@ namespace TASVideos.Pages.Forum.Posts
 		private readonly ExternalMediaPublisher _publisher;
 		private readonly ApplicationDbContext _db;
 		private readonly ITopicWatcher _topicWatcher;
+		private readonly ILogger<CreateModel> _logger;
 
 		public CreateModel(
 			UserManager userManager,
 			ExternalMediaPublisher publisher,
 			ApplicationDbContext db,
-			ITopicWatcher topicWatcher)
+			ITopicWatcher topicWatcher,
+			ILogger<CreateModel> logger)
 			: base(db, topicWatcher)
 		{
 			_userManager = userManager;
 			_publisher = publisher;
 			_topicWatcher = topicWatcher;
 			_db = db;
+			_logger = logger;
 		}
 
 		[FromRoute]
@@ -153,6 +157,7 @@ namespace TASVideos.Pages.Forum.Posts
 			{
 				// emails are currently somewhat unstable
 				// we want to continue the request even if the email fails, so eat the exception
+				_logger.LogWarning("Email notification failed on new reply creation");
 			}
 
 			return BaseRedirect($"/Forum/Posts/{id}#{id}");

--- a/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
@@ -142,10 +142,18 @@ namespace TASVideos.Pages.Forum.Posts
 				$"{user.UserName}{mood}",
 				"New Forum Post");
 
-			await _topicWatcher.NotifyNewPost(new TopicNotification(
-				id, topic.Id, topic.Title, user.Id));
-
 			await _userManager.AssignAutoAssignableRolesByPost(user);
+
+			try
+			{
+				await _topicWatcher.NotifyNewPost(new TopicNotification(
+					id, topic.Id, topic.Title, user.Id));
+			}
+			catch
+			{
+				// emails are currently somewhat unstable
+				// we want to continue the request even if the email fails, so eat the exception
+			}
 
 			return BaseRedirect($"/Forum/Posts/{id}#{id}");
 		}


### PR DESCRIPTION
Posts should not rely on the email notification to succeed to finish processing the request.

Email exceptions could have been a reason for the weird posting behavior users were having, resulting in double posts and blank pages.