### PR TITLE
Add search to game list

### DIFF
--- a/TASVideos/Pages/Games/List.cshtml
+++ b/TASVideos/Pages/Games/List.cshtml
@@ -1,14 +1,27 @@
 ﻿@page "{handler?}"
 @model ListModel
 @{
-	ViewData["Title"] = "Game List" + (!string.IsNullOrWhiteSpace(Model.Games.SystemCode) ? "/" + Model.Games.SystemCode : string.Empty);
+	ViewData["Title"] = "Game List" +
+		(!string.IsNullOrWhiteSpace(Model.Games.SystemCode) ? " - " + Model.Games.SystemCode : string.Empty) +
+		(!string.IsNullOrWhiteSpace(Model.Games.SearchTerms) ? " - " + $@"""{Model.Games.SearchTerms}""" : string.Empty);
 }
 
 <a asp-page="Edit" class="btn btn-primary mb-3 float-end"><i class="fa fa-plus"></i> Create</a>
-<form class="mb-3 d-flex align-items-center">
-	<div class="input-group">
-		<label asp-for="@Model.Games.SystemCode" class="input-group-text"></label>
-		<select asp-items="@Model.SystemList" asp-for="@Model.Games.SystemCode" name="SystemCode" class="form-control"></select>
+<form class="row">
+	<div class="col-lg-5 col-12 mb-1">
+		<div class="input-group">
+			<label asp-for="SearchTerms" class="input-group-text"></label>
+			<input type="text" asp-for="SearchTerms" class="form-control" />
+		</div>
+		<span asp-validation-for="SearchTerms" class="text-danger"></span>
+	</div>
+	<div class="col-lg-5 col-12 mb-1">
+		<div class="input-group">
+			<label asp-for="@Model.Games.SystemCode" class="input-group-text"></label>
+			<select asp-items="@Model.SystemList" asp-for="@Model.Games.SystemCode" name="SystemCode" class="form-control"></select>
+		</div>
+	</div>
+	<div class="col-2">
 		<button type="Submit" class="btn btn-secondary">Go</button>
 	</div>
 </form>

--- a/TASVideos/Pages/Games/Models/GameListRequest.cs
+++ b/TASVideos/Pages/Games/Models/GameListRequest.cs
@@ -1,4 +1,5 @@
-﻿using TASVideos.Core;
+﻿using System.ComponentModel.DataAnnotations;
+using TASVideos.Core;
 
 namespace TASVideos.Pages.Games.Models
 {
@@ -11,5 +12,7 @@ namespace TASVideos.Pages.Games.Models
 		}
 
 		public string? SystemCode { get; set; }
+
+		public string? SearchTerms { get; set; }
 	}
 }

--- a/TASVideos/Pages/Games/Models/SystemPageOf.cs
+++ b/TASVideos/Pages/Games/Models/SystemPageOf.cs
@@ -15,6 +15,8 @@ namespace TASVideos.Pages.Games.Models
 		[Display(Name = "System")]
 		public string? SystemCode { get; set; }
 
+		public string? SearchTerms { get; set; }
+
 		public static new SystemPageOf<T> Empty() => new (Enumerable.Empty<T>());
 	}
 }

--- a/TASVideos/Pages/Shared/_Pager.cshtml
+++ b/TASVideos/Pages/Shared/_Pager.cshtml
@@ -13,10 +13,11 @@
 			@{
 				var pagerClass = "btn btn-secondary border-dark flex-grow-0";
 				var ellipsisClass = "btn btn-outline-secondary border-dark flex-grow-0";
+				var additionalProperties = Model.AdditionalProperties();
 			}
 			<a disable="@Model.CurrentPage == 1"
 				asp-page="@ViewContext.Page()"
-				asp-all-route-data="@Model.AdditionalProperties()"
+				asp-all-route-data="@additionalProperties"
 				asp-route-CurrentPage="@(Model.CurrentPage - 1)"
 				asp-route-PageSize="@Model.PageSize"
 				asp-route-Sort="@Model.Sort"
@@ -36,7 +37,7 @@
 				foreach (var iteratorPage in leftShown)
 				{
 					<a asp-page="@ViewContext.Page()"
-						asp-all-route-data="@Model.AdditionalProperties()"
+						asp-all-route-data="@additionalProperties"
 						asp-route-CurrentPage="@iteratorPage"
 						asp-route-PageSize="@Model.PageSize"
 						asp-route-Sort="@Model.Sort"
@@ -45,7 +46,7 @@
 				if (leftHidden.Count == 1)
 				{
 					<a asp-page="@ViewContext.Page()"
-						asp-all-route-data="@Model.AdditionalProperties()"
+						asp-all-route-data="@additionalProperties"
 						asp-route-CurrentPage="@leftHidden.First()"
 						asp-route-PageSize="@Model.PageSize"
 						asp-route-Sort="@Model.Sort"
@@ -59,7 +60,7 @@
 						{
 							<li>
 								<a asp-page="@ViewContext.Page()"
-									asp-all-route-data="@Model.AdditionalProperties()"
+									asp-all-route-data="@additionalProperties"
 									asp-route-CurrentPage="@iteratorPage"
 									asp-route-PageSize="@Model.PageSize"
 									asp-route-Sort="@Model.Sort"
@@ -71,7 +72,7 @@
 				foreach (var iteratorPage in middleShown)
 				{
 					<a asp-page="@ViewContext.Page()"
-						asp-all-route-data="@Model.AdditionalProperties()"
+						asp-all-route-data="@additionalProperties"
 						asp-route-CurrentPage="@iteratorPage"
 						asp-route-PageSize="@Model.PageSize"
 						asp-route-Sort="@Model.Sort"
@@ -80,7 +81,7 @@
 				if (rightHidden.Count == 1)
 				{
 					<a asp-page="@ViewContext.Page()"
-						asp-all-route-data="@Model.AdditionalProperties()"
+						asp-all-route-data="@additionalProperties"
 						asp-route-CurrentPage="@rightHidden.First()"
 						asp-route-PageSize="@Model.PageSize"
 						asp-route-Sort="@Model.Sort"
@@ -93,7 +94,7 @@
 						{
 							<li>
 								<a asp-page="@ViewContext.Page()"
-									asp-all-route-data="@Model.AdditionalProperties()"
+									asp-all-route-data="@additionalProperties"
 									asp-route-CurrentPage="@iteratorPage"
 									asp-route-PageSize="@Model.PageSize"
 									asp-route-Sort="@Model.Sort"
@@ -105,7 +106,7 @@
 				foreach (var iteratorPage in rightShown)
 				{
 					<a asp-page="@ViewContext.Page()"
-						asp-all-route-data="@Model.AdditionalProperties()"
+						asp-all-route-data="@additionalProperties"
 						asp-route-CurrentPage="@iteratorPage"
 						asp-route-PageSize="@Model.PageSize"
 						asp-route-Sort="@Model.Sort"
@@ -114,7 +115,7 @@
 			}
 			<a disable="@Model.CurrentPage == Model.LastPage()"
 				asp-page="@ViewContext.Page()"
-				asp-all-route-data="@Model.AdditionalProperties()"
+				asp-all-route-data="@additionalProperties"
 				asp-route-CurrentPage="@(Model.CurrentPage + 1)"
 				asp-route-PageSize="@Model.PageSize"
 				asp-route-Sort="@Model.Sort"


### PR DESCRIPTION
Resolves #750.

Not really happy with this. Technically I don't need to create an own "SearchTerms" variable in /Games/List.cshtml.cs, the query automatically takes it to the "Search" and into the "(Search.)SearchTerms". But now the URL will say "Search.SearchTerms" which breaks things, so it's possible to overwrite the "name" attribute inside the .cshtml. However, this causes the validation to not work, because it relies on the attribute.

In short we either have no automatic validation, or an extra variable in the root like this.