### PR TITLE
Split CamelCase on subpage lists to mirror their titles

### DIFF
--- a/TASVideos/Pages/Shared/Components/ListSubPages/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/ListSubPages/Default.cshtml
@@ -11,7 +11,7 @@
 <div condition="@Model.Any()" class="card">
 	<div class="card-header">
 		<collapsablecontent-header body-id="collapse-content-@pageId">
-			<i class="fa fa-chevron-circle-down"></i> <strong>Subpages for @ViewData["Parent"]</strong>
+			<i class="fa fa-chevron-circle-down"></i> <strong>Subpages for @ViewData["Parent"].ToString().SplitCamelCase()</strong>
 		</collapsablecontent-header>
 	</div>
 	<collapsablecontent-body id="collapse-content-@pageId" start-shown="@show">
@@ -20,11 +20,11 @@
 				@foreach (var pageGroup in pageGrouping.OrderBy(g => g.Key))
 				{
 					<li>
-						<a href="/@($"{parent}/{pageGroup.Key}")">@pageGroup.Key?.Replace($"{parent}/", "")</a>
+						<a href="/@($"{parent}/{pageGroup.Key}")">@pageGroup.Key?.Replace($"{parent}/", "").SplitCamelCase()</a>
 						<ul condition="pageGroup.Count() > 1">
 							@foreach (var subpage in pageGroup.Where(pg => pg != $"{parent}/{pageGroup.Key}").OrderBy(pg => pg))
 							{
-								<li><a href="/@subpage">@subpage.Replace($"{parent}/{pageGroup.Key}/", "")</a></li>
+								<li><a href="/@subpage">@subpage.Replace($"{parent}/{pageGroup.Key}/", "").SplitCamelCase()</a></li>
 							}
 						</ul>
 					</li>


### PR DESCRIPTION
Resolve #440.

There have been suggestions how to move away from splitting camel case completely and use some other method, but currently it's inconsistent to split them sometimes but not other times.
For now let's just do what the old site did and split them wherever they show up.