### PR TITLE
Disable antiforgery token for logout button

### DIFF
--- a/TASVideos/Pages/Account/Logout.cshtml.cs
+++ b/TASVideos/Pages/Account/Logout.cshtml.cs
@@ -6,6 +6,7 @@ using TASVideos.Core.Services;
 namespace TASVideos.Pages.Account
 {
 	[Authorize]
+	[IgnoreAntiforgeryToken]
 	public class LogoutModel : BasePageModel
 	{
 		private readonly SignInManager _signInManager;

--- a/TASVideos/Pages/Shared/_LoginPartial.cshtml
+++ b/TASVideos/Pages/Shared/_LoginPartial.cshtml
@@ -12,7 +12,7 @@
 <div class="d-md-flex">
 	@if (isSignedIn)
 	{
-		<form asp-page="/Account/Logout" method="post" id="logoutForm">
+		<form asp-page="/Account/Logout" method="post" id="logoutForm" asp-antiforgery="false">
 			<navbar>
 				<nav-item activate="Messages">
 					<a id="Inbox" class="nav-link text-nowrap" asp-page="/Messages/Inbox">


### PR DESCRIPTION
This fixes all pages having a token and thus disabling the response cache.
For logged in users, this should speed up browsing considerably.