### PR TITLE
Email Confimation - check if email is already confirmed before confirming

### DIFF
--- a/TASVideos/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/TASVideos/Pages/Account/ConfirmEmail.cshtml.cs
@@ -39,6 +39,12 @@ namespace TASVideos.Pages.Account
 				return Home();
 			}
 
+			if (user.EmailConfirmed)
+			{
+				// If user has already clicked the email link, no reason to do all the work of confirming
+				return Home();
+			}
+
 			var result = await _userManager.ConfirmEmailAsync(user, code);
 			if (!result.Succeeded)
 			{


### PR DESCRIPTION
External Media updates show that people click the email confirmation multiple times frequently.  Actually check if their email is confirmed before wasting effort confirming and sending duplicate external media posts.