### PR TITLE
Add "Show more" taghelper and use it for Author Notes in submission topics

### DIFF
--- a/TASVideos/Pages/Forum/Topics/Index.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml
@@ -105,9 +105,11 @@
 				<sub-link class="col-auto btn btn-secondary btn-sm" id="@SubmissionHelper.SubmissionId(Model.WikiPage.PageName)"><i class="fa fa-info-circle"></i> Full Submission Page</sub-link>
 			</row>
 		</cardheader>
-		<cardbody style="max-height: 600px; overflow-y: scroll">
-			<wiki-markup markup="@Model.WikiPage.Markup" page-data="Model.WikiPage"></wiki-markup>
-		</cardbody>
+		<show-more max-height="38rem">
+			<cardbody>
+				<wiki-markup markup="@Model.WikiPage.Markup" page-data="Model.WikiPage"></wiki-markup>
+			</cardbody>
+		</show-more>
 	</card>
 }
 

--- a/TASVideos/TagHelpers/ShowMoreTagHelper.cs
+++ b/TASVideos/TagHelpers/ShowMoreTagHelper.cs
@@ -12,6 +12,7 @@ namespace TASVideos.TagHelpers
 			output.TagName = "div";
 			output.Content.SetHtmlContent($@"<div style=""overflow-y: scroll; max-height: {MaxHeight};"" id=""{context.UniqueId}"">{content}</div>");
 			output.Content.AppendHtml($@"<div class=""p-2 text-center d-none border border-primary rounded"" id=""show-{context.UniqueId}""><a href=""#"" onclick=""return false;""><h4 class=""m-0""><i class=""fa fa-chevron-down""></i> Show more</h4></a></div>");
+			output.Content.AppendHtml($@"<div class=""p-2 text-center d-none border border-primary rounded"" id=""hide-{context.UniqueId}""><a href=""#"" onclick=""return false;""><h4 class=""m-0""><i class=""fa fa-chevron-up""></i> Hide</h4></a></div>");
 			output.Content.AppendHtml($@"
 <script>
 	{{
@@ -19,6 +20,9 @@ namespace TASVideos.TagHelpers
 		if (content.scrollHeight > content.clientHeight)
 			{{
 				let show = document.getElementById('show-{context.UniqueId}');
+				let hide = document.getElementById('hide-{context.UniqueId}');
+				let height = content.style.maxHeight;
+				let offset = content.scrollHeight - content.clientHeight;
 				content.style.overflowY = 'hidden'
 				show.classList.remove('d-none');
 				show.onclick = function()
@@ -26,6 +30,15 @@ namespace TASVideos.TagHelpers
 					content.style.overflowY = null;
 					content.style.maxHeight = null;
 					show.classList.add('d-none');
+					hide.classList.remove('d-none');
+				}}
+				hide.onclick = function()
+				{{
+					window.scrollBy({{top: -offset, left: 0, behavior: 'instant'}});
+					content.style.overflowY = 'hidden';
+					content.style.maxHeight = height;
+					hide.classList.add('d-none');
+					show.classList.remove('d-none');
 				}}
 			}}
 	}}

--- a/TASVideos/TagHelpers/ShowMoreTagHelper.cs
+++ b/TASVideos/TagHelpers/ShowMoreTagHelper.cs
@@ -22,7 +22,7 @@ namespace TASVideos.TagHelpers
 				let show = document.getElementById('show-{context.UniqueId}');
 				let hide = document.getElementById('hide-{context.UniqueId}');
 				let height = content.style.maxHeight;
-				let offset = content.scrollHeight - content.clientHeight;
+				let clHeight = content.clientHeight;
 				content.style.overflowY = 'hidden'
 				show.classList.remove('d-none');
 				show.onclick = function()
@@ -34,7 +34,7 @@ namespace TASVideos.TagHelpers
 				}}
 				hide.onclick = function()
 				{{
-					window.scrollBy({{top: -offset, left: 0, behavior: 'instant'}});
+					window.scrollBy({{top: clHeight - content.scrollHeight, left: 0, behavior: 'instant'}});
 					content.style.overflowY = 'hidden';
 					content.style.maxHeight = height;
 					hide.classList.add('d-none');

--- a/TASVideos/TagHelpers/ShowMoreTagHelper.cs
+++ b/TASVideos/TagHelpers/ShowMoreTagHelper.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace TASVideos.TagHelpers
+{
+	public class ShowMoreTagHelper : TagHelper
+	{
+		public string MaxHeight { get; set; } = "none";
+		public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+		{
+			var content = (await output.GetChildContentAsync()).GetContent();
+			output.TagName = "div";
+			output.Content.SetHtmlContent($@"<div style=""overflow-y: scroll; max-height: {MaxHeight};"" id=""{context.UniqueId}"">{content}</div>");
+			output.Content.AppendHtml($@"<div class=""p-2 text-center d-none border border-primary rounded"" id=""show-{context.UniqueId}""><a href=""#"" onclick=""return false;""><h4 class=""m-0""><i class=""fa fa-chevron-down""></i> Show more</h4></a></div>");
+			output.Content.AppendHtml($@"
+<script>
+	{{
+		let content = document.getElementById(""{context.UniqueId}"");
+		if (content.scrollHeight > content.clientHeight)
+			{{
+				let show = document.getElementById('show-{context.UniqueId}');
+				content.style.overflowY = 'hidden'
+				show.classList.remove('d-none');
+				show.onclick = function()
+				{{
+					content.style.overflowY = null;
+					content.style.maxHeight = null;
+					show.classList.add('d-none');
+				}}
+			}}
+	}}
+</script>");
+		}
+	}
+}


### PR DESCRIPTION
Having long blocks of content has disadvantages when browsing pages.
This is why those blocks are usually limited in height, and their content inside scrollable.
However, this nested scrolling is very mobile-unfriendly and even desktop users can have problems dealing with multiple scrollbars.

This "Show more" solution is often used to avoid long blocks but also make it mobile-friendly.

https://user-images.githubusercontent.com/22375320/148708862-06369a00-d6c7-4194-876b-42aa1c97838b.mp4

The TagHelper features:
- custom maximum height
- automatic detection if a "Show more" is needed or if the full content fits inside
- page position adjustment when clicking "Hide"
- old scrollbar method if javascript is disabled