### PR TITLE
give blockquote a background and italics

### DIFF
--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -364,11 +364,15 @@ tt {
 	unicode-bidi: bidi-override;
 }
 
-tt, code, kbd, pre, samp {
+tt, code, kbd, pre, samp, blockquote {
 	background: var(--bs-gray-400);
 	border-radius: 5px;
 	padding: 0.125rem 0.375rem;
 	font-size: 85%;
+}
+
+blockquote {
+	font-style: italic;
 }
 
 pre code {


### PR DESCRIPTION
fixes #973 
![image](https://user-images.githubusercontent.com/38826675/149648611-7d414f18-5c62-4729-8990-bacbfe113f88.png)

gives blockquote the same background as preformatted/code samples with italics to match the old site and differentiate it