### PR TITLE
Maybe fix the double newlines

### DIFF
--- a/TASVideos/Pages/Wiki/ViewSource.cshtml
+++ b/TASVideos/Pages/Wiki/ViewSource.cshtml
@@ -13,4 +13,4 @@
 	<a href="/@Model.WikiPage.PageName" class="btn btn-secondary"><span class="fa fa-arrow-left"></span> Back to Page</a>
 </div>
 <hr />
-<pre>@Html.Raw(Model.WikiPage.Markup.Replace("\n", "<br />"))</pre>
+<pre>@Html.Raw(Model.WikiPage.Markup)</pre>


### PR DESCRIPTION
Currently every source code display on the site doubles each newline: https://tasvideos.org/Wiki/ViewSource?path=TextFormattingRules%2FListOfModules
But it works fine on my local build. This might be due to line ending differences. However, I overlooked that there was a \n replacement in my previous change, it's not needed anymore anyway.