### PR TITLE
Simplify Post links

### DIFF
--- a/TASVideos.Core/Services/Email/EmailService.cs
+++ b/TASVideos.Core/Services/Email/EmailService.cs
@@ -80,7 +80,7 @@ namespace TASVideos.Core.Services.Email
 
 You are receiving this email because you are watching the topic, ""{template.TopicTitle}"" at {siteName}. This topic has received a reply since your last visit. You can use the following link to view the replies made, no more notifications will be sent until you visit the topic.
 
-{template.BaseUrl}/Forum/Posts/{template.PostId}#{template.PostId}
+{template.BaseUrl}/Forum/Posts/{template.PostId}
 
 If you no longer wish to watch this topic you can either click the ""Stop watching this topic link"" found at the top of the topic above, or by clicking the following link:
 

--- a/TASVideos.ForumEngine/Node.cs
+++ b/TASVideos.ForumEngine/Node.cs
@@ -287,7 +287,7 @@ namespace TASVideos.ForumEngine
 					await WriteHref(w, h, s => "/Forum/Topics/" + s, async s => "Thread #" + s);
 					break;
 				case "post":
-					await WriteHref(w, h, s => "/Forum/Posts/" + s + "#" + s, async s => "Post #" + s);
+					await WriteHref(w, h, s => "/Forum/Posts/" + s, async s => "Post #" + s);
 					break;
 				case "movie":
 					await WriteHref(

--- a/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
@@ -142,7 +142,7 @@ namespace TASVideos.Pages.Forum.Posts
 				topic.Forum.Restricted,
 				"New reply",
 				$"({topic.Forum.ShortName}: {topic.Title}) ({Post.Subject})",
-				$"Forum/Posts/{id}#{id}",
+				$"Forum/Posts/{id}",
 				$"{user.UserName}{mood}",
 				"New Forum Post");
 
@@ -160,7 +160,7 @@ namespace TASVideos.Pages.Forum.Posts
 				_logger.LogWarning("Email notification failed on new reply creation");
 			}
 
-			return BaseRedirect($"/Forum/Posts/{id}#{id}");
+			return BaseRedirect($"/Forum/Posts/{id}");
 		}
 	}
 }

--- a/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
@@ -137,12 +137,12 @@ namespace TASVideos.Pages.Forum.Posts
 					forumPost.Topic!.Forum!.Restricted,
 					$"Post edited ({forumPost.Topic.Forum.ShortName}: {forumPost.Topic.Title})",
 					"",
-					$"Forum/Posts/{Id}#{Id}",
+					$"Forum/Posts/{Id}",
 					User.Name(),
 					"Forum Post Edited");
 			}
 
-			return BaseRedirect($"/Forum/Posts/{Id}#{Id}");
+			return BaseRedirect($"/Forum/Posts/{Id}");
 		}
 
 		public async Task<IActionResult> OnPostDelete()

--- a/TASVideos/Pages/Forum/Posts/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Index.cshtml.cs
@@ -29,12 +29,14 @@ namespace TASVideos.Pages.Forum.Posts
 
 			return RedirectToPage(
 				"/Forum/Topics/Index",
+				null,
 				new
 				{
 					Id = model.TopicId,
 					CurrentPage = model.Page,
 					Highlight = Id
-				});
+				},
+				Id.ToString());
 		}
 	}
 }

--- a/TASVideos/Pages/Forum/Posts/User.cshtml
+++ b/TASVideos/Pages/Forum/Posts/User.cshtml
@@ -19,7 +19,7 @@
 				</div>
 				<div class="col-8 pt-0 pb-0">
 					<small style="display: inline-block">
-						<a href="/Forum/Posts/@(post.Id)#@post.Id" title="Link to this post" class="float-start"><i class="fa fa-bookmark-o"></i></a>
+						<a href="/Forum/Posts/@(post.Id)" title="Link to this post" class="float-start"><i class="fa fa-bookmark-o"></i></a>
 						Posted: @post.CreateTimestamp
 						<span condition="!string.IsNullOrWhiteSpace(post.Subject)">Post subject: @post.Subject</span>
 					</small>

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml
@@ -68,7 +68,7 @@
 					{
 						<timezone-convert asp-for="@topic.LastPostDateTime" /> <br />
 						<profile-link username="@topic.LastPostUserName"></profile-link>
-						<a href="/Forum/Posts/@topic.LastPostId#@topic.LastPostId" class="fa fa-arrow-circle-right" />
+						<a href="/Forum/Posts/@topic.LastPostId" class="fa fa-arrow-circle-right" />
 					}
 				</td>
 			</tr>

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml
@@ -17,7 +17,7 @@
 		<meta property="og:site_name" content="TASVideos" />
 		<meta property="og:title" content="@($"Forum Reply by {Model.HighlightedPost.PosterName}")" />
 		<meta property="og:description" content="@description" />
-		<meta property="og:url" content="@($"{HttpContext.Request.ToBaseUrl()}/Forum/Posts/{Model.HighlightedPost.Id}#{Model.HighlightedPost.Id}")" />
+		<meta property="og:url" content="@($"{HttpContext.Request.ToBaseUrl()}/Forum/Posts/{Model.HighlightedPost.Id}")" />
 		<meta property="og:image" content="@Model.HighlightedPost.GetCurrentAvatar()" />
 	}
 } else

--- a/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
@@ -4,7 +4,7 @@
 		<row class="align-items-center">
 			<div class="col-lg-2 col-md-3 col-auto">
 				<small>
-					<a href="/Forum/Posts/@(Model.Id)#@Model.Id"
+					<a href="/Forum/Posts/@(Model.Id)"
 					   title="Link to this post"
 					   class="float-start text-decoration-none text-dark">
 						<i class="fa fa-bookmark-o"></i>

--- a/TASVideos/Pages/Forum/_Category.cshtml
+++ b/TASVideos/Pages/Forum/_Category.cshtml
@@ -38,7 +38,7 @@
 				<div class="col-4 align-items-center">
 					<timezone-convert asp-for="@forum.LastPost.CreateTimestamp" /> <br />
 					<profile-link username="@forum.LastPost.CreateUserName"></profile-link>
-					<a href="/Forum/Posts/@forum.LastPost.Id#@forum.LastPost.Id" class="fa fa-arrow-circle-right"></a>
+					<a href="/Forum/Posts/@forum.LastPost.Id" class="fa fa-arrow-circle-right"></a>
 				</div>
 			}
 			</row>

--- a/TASVideos/Pages/RssFeeds/_RssNews.cshtml
+++ b/TASVideos/Pages/RssFeeds/_RssNews.cshtml
@@ -1,7 +1,7 @@
 ﻿@model TASVideos.Pages.RssFeeds.Models.RssNews
 @{
 	var baseUrl = ViewData["BaseUrl"];
-	var postUrl = $"{baseUrl}/Forum/Posts/{Model.PostId}#{Model.PostId}";
+	var postUrl = $"{baseUrl}/Forum/Posts/{Model.PostId}";
 }
 <item>
 	<title>@Model.Subject</title>

--- a/TASVideos/Pages/Search/Index.cshtml
+++ b/TASVideos/Pages/Search/Index.cshtml
@@ -76,7 +76,7 @@
 			{
 				<tr>
 					<td>
-						<a href="/Forum/Posts/@result.PostId#@result.PostId">@result.TopicName</a>
+						<a href="/Forum/Posts/@result.PostId">@result.TopicName</a>
 					</td>
 					<td>
 						@Html.Raw(result.Highlight)

--- a/TASVideos/Pages/Shared/Components/TopicFeed/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/TopicFeed/Default.cshtml
@@ -7,8 +7,8 @@
 		var collapseId = $"collapse-content-{post.Id}";
 		<div class="card">
 			<div class="card-body">
-				<h5 condition="!Model.HideContent"><a href="/Forum/Posts/@(post.Id)#@(post.Id)">@post.Subject</a></h5>
-				<h5 condition="Model.HideContent"><a class="collapsed" data-bs-toggle="collapse" href="/Forum/Posts/@(post.Id)#@(post.Id)" data-bs-target="#@collapseId" role="button" aria-expanded="false"><i class="fa fa-chevron-circle-down"></i> @post.Subject</a></h5>
+				<h5 condition="!Model.HideContent"><a href="/Forum/Posts/@(post.Id)">@post.Subject</a></h5>
+				<h5 condition="Model.HideContent"><a class="collapsed" data-bs-toggle="collapse" href="/Forum/Posts/@(post.Id)" data-bs-target="#@collapseId" role="button" aria-expanded="false"><i class="fa fa-chevron-circle-down"></i> @post.Subject</a></h5>
 				<h6 class="card-subtitle mb-2 text-muted">
 					<small>
 						posted by <a href="/@post.PosterName">@post.PosterName</a> <timezone-convert asp-for="@post.CreateTimestamp" in-line="true" />


### PR DESCRIPTION
Currently, all Post links like
`https://tasvideos.org/Forum/Posts/511157` turn into
-> `https://tasvideos.org/Forum/Topics/23000?CurrentPage=1&Highlight=511157`
And
`https://tasvideos.org/Forum/Posts/511157#511157` turn into
-> `https://tasvideos.org/Forum/Topics/23000?CurrentPage=1&Highlight=511157#511157`
The difference is the ` #511157` (called a uri fragment).

This pull request changes the behavior so that even post links without the fragment add (or overwrite!) the fragment to the post.
I.e. posts like this
`https://tasvideos.org/Forum/Posts/511157` and this
`https://tasvideos.org/Forum/Posts/511157#511157` and even this
`https://tasvideos.org/Forum/Posts/511157#1234` all get converted into the proper
-> `https://tasvideos.org/Forum/Topics/23000?CurrentPage=1&Highlight=511157#511157`.

<hr>

This simplifies a lot of links, makes them look nicer, and makes the Discord embeds work (Discord strips all fragments away).

**But we lose one feature** with this: The ability to highlight one post but anchor something different (like a different post).
Because the fragments are never sent to the server we can't do logic depending on them. We either always replace it on posts, or never.