### PR TITLE
make highlight actually highlight text

### DIFF
--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -212,7 +212,11 @@ article.wiki, .postbody {
 	}
 
 	.highlight {
-		background-color: var(--bs-light);
+		background-color: var(--bs-yellow);
+		color: black;
+		border-radius: 5px;
+		padding: 0.125rem 0.375rem;
+		font-size: 85%;
 	}
 }
 


### PR DESCRIPTION
fixes #989

(uses the same yellow bg/black text on both light and dark)
![image](https://user-images.githubusercontent.com/38826675/149648840-69c05973-b905-4323-8722-ea605ae37862.png)
