### PR TITLE
Put post id attributes on the post's div, not the self-link

### DIFF
--- a/TASVideos/Pages/Forum/Posts/User.cshtml
+++ b/TASVideos/Pages/Forum/Posts/User.cshtml
@@ -11,7 +11,7 @@
 </fullrow>
 @foreach (var post in Model.UserPosts.Posts)
 {
-	<card>
+	<card id="@post.Id">
 		<cardheader>
 			<row>
 				<div class="col-4 border-end">
@@ -19,7 +19,7 @@
 				</div>
 				<div class="col-8 pt-0 pb-0">
 					<small style="display: inline-block">
-						<a id="@post.Id" href="/Forum/Posts/@(post.Id)#@post.Id" title="Link to this post" class="float-start"><i class="fa fa-bookmark-o"></i></a>
+						<a href="/Forum/Posts/@(post.Id)#@post.Id" title="Link to this post" class="float-start"><i class="fa fa-bookmark-o"></i></a>
 						Posted: @post.CreateTimestamp
 						<span condition="!string.IsNullOrWhiteSpace(post.Subject)">Post subject: @post.Subject</span>
 					</small>

--- a/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
@@ -1,11 +1,10 @@
 ﻿@model TASVideos.Pages.Forum.Posts.Models.ForumPostEntry
-<card class="@(Model.Highlight ? "forum-post-highlight border-warning border-2" : "border-primary") border mb-2">
+<card id="@Model.Id" class="@(Model.Highlight ? "forum-post-highlight border-warning border-2" : "border-primary") border mb-2">
 	<cardheader class="px-2 py-1">
 		<row class="align-items-center">
 			<div class="col-lg-2 col-md-3 col-auto">
 				<small>
-					<a id="@Model.Id"
-					   href="/Forum/Posts/@(Model.Id)#@Model.Id"
+					<a href="/Forum/Posts/@(Model.Id)#@Model.Id"
 					   title="Link to this post"
 					   class="float-start text-decoration-none text-dark">
 						<i class="fa fa-bookmark-o"></i>


### PR DESCRIPTION
The unique `id` HTML attribute of each forum post is attached to the post's own `a` permalink:
```
<div class="card">
  ...
  <a id="ID" href="...#ID" title="Link to this post">...</a>
```
This works, more or less, because the self-link is located near the top of the post. But I think it makes more sense for the `id` to be attached to the `div` of the whole post:
```
<div id="ID" class="card">
  ...
  <a href="...#ID" title="Link to this post">...</a>
```

I did the same thing with the /Forum/Posts/User/* handler, even though the links on those pages go to the forum, not to the pages themselves.

Attaching the `id` to the whole post also means that the CSS `:target` pseudo-class applies to everything in the post, which could be used, for example, to apply highlighting in a different way, as in #476.