### PR TITLE
refactor quote markup

### DIFF
--- a/TASVideos.ForumEngine/Node.cs
+++ b/TASVideos.ForumEngine/Node.cs
@@ -203,17 +203,17 @@ namespace TASVideos.ForumEngine
 					break;
 				case "quote":
 					w.OpenTag("figure");
-					w.OpenTag("blockquote");
-					await WriteChildren(w, h);
-					w.CloseTag("blockquote");
 					if (Options != "")
 					{
 						w.OpenTag("figcaption");
-						w.Attribute("class", "blockquote-footer");
 						await BbParser.Parse(Options, false, true).WriteHtml(w, h);
+						w.Text(" wrote:");
 						w.CloseTag("figcaption");
 					}
 
+					w.OpenTag("blockquote");
+					await WriteChildren(w, h);
+					w.CloseTag("blockquote");
 					w.CloseTag("figure");
 					break;
 				case "code":

--- a/TASVideos.ForumEngine/Node.cs
+++ b/TASVideos.ForumEngine/Node.cs
@@ -202,20 +202,19 @@ namespace TASVideos.ForumEngine
 					await WriteClassyTag(w, h, "span", "highlight");
 					break;
 				case "quote":
-					w.OpenTag("div");
-					w.Attribute("class", "quotecontainer");
-					if (Options != "")
-					{
-						w.OpenTag("cite");
-						await BbParser.Parse(Options, false, true).WriteHtml(w, h);
-						w.Text(" wrote:");
-						w.CloseTag("cite");
-					}
-
+					w.OpenTag("figure");
 					w.OpenTag("blockquote");
 					await WriteChildren(w, h);
 					w.CloseTag("blockquote");
-					w.CloseTag("div");
+					if (Options != "")
+					{
+						w.OpenTag("figcaption");
+						w.Attribute("class", "blockquote-footer");
+						await BbParser.Parse(Options, false, true).WriteHtml(w, h);
+						w.CloseTag("figcaption");
+					}
+
+					w.CloseTag("figure");
 					break;
 				case "code":
 					{

--- a/TASVideos.WikiEngine/NewParser.cs
+++ b/TASVideos.WikiEngine/NewParser.cs
@@ -737,16 +737,15 @@ namespace TASVideos.WikiEngine
 			else if (Eat("%%QUOTE"))
 			{
 				var authorBlock = new Element(_index, "figcaption");
-				authorBlock.Attributes["class"] = "author blockquote-footer";
+				authorBlock.Attributes["class"] = "author";
 				var author = EatClassText();
 
 				ClearBlockTags();
 
 				var e = new Element(_index, "figure");
-				e.Attributes["class"] = "row";
 				if (author != "")
 				{
-					authorBlock.Children.Add(new Text(authorBlock.CharStart, author));
+					authorBlock.Children.Add(new Text(authorBlock.CharStart, "Quoting " + author));
 					e.Children.Add(authorBlock);
 				}
 

--- a/TASVideos.WikiEngine/NewParser.cs
+++ b/TASVideos.WikiEngine/NewParser.cs
@@ -729,24 +729,24 @@ namespace TASVideos.WikiEngine
 			}
 			else if (Eat("%%QUOTE_END"))
 			{
-				if (!TryPop("sillyquote"))
+				if (!TryPop("figure"))
 				{
 					Abort("Mismatched %%QUOTE_END", _index);
 				}
 			}
 			else if (Eat("%%QUOTE"))
 			{
-				var authorBlock = new Element(_index, "cite");
-				authorBlock.Attributes["class"] = "author";
+				var authorBlock = new Element(_index, "figcaption");
+				authorBlock.Attributes["class"] = "author blockquote-footer";
 				var author = EatClassText();
 
 				ClearBlockTags();
 
-				var e = new Element(_index, "sillyquote");
-				e.Attributes["class"] = "quotecontainer";
+				var e = new Element(_index, "figure");
+				e.Attributes["class"] = "row";
 				if (author != "")
 				{
-					authorBlock.Children.Add(new Text(authorBlock.CharStart, "Quoting " + author));
+					authorBlock.Children.Add(new Text(authorBlock.CharStart, author));
 					e.Children.Add(authorBlock);
 				}
 

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -170,7 +170,7 @@ article.wiki, .postbody {
 	display: none;
 }
 
-.quotecontainer {
+figure {
 	margin: 0.75rem;
 	padding: .25rem;
 	background-color: var(--bs-gray-200);
@@ -368,24 +368,31 @@ tt {
 	unicode-bidi: bidi-override;
 }
 
-tt, code, kbd, pre, samp, blockquote {
+tt, code, kbd, pre, samp, .wiki blockquote {
 	background: var(--bs-gray-400);
+}
+
+tt, code, kbd, pre, samp, dt, .wiki blockquote {
 	border-radius: 5px;
 	padding: 0.125rem 0.375rem;
 	font-size: 85%;
 }
+dt, .wiki blockquote {
+	display: inline-block;
+}
 
-blockquote {
+dt {
+	background: var(--cardprimary);
+}
+
+.wiki blockquote {
 	font-style: italic;
+}
+
+.blockquote-footer {
+	order: 1;
 }
 
 pre code {
 	padding: 0;
-}
-
-dt {
-	background: var(--cardsecondary);
-	border-radius: 5px;
-	padding: 0.125rem 0.375rem;
-	font-size: 85%;
 }

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -389,10 +389,6 @@ dt {
 	font-style: italic;
 }
 
-.blockquote-footer {
-	order: 1;
-}
-
 pre code {
 	padding: 0;
 }


### PR DESCRIPTION
fixes #1004 - uses figure and figcaption per newer HTML spec where `cite` is intended for the title of works, also integrates with bootstrap's default styling using blockquote-footer for the author and fixes the background conflict in the forum where blockquote was used for quotes.