### PR TITLE
highlight terms with a background color

### DIFF
--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -374,3 +374,10 @@ tt, code, kbd, pre, samp {
 pre code {
 	padding: 0;
 }
+
+dt {
+	background: var(--cardsecondary);
+	border-radius: 5px;
+	padding: 0.125rem 0.375rem;
+	font-size: 85%;
+}


### PR DESCRIPTION
fixes #974
<img width="158" alt="dtStyleDark" src="https://user-images.githubusercontent.com/38826675/149648485-a9c98604-4f34-4602-bdf9-1dabb1e40339.PNG">
<img width="130" alt="dtStyleLight" src="https://user-images.githubusercontent.com/38826675/149648487-f58fb3bd-8c2b-4bd3-885d-7e3d666b28a3.PNG">

