### PR TITLE
Make ShowMore TagHelper account for different content scroll positions

### DIFF
--- a/TASVideos/TagHelpers/ShowMoreTagHelper.cs
+++ b/TASVideos/TagHelpers/ShowMoreTagHelper.cs
@@ -27,10 +27,12 @@ namespace TASVideos.TagHelpers
 				show.classList.remove('d-none');
 				show.onclick = function()
 				{{
+					let scroll = content.scrollTop;
 					content.style.overflowY = null;
 					content.style.maxHeight = null;
 					show.classList.add('d-none');
 					hide.classList.remove('d-none');
+					window.scrollBy({{top: scroll, left: 0, behavior: 'instant'}});
 				}}
 				hide.onclick = function()
 				{{
@@ -39,6 +41,7 @@ namespace TASVideos.TagHelpers
 					content.style.maxHeight = height;
 					hide.classList.add('d-none');
 					show.classList.remove('d-none');
+					content.scrollTop = 0;
 				}}
 			}}
 	}}


### PR DESCRIPTION
It now keeps the scroll position when expanding, even if the content somehow was scrolled by other means (e.g. by clicking a link with a fragment). It also resets the scroll when hiding to restore the initial position.