### PR TITLE
More Media Notification fixes

### DIFF
--- a/TASVideos/Pages/Publications/AdditionalMovies.cshtml.cs
+++ b/TASVideos/Pages/Publications/AdditionalMovies.cshtml.cs
@@ -138,7 +138,7 @@ namespace TASVideos.Pages.Publications
 				{
 					await _publisher.SendPublicationEdit(
 						$"{Id}M edited by {User.Name()}",
-						$"{log} | {PublicationTitle}",
+						$"{log}",
 						$"{Id}M");
 				}
 			}

--- a/TASVideos/Pages/Publications/Catalog.cshtml.cs
+++ b/TASVideos/Pages/Publications/Catalog.cshtml.cs
@@ -183,7 +183,7 @@ namespace TASVideos.Pages.Publications
 			{
 				await _publisher.SendPublicationEdit(
 					$"{Id}M Catalog edited by {User.Name()}",
-					string.Join(", ", externalMessages),
+					$"{string.Join(", ", externalMessages)} | {publication.Title}",
 					$"{Id}M");
 			}
 

--- a/TASVideos/Pages/Publications/EditFiles.cshtml.cs
+++ b/TASVideos/Pages/Publications/EditFiles.cshtml.cs
@@ -126,7 +126,7 @@ namespace TASVideos.Pages.Publications
 				await _publicationMaintenanceLogger.Log(Id, User.GetUserId(), log);
 				await _publisher.SendPublicationEdit(
 					$"{Id}M edited by {User.Name()}",
-					$"{log} | {Title}",
+					$"{log}",
 					$"{Id}M");
 			}
 

--- a/TASVideos/Pages/Publications/EditUrls.cshtml.cs
+++ b/TASVideos/Pages/Publications/EditUrls.cshtml.cs
@@ -172,7 +172,7 @@ namespace TASVideos.Pages.Publications
 				{
 					await _publisher.SendPublicationEdit(
 						$"{Id}M edited by {User.Name()}",
-						$"Deleted {url.Type} url | {Title}",
+						$"Deleted {url.Type} url",
 						$"{Id}M");
 
 					await _youtubeSync.UnlistVideo(url.Url!);

--- a/TASVideos/Pages/Submissions/Catalog.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Catalog.cshtml.cs
@@ -198,7 +198,7 @@ namespace TASVideos.Pages.Submissions
 			{
 				await _publisher.SendSubmissionEdit(
 					$"{Id}S Catalog edited by {User.Name()}",
-					string.Join(", ", externalMessages),
+					$"{string.Join(", ", externalMessages)} | {submission.Title}",
 					$"{Id}S");
 			}
 


### PR DESCRIPTION
- Remove reporting titles when they're empty.
- Add reporting titles on catalog edits to be consistent there.