### PR TITLE
Add Permission To Login

### DIFF
--- a/TASVideos.Core/Extensions/ClaimsExtensions.cs
+++ b/TASVideos.Core/Extensions/ClaimsExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using TASVideos.Data.Entity;
+
+namespace TASVideos.Core.Extensions
+{
+	public static class ClaimsExtensions
+	{
+		public static IEnumerable<PermissionTo> Permissions(this IEnumerable<Claim> claims)
+		{
+			return claims
+				.Where(c => c.Type == CustomClaimTypes.Permission)
+				.Select(c => Enum.Parse<PermissionTo>(c.Value))
+				.ToList();
+		}
+
+		public static IEnumerable<Claim> ThatArePermissions(this IEnumerable<Claim> claims)
+		{
+			return claims.Where(c => c.Type == CustomClaimTypes.Permission);
+		}
+	}
+}

--- a/TASVideos.Core/Extensions/ClaimsPrincipalExtensions.cs
+++ b/TASVideos.Core/Extensions/ClaimsPrincipalExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using TASVideos.Core.Extensions;
 using TASVideos.Data.Entity;
 
 namespace TASVideos
@@ -36,10 +37,7 @@ namespace TASVideos
 				return Enumerable.Empty<PermissionTo>();
 			}
 
-			return user.Claims
-				.Where(c => c.Type == CustomClaimTypes.Permission)
-				.Select(c => Enum.Parse<PermissionTo>(c.Value))
-				.ToList();
+			return user.Claims.Permissions();
 		}
 
 		public static bool Has(this ClaimsPrincipal user, PermissionTo permission)
@@ -60,7 +58,7 @@ namespace TASVideos
 			}
 
 			foreach (var claim in user.Claims
-				.Where(c => c.Type == CustomClaimTypes.Permission)
+				.ThatArePermissions()
 				.ToList())
 			{
 				ci.RemoveClaim(claim);

--- a/TASVideos.Core/Services/SignInManager.cs
+++ b/TASVideos.Core/Services/SignInManager.cs
@@ -56,6 +56,8 @@ namespace TASVideos.Core.Services
 
 			if (result.Succeeded)
 			{
+				var canLogIn = await _userManager.HasPermissionTo(user.Id, PermissionTo.Login);
+
 				user.LastLoggedInTimeStamp = DateTime.UtcNow;
 
 				// Note: This runs a save changes so LastLoggedInTimeStamp will get updated too

--- a/TASVideos.Core/Services/UserManager.cs
+++ b/TASVideos.Core/Services/UserManager.cs
@@ -69,12 +69,6 @@ namespace TASVideos.Core.Services
 			return claims;
 		}
 
-		public async Task<bool> HasPermissionTo(int userId, PermissionTo perm)
-		{
-			var perms = await GetUserPermissionsById(userId);
-			return perms.Any(p => p == perm);
-		}
-
 		/// <summary>
 		/// Returns a list of all permissions of the <seea cref="User"/> with the given id
 		/// </summary>

--- a/TASVideos.Core/Services/UserManager.cs
+++ b/TASVideos.Core/Services/UserManager.cs
@@ -69,6 +69,12 @@ namespace TASVideos.Core.Services
 			return claims;
 		}
 
+		public async Task<bool> HasPermissionTo(int userId, PermissionTo perm)
+		{
+			var perms = await GetUserPermissionsById(userId);
+			return perms.Any(p => p == perm);
+		}
+
 		/// <summary>
 		/// Returns a list of all permissions of the <seea cref="User"/> with the given id
 		/// </summary>

--- a/TASVideos.Data/Entity/PermissionTo.cs
+++ b/TASVideos.Data/Entity/PermissionTo.cs
@@ -44,7 +44,11 @@ namespace TASVideos.Data.Entity
 
 		[Group("User")]
 		[Description("The ability to upload movie and related files for personal storage.")]
-		UploadUserFiles,
+		UploadUserFiles = 13,
+
+		[Group("User")]
+		[Description("Grants the ability to log into the site. Without this permissions, a user account is effectively banned.")]
+		Login = 14,
 
 		[Group("User")]
 		[Description("The ability to send private messages.")]

--- a/TASVideos/Pages/Account/Login.cshtml.cs
+++ b/TASVideos/Pages/Account/Login.cshtml.cs
@@ -56,6 +56,11 @@ namespace TASVideos.Pages.Account
 				return RedirectToPage("/Account/Lockout");
 			}
 
+			if (result.IsNotAllowed)
+			{
+				return AccessDenied();
+			}
+
 			ModelState.AddModelError(string.Empty, "Invalid login attempt.");
 			return Page();
 		}


### PR DESCRIPTION
Checks for this permission on sign-in, if not present, redirects to AccessDenied.  One thought I have, is we could redirect to a wiki page that explains the situation . I have no thoughts as to the name of this page, but if someone has one and wants this, I can add that in.

As part of this deployment, Default User and Site Admin will need this permission added.
Since this checks the role_permissions table, it will see all eligible users as having this permissions, so there should not be any login complications for existing users.