### PR TITLE
New JRSR parser

### DIFF
--- a/TASVideos.Parsers/Parsers/Jrsr.cs
+++ b/TASVideos.Parsers/Parsers/Jrsr.cs
@@ -152,6 +152,12 @@ namespace TASVideos.MovieParsers.Parsers
 								timestamp = lastTimestamp + timestamp;
 							}
 
+							// "Events must be in time order from first to last."
+							if (timestamp < lastTimestamp)
+							{
+								throw new FormatException($"Event timestamp {timestamp} is before preceding timestamp {lastTimestamp}");
+							}
+
 							lastTimestamp = timestamp;
 
 							var eventClass = tokens[1];

--- a/TASVideos.Parsers/Parsers/Jrsr.cs
+++ b/TASVideos.Parsers/Parsers/Jrsr.cs
@@ -1,8 +1,52 @@
-﻿using System.IO;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using TASVideos.Extensions;
 using TASVideos.MovieParsers.Extensions;
 using TASVideos.MovieParsers.Result;
+
+/*
+ * https://tasvideos.org/EmulatorResources/JPC/JRSRFormat
+ *
+ * Abstractly, a JRSR file is a container for a list of named sections. Each
+ * section contains a list of lines. Section names must be unique. The order of
+ * section names does not matter (think of it as a mapping). Inside a section,
+ * the order of lines matters.
+ *
+ * The format of a line depends on the name of the section it appears in. Most
+ * commonly, lines are in "component" format, which encodes a list of zero or
+ * more non-empty text tokens.
+ *
+ * The internal class JrsrSectionParser is a one-pass, memory-bounded parser for
+ * the syntactic elements of JRSR. It provides a way to incrementally read
+ * section names and lines within sections, without interpreting them. The
+ * private method JrsrSectionParser.DecodeComponent iterates over the tokens of
+ * a line in "component" format.
+ *
+ * The public class Jrsr interprets the semantics of the JRSR structure; i.e.,
+ * it looks for specific section names and understands the format of the lines
+ * within them.
+ */
+
+/*
+ * JRSR files are Unicode text, encoded in UTF-8. This is not a perfect match
+ * for System.IO.StreamReader and the char data type, which deal not in whole
+ * Unicode code points or Unicode scalar values, but in UTF-16 code units. Code
+ * points outside the basic multilingual plane (BMP; >= 0x10000) are represented
+ * not as a single char but as a pair of surrogates.
+ *
+ * The really correct thing to do would be to decode the input into a sequence
+ * of System.Text.Rune (which represents a whole Unicode scalar value), but
+ * StreamReader and char are actually sufficient for our purposes. This is
+ * because all the syntax elements we care about (spaces and linefeeds, '+',
+ * '\', '(', ')', keywords "JRSR", "!BEGIN", "!END") consist only of characters
+ * from the BMP. Anything that is true or false of these characters is also true
+ * or false of the UTF-16 code units that represent them; anything that is true
+ * or false of code points outside the BMP is also true or false of all
+ * surrogates.
+ */
 
 namespace TASVideos.MovieParsers.Parsers
 {
@@ -130,6 +174,598 @@ namespace TASVideos.MovieParsers.Parsers
 		{
 			public const string RerecordCount = "+RERECORDS";
 			public const string StartsFromSavestate = "+SAVESTATEID";
+		}
+	}
+
+	/// <summary>
+	/// Parser for the structure of a JRSR file. Call <see cref="NextSection"/>
+	/// to get the name of the next section, or <c>null</c> if there are no more
+	/// sections. While in a section, call <see cref="NextLine"/> to get the
+	/// next line, or <c>null</c> if there are no more lines in the section.
+	/// This class does not check or enforce uniqueness of section names.
+	/// </summary>
+	/// <example>
+	/// <code>
+	/// using (var parser = JrsrSectionParser.CreateAsync(stream, 10000))
+	/// {
+	///     while (await parser.NextSection() is string sectionName)
+	///     {
+	///         if (sectionName == "events")
+	///         {
+	///             while (await parser.NextLine() is string line)
+	///             {
+	///                 var tokens = JrsrSectionParser.DecodeComponent(line).ToList();
+	///             }
+	///         }
+	///     }
+	/// }
+	/// </code>
+	/// </example>
+	internal class JrsrSectionParser : IDisposable
+	{
+		/*
+		 * https://tasvideos.org/EmulatorResources/JPC/JRSRFormat#FileStructure
+		 * https://repo.or.cz/jpcrr.git/blob/6ab255ce10b2dd10b0ac3ab2e2be708e0b26eeaa:/org/jpc/jrsr/JRSRArchiveReader.java#l714
+		 *
+		 * Grammar for JRSR sections and lines:
+		 *   space ::= [#x09#x20#x1680#x180e#x2000-#x200a#x2028#x205f#x3000]
+		 *   lf    ::= [#x0a#x0d#x1c-#x1e#x85#x2029]
+		 *   nonlf ::= [^#x0a#x0d#x1c-#x1e#x85#x2029]
+		 *   jrsr  ::= "JRSR" lf+ sections?
+		 *   begin ::= "!BEGIN" space+ nonlf+ lf+
+		 *   line  ::= "+" nonlf+ lf+
+		 *   end   ::= "!END" lf+
+		 *   sections ::= section-begin
+		 *                line*
+		 *                (section-end?
+		 *                 section-begin
+		 *                 line*)*
+		 *                section-end
+		 */
+
+		private readonly StreamReader _reader;
+
+		// A safety limit on the length of section names and the length of lines
+		// within sections. The JRSR format does not otherwise limit the length
+		// of these strings.
+		private readonly int _lengthLimit;
+
+		private bool _inSection = false;
+
+		// We will need to read 1 char at a time from the stream, and also to be
+		// able to "unread" up to 1 char so that it can be read again later.
+		private char[] _readBuf = new char[1];
+		private char? _unread = null;
+
+		/// <summary>
+		/// If a character was previously unread using <see cref="UnreadChar"/>,
+		/// returns it an clears the unread buffer. Otherwise, reads and returns
+		/// the next character from <see cref="_reader"/>. Returns -1 at the end
+		/// of the stream.
+		/// </summary>
+		/// <exception name="FormatException">The next bytes in the stream do
+		/// not encode a character in UTF-8.</exception>
+		private async Task<int> ReadChar()
+		{
+			if (_unread is char c)
+			{
+				// If we previously unread a character, return it now.
+				_unread = null;
+				return (int)c;
+			}
+			else
+			{
+				// Otherwise, read a new character from _reader.
+				try
+				{
+					var n = await _reader.ReadBlockAsync(_readBuf, 0, _readBuf.Length);
+					return n == 0 ? -1 : _readBuf[0];
+				}
+				catch (DecoderFallbackException ex)
+				{
+					throw new FormatException("Decode", ex);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Stores a <see cref="c"/> in the unread buffer, to be returned by a
+		/// future call to <see cref="ReadChar"/>.
+		/// </summary>
+		/// <exception name="InvalidOperationException">The method was called
+		/// twice in a row, without an intervening <see cref="ReadChar"/> to
+		/// clear the unread buffer.</exception>
+		private void UnreadChar(char c)
+		{
+			if (_unread is char)
+			{
+				throw new InvalidOperationException("UnreadChar called twice without intervening ReadChar");
+			}
+
+			_unread = c;
+		}
+
+		// The constructor is private, only accessible through the public
+		// factory method CreateAsync.
+		private JrsrSectionParser(StreamReader reader, int lengthLimit)
+		{
+			_reader = reader;
+			_lengthLimit = lengthLimit;
+		}
+
+		public void Dispose() => _reader.Dispose();
+
+		/// <summary>
+		/// Creates a new instance of <see cref="JrsrSectionParser"/>.
+		/// </summary>
+		/// <param name="file">The <c>Stream</c> to read from.</param>
+		/// <param name="lengthLimit">A limit on the length of section names and
+		/// line. Strings longer than this result in <c>FormatException</c>, as
+		/// if there had been a syntax error.</param>
+		/// <exception name="FormatException">The file header is missing the
+		/// JRSR magic.</exception>
+		/// <exception name="DecoderFallbackException">The file is incorrectly
+		/// encoded as UTF-8.</exception>
+		public static async Task<JrsrSectionParser> CreateAsync(Stream stream, int lengthLimit)
+		{
+			// https://tasvideos.org/EmulatorResources/JPC/JRSRFormat#FileConventions
+			// "The character set is always UTF-8."
+			// encoderShouldEmitUTF8Identifier=false means that the StreamReader
+			// will retain a UTF-8 byte order mark "\xef\xbb\xbf" if present at
+			// the beginning of the Stream--we want to detect that as a syntax
+			// error. throwOnInvalidBytes=true means to throw a
+			// DecoderFallbackException for badly encoded UTF-8, rather than
+			// substituting the replacement character U+FFFD.
+			var reader = new StreamReader(stream, new UTF8Encoding(false, true), false);
+
+			try
+			{
+				// Check magic.
+				// https://tasvideos.org/EmulatorResources/JPC/JRSRFormat#Magic
+				var magic = new char[5];
+				var n = await reader.ReadBlockAsync(magic, 0, magic.Length);
+				if (!(n == 5 && new string(magic[..4]) == "JRSR" && IsLinefeed(magic[4])))
+				{
+					throw new FormatException("Missing magic");
+				}
+			}
+			catch (DecoderFallbackException ex)
+			{
+				throw new FormatException("Decode", ex);
+			}
+
+			return new JrsrSectionParser(reader, lengthLimit);
+		}
+
+		/// <summary>
+		/// Returns whether <paramref name="c"/> is a JRSR space character. This
+		/// method returns false for all surrogates.
+		/// </summary>
+		private static bool IsSpace(char c)
+		{
+			switch (c)
+			{
+				// https://tasvideos.org/EmulatorResources/JPC/JRSRFormat#Spaces
+				// https://repo.or.cz/jpcrr.git/blob/6ab255ce10b2dd10b0ac3ab2e2be708e0b26eeaa:/org/jpc/Misc.java#l100
+				// The tasvideos.org documentation, as of Revision 7, is
+				// missing one character from the reference implementation,
+				// "\u000c" == "\f" == form feed.
+				case '\u0009':
+				case '\u000c':
+				case '\u0020':
+				case '\u1680':
+				case '\u180e':
+				case '\u2028':
+				case '\u205f':
+				case '\u3000':
+				case '\u2000':
+				case '\u2001':
+				case '\u2002':
+				case '\u2003':
+				case '\u2004':
+				case '\u2005':
+				case '\u2006':
+				case '\u2007':
+				case '\u2008':
+				case '\u2009':
+				case '\u200a':
+					return true;
+
+				default:
+					return false;
+			}
+		}
+
+		/// <summary>
+		/// Returns whether <paramref name="c"/> is a JRSR linefeed character.
+		/// This method returns false for all surrogates.
+		/// </summary>
+		private static bool IsLinefeed(char c)
+		{
+			switch (c)
+			{
+				// https://tasvideos.org/EmulatorResources/JPC/JRSRFormat#LineFeeds
+				// https://repo.or.cz/jpcrr.git/blob/6ab255ce10b2dd10b0ac3ab2e2be708e0b26eeaa:/org/jpc/jrsr/UTFInputLineStream.java#l194
+				case '\u000a':
+				case '\u000d':
+				case '\u001c':
+				case '\u001d':
+				case '\u001e':
+				case '\u0085':
+				case '\u2029':
+					return true;
+
+				default:
+					return false;
+			}
+		}
+
+		/// <summary>
+		/// Parses ahead in the file to find the beginning of the next section,
+		/// skipping over remaining lines in the current section if any, and
+		/// returns the section name. Returns <c>null</c> if there are no more
+		/// sections.
+		/// </summary>
+		/// <exception name="FormatException">There is a syntax error in the
+		/// file, or a section name exceeds the length limit.</exception>
+		public async Task<string?> NextSection()
+		{
+			while (true)
+			{
+				// We are now at the beginning of a line (or at end of file).
+				var c = await ReadChar();
+				if (c == -1)
+				{
+					if (_inSection)
+					{
+						throw new FormatException("Expected !END before end of file");
+					}
+					else
+					{
+						// EOF and not in a section, we are done.
+						return null;
+					}
+				}
+				else if (IsLinefeed((char)c))
+				{
+					// Blank lines are ignored.
+				}
+				else if ((char)c == '!')
+				{
+					// Command is expected to be "BEGIN" or "END". cc is the
+					// character that immediately follows the command.
+					var command = new StringBuilder();
+					int cc;
+					while (true)
+					{
+						cc = await ReadChar();
+						if (cc == -1)
+						{
+							throw new FormatException("Unexpected end of file");
+						}
+						else if (IsSpace((char)cc) || IsLinefeed((char)cc))
+						{
+							break;
+						}
+
+						// We are only expecting BEGIN or END here. If we read
+						// more than 5 characters without finding a space or a
+						// linefeed, it's an error.
+						if (command.Length >= 5)
+						{
+							throw new FormatException("Expected BEGIN or END after !");
+						}
+
+						command.Append((char)cc);
+					}
+
+					if (command.ToString() == "BEGIN")
+					{
+						// Skip over the spaces that follow !BEGIN. There must
+						// be at least one.
+						if (!IsSpace((char)cc))
+						{
+							throw new FormatException("Expected space after !BEGIN");
+						}
+
+						while (true)
+						{
+							cc = await ReadChar();
+							if (cc == -1)
+							{
+								throw new FormatException("Unexpected end of file");
+							}
+							else if (!IsSpace((char)cc))
+							{
+								break;
+							}
+						}
+
+						// The section name is everything to the end of the
+						// line, including spaces.
+						var sectionName = new StringBuilder();
+						while (true)
+						{
+							if (cc == -1)
+							{
+								throw new FormatException("Unexpected end of file");
+							}
+							else if (IsLinefeed((char)cc))
+							{
+								break;
+							}
+
+							if (sectionName.Length >= _lengthLimit)
+							{
+								throw new FormatException("Section name exceeds length limit");
+							}
+
+							sectionName.Append((char)cc);
+							cc = await ReadChar();
+						}
+
+						if (sectionName.Length == 0)
+						{
+							throw new FormatException("Expected section name after !BEGIN");
+						}
+
+						// We have found the name of the next section, and are
+						// ready to start reading the section's lines.
+						_inSection = true;
+						return sectionName.ToString();
+					}
+					else if (command.ToString() == "END")
+					{
+						if (!IsLinefeed((char)cc))
+						{
+							throw new FormatException("Expected linefeed after !END");
+						}
+
+						if (!_inSection)
+						{
+							throw new FormatException("Expected !BEGIN before !END");
+						}
+
+						// The current section is ended (so now '+' at the
+						// beginning of a line is a syntax error, not a line to
+						// be skipped). We are still looking for the beginning
+						// of the next section and its section name.
+						_inSection = false;
+					}
+					else
+					{
+						throw new FormatException("Expected BEGIN or END after !");
+					}
+				}
+				else if ((char)c == '+' && _inSection)
+				{
+					// We are looking for the next section, so skip over any
+					// lines in the current section.
+					while (true)
+					{
+						var cc = await ReadChar();
+						if (cc == -1)
+						{
+							throw new FormatException("Unexpected end of file");
+						}
+						else if (IsLinefeed((char)cc))
+						{
+							break;
+						}
+					}
+				}
+				else
+				{
+					if (!_inSection)
+					{
+						throw new FormatException("Expected !BEGIN");
+					}
+					else
+					{
+						throw new FormatException("Expected !END");
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// Parses ahead in the file to find the next in-section line, and
+		/// returns the line. Returns <c>null</c> if there are no more lines.
+		/// </summary>
+		/// <exception name="FormatException">There is a syntax error in the
+		/// file, or the line exceeds the length limit.</exception>
+		/// <exception name="InvalidOperationException">The method was called
+		/// while not in a section.</exception>
+		public async Task<string?> NextLine()
+		{
+			if (!_inSection)
+			{
+				throw new InvalidOperationException("Not in a section");
+			}
+
+			while (true)
+			{
+				var c = await ReadChar();
+				if (c == -1)
+				{
+					throw new FormatException("Unexpected end of file");
+				}
+				else if (IsLinefeed((char)c))
+				{
+					// Blank lines are ignored.
+				}
+				else if ((char)c == '+')
+				{
+					var line = new StringBuilder();
+					while (true)
+					{
+						var cc = await ReadChar();
+						if (cc == -1)
+						{
+							throw new FormatException("Unexpected end of file");
+						}
+						else if (IsLinefeed((char)cc))
+						{
+							break;
+						}
+
+						if (line.Length >= _lengthLimit)
+						{
+							throw new FormatException("Line exceeds length limit");
+						}
+
+						line.Append((char)cc);
+					}
+
+					return line.ToString();
+				}
+				else
+				{
+					// Whatever is here, it is not a line. Let NextSection check
+					// the syntax of whatever follows.
+					UnreadChar((char)c);
+					return null;
+				}
+			}
+		}
+
+		/*
+		 * https://tasvideos.org/EmulatorResources/JPC/JRSRFormat#LineComponentFormat
+		 * https://repo.or.cz/jpcrr.git/blob/6ab255ce10b2dd10b0ac3ab2e2be708e0b26eeaa:/org/jpc/Misc.java#l232
+		 *
+		 * Grammar for "component" format:
+		 *   component ::= (space* token)* space*
+		 *   token ::= plain | "(" paren ")"
+		 *   char  ::= "\" any | [^()\]
+		 *   plain ::= (char - space)+
+		 *   paren ::= (char | "(" paren ")")+
+		 *
+		 * The documentation says that component format "encodes a non-empty
+		 * array of non-empty strings," but the parsing algorithm given there
+		 * actually permits the array to be empty. The individual strings must
+		 * be non-empty.
+		 *
+		 * There are two ways of escaping characters that would otherwise
+		 * separate tokens: prefixing with a backslash or enclosing in
+		 * parentheses. Within a parentheses-escaped token, parentheses must be
+		 * balanced unless backslash-escaped. The outermost pair of parentheses
+		 * is discarded, but the parentheses inside are retained as part of the
+		 * token.
+		 *
+		 * In the context of a JRSR file, it is impossible for a line to
+		 * contain a linefeed character, because it would have terminated the
+		 * line. If we encounter a linefeed, we treat it as a normal token
+		 * character.
+		 */
+
+		/// <summary>
+		/// Returns an iterator over the tokens of of a line in "component"
+		/// format.
+		/// </summary>
+		/// <exception name="FormatException">The line has unbalanced
+		/// parentheses, or a terminating backslash.</exception>
+		public static IEnumerable<string> DecodeComponent(string line)
+		{
+			var token = new StringBuilder();
+			var escaped = false;
+			var depth = 0;
+			foreach (var c in line)
+			{
+				if (escaped)
+				{
+					token.Append(c);
+					escaped = false;
+				}
+				else if (IsSpace(c))
+				{
+					// There is an omission in the tasvideos.org documentation
+					// here, as of Revision 7. Space characters outside
+					// parentheses (depth == 0) end a token, but inside
+					// parentheses they are part of the token.
+					if (depth == 0)
+					{
+						if (token.Length > 0)
+						{
+							yield return token.ToString();
+							token.Clear();
+						}
+					}
+					else
+					{
+						token.Append(c);
+					}
+				}
+				else if (c == '(')
+				{
+					if (depth == 0)
+					{
+						// This left parenthesis terminates the current token
+						// and begins a new token.
+						if (token.Length > 0)
+						{
+							yield return token.ToString();
+							token.Clear();
+						}
+					}
+					else
+					{
+						// This left parenthesis is itself enclosed within
+						// parentheses and counts as part of the token.
+						token.Append(c);
+					}
+
+					depth = checked(depth + 1);
+				}
+				else if (c == ')')
+				{
+					if (depth == 0)
+					{
+						throw new FormatException("Unmatched ')'");
+					}
+					else if (depth == 1)
+					{
+						// This right parenthesis terminates the current token,
+						// which was begin by a left parenthesis.
+						if (token.Length > 0)
+						{
+							yield return token.ToString();
+							token.Clear();
+						}
+					}
+					else
+					{
+						// This right parenthesis is itself enclosed within
+						// parentheses and counts as part of the token.
+						token.Append(c);
+					}
+
+					depth = depth - 1;
+				}
+				else if (c == '\\')
+				{
+					escaped = true;
+				}
+				else
+				{
+					token.Append(c);
+				}
+			}
+
+			if (escaped)
+			{
+				throw new FormatException("'\\' at end of line");
+			}
+
+			if (depth != 0)
+			{
+				throw new FormatException("Unmatched '('");
+			}
+
+			if (token.Length > 0)
+			{
+				yield return token.ToString();
+				token.Clear();
+			}
 		}
 	}
 }

--- a/TASVideos.Parsers/Parsers/Jrsr.cs
+++ b/TASVideos.Parsers/Parsers/Jrsr.cs
@@ -181,7 +181,19 @@ namespace TASVideos.MovieParsers.Parsers
 									throw new FormatException($"Unknown {eventClass} parameter {tokens[2]}");
 								}
 							}
-							else if (!JrsrSectionParser.IsSpecialEventClass(eventClass))
+							else if (eventClass == "SAVESTATE")
+							{
+								// Just check the syntax.
+								if (tokens.Count != 4)
+								{
+									throw new FormatException($"Bad format for {eventClass} special event");
+								}
+							}
+							else if (JrsrSectionParser.IsSpecialEventClass(eventClass))
+							{
+								throw new FormatException($"Unknown special event class {eventClass}");
+							}
+							else
 							{
 								lastNonSpecialTimestamp = lastTimestamp;
 							}

--- a/tests/TASVideos.MovieParsers.Tests/JrsrSampleFiles/frames.jrsr
+++ b/tests/TASVideos.MovieParsers.Tests/JrsrSampleFiles/frames.jrsr
@@ -3,6 +3,7 @@ JRSR
 +RERECORDS 17984
 +INITIALTIME 1000000000000
 !BEGIN events
++0 OPTION RELATIVE
 +1231487685000 org.jpc.emulator.peripheral.Keyboard KEYEDGE 205
 +1231669883178 org.jpc.emulator.peripheral.Keyboard KEYEDGE 205
 !END

--- a/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
@@ -311,6 +311,14 @@ namespace TASVideos.MovieParsers.Tests
 +3333333400 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
 +-1 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
 ")]
+		// Unknown special event is an error.
+		[DataRow(
+@"JRSR
+!BEGIN header
+!BEGIN events
++0 SPECIAL foobar
+!END
+")]
 		public async Task EventTimestampsError(string contents)
 		{
 			var result = await ParseFromString(contents);

--- a/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
@@ -26,20 +26,6 @@ namespace TASVideos.MovieParsers.Tests
 		}
 
 		[TestMethod]
-		[DataRow(null, null)]
-		[DataRow("", null)]
-		[DataRow(" ", null)]
-		[DataRow("NoPlus", null)]
-		[DataRow("+NoNumber", null)]
-		[DataRow("+1", 1L)]
-		[DataRow("+196064706 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28", 196064706L)]
-		public void GetTime(string line, long? expected)
-		{
-			var actual = Jrsr.GetTime(line);
-			Assert.AreEqual(expected, actual);
-		}
-
-		[TestMethod]
 		public async Task EmptyFile()
 		{
 			var result = await _jrsrParser.Parse(Embedded("emptyfile.jrsr"));

--- a/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
@@ -135,6 +135,50 @@ namespace TASVideos.MovieParsers.Tests
 			return await new Jrsr().Parse(reader);
 		}
 
+		// It should be an error if RERECORDS appears more than once, even if
+		// some of the appearances do not parse correctly.
+		[TestMethod]
+		[DataRow(
+@"JRSR
+!BEGIN header
++RERECORDS 100
++RERECORDS 100
+!END
+")]
+		[DataRow(
+@"JRSR
+!BEGIN header
++RERECORDS
++RERECORDS 100
+!END
+")]
+		[DataRow(
+@"JRSR
+!BEGIN header
++RERECORDS 100
++RERECORDS
+!END
+")]
+		[DataRow(
+@"JRSR
+!BEGIN header
++RERECORDS -123
++RERECORDS 100
+!END
+")]
+		[DataRow(
+@"JRSR
+!BEGIN header
++RERECORDS 100
++RERECORDS -123
+!END
+")]
+		public async Task RerecordsMultiplicity(string contents)
+		{
+			var result = await ParseFromString(contents);
+			Assert.IsFalse(result.Success);
+		}
+
 		[TestMethod]
 		// No events section.
 		[DataRow(

--- a/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
@@ -232,6 +232,24 @@ namespace TASVideos.MovieParsers.Tests
 +1666666700 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
 !END
 ", 300)]
+		// Consecutive timestamps may be equal.
+		[DataRow(
+@"JRSR
+!BEGIN header
+!BEGIN events
++1666666700 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
++1666666700 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
+!END
+", 100)]
+		[DataRow(
+@"JRSR
+!BEGIN header
+!BEGIN events
++0 OPTION RELATIVE
++1666666700 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
++0 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
+!END
+", 100)]
 		public async Task EventTimestamps(string contents, int expected)
 		{
 			var result = await ParseFromString(contents);
@@ -274,6 +292,24 @@ namespace TASVideos.MovieParsers.Tests
 !BEGIN events
 +0 OPTION ERROR
 !END
+")]
+		// Timestamps must be nondecreasing.
+		[DataRow(
+@"JRSR
+!BEGIN header
+!BEGIN events
++3333333400 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
++3333333399 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
+")]
+		// Timestamps are supposed to be non-negative, but check for
+		// nondecreasing RELATIVE timestamps as well.
+		[DataRow(
+@"JRSR
+!BEGIN header
+!BEGIN events
++0 OPTION RELATIVE
++3333333400 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
++-1 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
 ")]
 		public async Task EventTimestampsError(string contents)
 		{

--- a/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
@@ -196,6 +196,17 @@ namespace TASVideos.MovieParsers.Tests
 		}
 
 		[TestMethod]
+		// More than one events section.
+		[DataRow(
+@"JRSR
+!BEGIN header
+!BEGIN events
++1666666700 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
+!END
+!BEGIN events
++1666666700 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
+!END
+")]
 		// Missing parameter to OPTION.
 		[DataRow(
 @"JRSR

--- a/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TASVideos.MovieParsers.Parsers;
@@ -6,6 +10,9 @@ using TASVideos.MovieParsers.Result;
 
 namespace TASVideos.MovieParsers.Tests
 {
+#pragma warning disable SA1117
+#pragma warning disable SA1137
+#pragma warning disable SA1515
 	[TestClass]
 	[TestCategory("JrsrParsers")]
 	public class JrsrTests : BaseParserTests
@@ -130,6 +137,469 @@ namespace TASVideos.MovieParsers.Tests
 			Assert.AreEqual(0, result.RerecordCount, "Rerecord count assumed to be 0");
 			AssertNoErrors(result);
 			Assert.AreEqual(1, result.Warnings.Count());
+		}
+
+		/// <summary>
+		/// Serializes the contents of a JRSR file into a flat array of strings.
+		/// Each section name is followed by that section's lines, then a null
+		/// element. The end of the final section is marked by an additional
+		/// null element.
+		/// </summary>
+		private async Task<string?[]> Serialize(Stream reader, int lengthLimit = 10000)
+		{
+			// We will serialize the JRSR structure into a flat list of strings,
+			// where each section name is followed by the section's lines, and
+			// sections and the whole document are terminated by null.
+			using var parser = await JrsrSectionParser.CreateAsync(reader, lengthLimit);
+			var serialized = new List<string?>();
+			while (await parser.NextSection() is string sectionName)
+			{
+				serialized.Add(sectionName);
+				while (await parser.NextLine() is string line)
+				{
+					serialized.Add(line);
+				}
+
+				serialized.Add(null);
+			}
+
+			serialized.Add(null);
+			return serialized.ToArray();
+		}
+
+		/// <summary>
+		/// Like <see cref="Serialize"/>, but reads the JRSR from a string,
+		/// which will be encoded to UTF-8 and wrapped in a <c>Stream</c>.
+		/// </summary>
+		private async Task<string?[]> SerializeFromString(string contents, int lengthLimit = 10000)
+		{
+			using var reader = new MemoryStream(new UTF8Encoding(false, true).GetBytes(contents));
+			return await Serialize(reader, lengthLimit);
+		}
+
+		[TestMethod]
+		// It's permitted to have zero sections.
+		[DataRow("JRSR\n", null)]
+		// Sections may be empty.
+		[DataRow(
+@"JRSR
+!BEGIN foo
+!END
+", "foo", null,
+   null)]
+		[DataRow(
+@"JRSR
+!BEGIN foo
+!END
+!BEGIN bar
+!END
+", "foo", null,
+   "bar", null,
+   null)]
+		// Uniqueness of section names is not checked a the JrsrSectionParser
+		// level.
+		[DataRow(
+@"JRSR
+!BEGIN foo
+!END
+!BEGIN bar
+!END
+!BEGIN foo
+!END
+", "foo", null,
+   "bar", null,
+   "foo", null,
+   null)]
+		// !END is optional for non-final sections.
+		[DataRow(
+@"JRSR
+!BEGIN foo
+!BEGIN bar
+!END
+", "foo", null,
+   "bar", null,
+   null)]
+		// Section names may contain spaces, including trailing spaces.
+		[DataRow(
+"JRSR\n" +
+"!BEGIN\x20section\x20name\x20\x20\n" +
+"!END\n" +
+"", "section\x20name\x20\x20", null,
+	null)]
+		// Non-ASCII section names and line contents.
+		[DataRow(
+"JRSR\n" +
+"!BEGIN section \u2603\n" +
+"+line \u2603\n" +
+"!BEGIN section \U0001f427\n" +
+"+line \U0001f427\n" +
+"!BEGIN section \u2800\n" +
+"+line \u2800\n" +
+"!BEGIN section \u2c00\n" +
+"+line \u2c00\n" +
+"!END\n" +
+"", "section \u2603", "line \u2603", null,
+	"section \U0001f427", "line \U0001f427", null,
+	"section \u2800", "line \u2800", null,
+	"section \u2c00", "line \u2c00", null,
+	null)]
+		// Blank lines are permitted anywhere after magic.
+		[DataRow(
+@"JRSR
+
+!BEGIN foo
+
++line 1
+
+
++line 2
+
+!END
+!BEGIN bar
++line 1
+!END
+
+
+", "foo", "line 1", "line 2", null,
+   "bar", "line 1", null,
+   null)]
+		// All space and linefeed characters.
+		[DataRow(
+"JRSR\u000a" +
+"!BEGIN\u0009\u000c\u0020foo\u000d" +
+"+line\u1680\u180e1\u2028\u205f\u001c" +
+"+line\u3000\u20002\u2001\u2002\u001d" +
+"+line\u2003\u20043\u2005\u2006\u001e" +
+"+line\u2007\u20084\u2009\u200a\u0085" +
+"!END\u2029" +
+"", "foo",
+		"line\u1680\u180e1\u2028\u205f",
+		"line\u3000\u20002\u2001\u2002",
+		"line\u2003\u20043\u2005\u2006",
+		"line\u2007\u20084\u2009\u200a",
+		null,
+	null)]
+		// Lines may contain section delimiters.
+		[DataRow(
+@"JRSR
+!BEGIN foo
++!BEGIN bar
++!END
+!END
+", "foo", "!BEGIN bar", "!END", null,
+   null)]
+		// Lines may have leading and trailing whitespace.
+		[DataRow(
+"JRSR\n" +
+"!BEGIN foo\n" +
+"+\x20\x20hello\x20world\x20\x20\n" +
+"!END\n" +
+"", "foo", "\x20\x20hello\x20world\x20\x20", null,
+	null)]
+		// Section names that differ in case or Unicode normalization are
+		// considered distinct.
+		[DataRow(
+"JRSR\n" +
+"!BEGIN section\n" +
+"!BEGIN Section\n" +
+"!BEGIN SECTION\n" +
+"!BEGIN \u00e9tude\n" +
+"!BEGIN e\u0301tude\n" +
+"!END\n" +
+"", "section", null,
+	"Section", null,
+	"SECTION", null,
+	"\u00e9tude", null,
+	"e\u0301tude", null,
+	null)]
+		public async Task ParserGood(string contents, params string?[] expected)
+		{
+			CollectionAssert.AreEqual(expected, await SerializeFromString(contents));
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(FormatException))]
+		// Missing magic.
+		[DataRow("")]
+		[DataRow(
+@"!BEGIN foo
+!END
+")]
+		// No whitespace permitted before magic.
+		[DataRow(
+@"
+JRSR
+!BEGIN foo
+!END
+")]
+		[DataRow(
+@" JRSR
+!BEGIN foo
+!END
+")]
+		// No BOM permitted before magic.
+		[DataRow(
+"\ufeffJRSR\n" +
+"!BEGIN foo\n" +
+"!END\n" +
+"")]
+		// Need whitespace after !BEGIN.
+		[DataRow(
+@"JRSR
+!BEGIN")]
+		// Need a section name after !BEGIN.
+		[DataRow(
+@"JRSR
+!BEGIN ")]
+		[DataRow(
+"JRSR\n" +
+"!BEGIN \n" +
+"")]
+		// Need a linefeed after section name
+		[DataRow(
+@"JRSR
+!BEGIN foo")]
+		// Need !END after the final !BEGIN.
+		[DataRow(
+@"JRSR
+!BEGIN foo
+")]
+		[DataRow(
+@"JRSR
+!BEGIN foo
+!END
+!BEGIN bar
+")]
+		// Need linefeed after !END.
+		[DataRow(
+@"JRSR
+!BEGIN foo
+!END ")]
+		[DataRow(
+"JRSR\n" +
+"!BEGIN foo\n" +
+"!END \n" +
+"")]
+		[DataRow(
+@"JRSR
+!BEGIN foo
+!END foo
+")]
+		// Need !BEGIN before !END.
+		[DataRow(
+@"JRSR
+!END
+")]
+		// Expect BEGIN or END after !.
+		[DataRow(
+@"JRSR
+!ERROR
+")]
+		[DataRow(
+@"JRSR
+!BEGIN foo
+!ERROR
+!END
+")]
+		// Lines must be in a section.
+		[DataRow(
+@"JRSR
++line
+!BEGIN foo
+!END
+")]
+		[DataRow(
+@"JRSR
+!BEGIN foo
+!END
++line
+")]
+		public async Task ParserFormatException(string contents)
+		{
+			await SerializeFromString(contents);
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(FormatException))]
+		public async Task ParserDecoderUTF16()
+		{
+			// Input not encoded as UTF-8 should be an error.
+			var contents = @"JRSR
+!BEGIN foo
++line
+!END
+";
+			using var reader = new MemoryStream(Encoding.Unicode.GetBytes(contents));
+			await Serialize(reader);
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(FormatException))]
+		public async Task ParserDecoderUTF8Error()
+		{
+			// Input with UTF-8 encoding errors should be an error. We must
+			// paste the input together ourselves because
+			// System.Text.UTF8Encoding refuses to encode surrogates.
+			var enc = new UTF8Encoding(false, true);
+			var contents = enc.GetBytes("JRSR\n!BEGIN foo\n+")
+				.Concat(new byte[] { 0xed, 0xa0, 0x80 }) // UTF-8 encoding of the surrogate '\ud800'
+				.Concat(enc.GetBytes("\n!END\n"))
+				.ToArray();
+			using var reader = new MemoryStream(contents);
+			await Serialize(reader);
+		}
+
+		[TestMethod]
+		public async Task ParserDecoderNavigation()
+		{
+			var contents =
+@"JRSR
+!BEGIN section 1
++line 1.1
++line 1.2
++line 1.3
++line 1.4
++line 1.5
+!END
+!BEGIN section 2
++line 2.1
+!END
+";
+			using var reader = new MemoryStream(new UTF8Encoding(false, true).GetBytes(contents));
+			using var parser = await JrsrSectionParser.CreateAsync(reader, 10000);
+
+			// Cannot call NextLine before the first section.
+			await Assert.ThrowsExceptionAsync<InvalidOperationException>(parser.NextLine);
+
+			Assert.AreEqual("section 1", await parser.NextSection());
+			Assert.AreEqual("line 1.1", await parser.NextLine());
+			Assert.AreEqual("line 1.2", await parser.NextLine());
+
+			// Should skip over the remaining lines in section 1.
+			Assert.AreEqual("section 2", await parser.NextSection());
+			Assert.AreEqual("line 2.1", await parser.NextLine());
+			Assert.IsNull(await parser.NextLine());
+
+			// The result of NextLine should remain null.
+			Assert.IsNull(await parser.NextLine());
+
+			Assert.IsNull(await parser.NextSection());
+
+			// Cannot call NextLine after the final section.
+			await Assert.ThrowsExceptionAsync<InvalidOperationException>(parser.NextLine);
+
+			// The result of NextSection should remain null.
+			Assert.IsNull(await parser.NextSection());
+		}
+
+		[TestMethod]
+		public async Task ParserDecoderLengthLimit()
+		{
+			{
+				var contents =
+@"JRSR
+!BEGIN a
++1
+!BEGIN b
++2
+!END
+";
+				var expected = new[]
+				{
+					"a", "1", null,
+					"b", "2", null,
+					null,
+				};
+				await Assert.ThrowsExceptionAsync<FormatException>(() => SerializeFromString(contents, -1));
+				await Assert.ThrowsExceptionAsync<FormatException>(() => SerializeFromString(contents, 0));
+				CollectionAssert.AreEqual(expected, await SerializeFromString(contents, 1));
+				CollectionAssert.AreEqual(expected, await SerializeFromString(contents, 2));
+			}
+
+			{
+				var contents =
+@"JRSR
+!BEGIN a
++1
++11
++111
++1111
++11111
+!END
+";
+				var expected = new[]
+				{
+					"a", "1", "11", "111", "1111", "11111", null,
+					null,
+				};
+				await Assert.ThrowsExceptionAsync<FormatException>(() => SerializeFromString(contents, 4));
+				CollectionAssert.AreEqual(expected, await SerializeFromString(contents, 5));
+			}
+
+			{
+				var contents =
+@"JRSR
+!BEGIN a
+!BEGIN aa
+!BEGIN aaa
+!BEGIN aaaa
+!BEGIN aaaaa
+!END
+";
+				var expected = new[]
+				{
+					"a", null,
+					"aa", null,
+					"aaa", null,
+					"aaaa", null,
+					"aaaaa", null,
+					null,
+				};
+				await Assert.ThrowsExceptionAsync<FormatException>(() => SerializeFromString(contents, 4));
+				CollectionAssert.AreEqual(expected, await SerializeFromString(contents, 5));
+			}
+		}
+
+		[TestMethod]
+		[DataRow("")]
+		[DataRow("\u0009\u0020\u1680\u180e\u2028\u205f\u3000\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a")]
+		[DataRow("foo", "foo")]
+		[DataRow("foo\\\\", "foo\\")]
+		[DataRow("foo\U0001f427bar", "foo\U0001f427bar")]
+		[DataRow("foo\\\U0001f427bar", "foo\U0001f427bar")]
+		[DataRow("foo\ud800bar", "foo\ud800bar")]
+		[DataRow("foo\\\ud800bar", "foo\ud800bar")]
+		[DataRow("foo\udc00bar", "foo\udc00bar")]
+		[DataRow("foo\\\udc00bar", "foo\udc00bar")]
+		[DataRow("() ()() (()) (()())", "()", "()()")]
+		[DataRow("(hello(\\(world))((hello\\))world)", "hello((world)", "(hello))world")]
+		[DataRow("hello\\ world", "hello world")]
+		[DataRow("hello\\\u3000world", "hello\u3000world")]
+		[DataRow("hello\\\\world", "hello\\world")]
+		[DataRow("DISKNAME 0(FreeDOS (initial fda disk))", "DISKNAME", "0", "FreeDOS (initial fda disk)")]
+		[DataRow("COMMENT(Entry: 19900101000000 10ac35dd6bc6314cd5caf08a4ffb4275      76586 /DAVE.EXE)", "COMMENT", "Entry: 19900101000000 10ac35dd6bc6314cd5caf08a4ffb4275      76586 /DAVE.EXE")]
+		// The following contain linefeeds and cannot actually appear in the
+		// context of a JRSR file.
+		[DataRow("hello\\\u000aworld", "hello\u000aworld")]
+		[DataRow("hello\u000aworld", "hello\u000aworld")]
+		public void DecodeComponentGood(string line, params string[] expected)
+		{
+			CollectionAssert.AreEqual(expected, JrsrSectionParser.DecodeComponent(line).ToList());
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(FormatException))]
+		// Unmatched '('.
+		[DataRow("(foo")]
+		[DataRow("(foo(bar)baz")]
+		// Unmatched ')'.
+		[DataRow("foo)")]
+		[DataRow("foo(bar)baz)")]
+		// Backslash at end of string.
+		[DataRow("foo\\")]
+		public void DecodeComponentFormatException(string line)
+		{
+			JrsrSectionParser.DecodeComponent(line).ToList();
 		}
 	}
 }

--- a/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
@@ -149,6 +149,16 @@ namespace TASVideos.MovieParsers.Tests
 !BEGIN events
 !END
 ", 0)]
+		// Special events should not count towards frame count.
+		[DataRow(
+@"JRSR
+!BEGIN header
+!BEGIN events
++0 OPTION ABSOLUTE
++1666666700 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
++3333333400 SAVESTATE aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0
+!END
+", 100)]
 		// Timestamps are absolute by default.
 		[DataRow(
 @"JRSR
@@ -677,6 +687,19 @@ JRSR
 		public void DecodeComponentFormatException(string line)
 		{
 			JrsrSectionParser.DecodeComponent(line).ToList();
+		}
+
+		[TestMethod]
+		[DataRow("", false)]
+		[DataRow("OPTION", true)]
+		[DataRow("SAVESTATE", true)]
+		[DataRow("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", true)]
+		[DataRow("org.jpc.emulator.peripheral.Keyboard", false)]
+		[DataRow("OPTION SAVESTATE", false)]
+		[DataRow("OPTIO\u0418", false)] // Capital letter but not ASCII.
+		public void IsSpecialEventClass(string eventClass, bool expected)
+		{
+			Assert.AreEqual(expected, JrsrSectionParser.IsSpecialEventClass(eventClass));
 		}
 	}
 }


### PR DESCRIPTION
Fixes #889, fixes #890, fixes #1061.

This parser implements more of the [JRSR documentation](https://tasvideos.org/EmulatorResources/JPC/JRSRFormat) at tasvideos.org, for example in understanding all of the permissible delimiter characters and ways that strings can be escaped, while also being more careful about error checking. It is based on one I wrote in Python for my [Arduino-based verification project](https://tasvideos.org/Forum/Topics/22864). The parser does not load the entire file into memory before parsing, so it is safer to run on large or untrusted files.

I think of JRSR as basically a container format. It stores a list of named sections, which each contain a list of lines. In most sections, each line is further divided into a list of tokens. Take this JRSR file for example:

```
JRSR
!BEGIN header
+RERECORDS 100
+AUTHORS(Author 1)Author\ 2
!BEGIN initialization
+INITIALTIME 1000000000000
+CPUDIVIDER 50
+MEMORYSIZE 4096
!BEGIN events
+0 OPTION RELATIVE
+0 SAVESTATE 9fc3745cb3973e276b3baac6e0f52989737c75dd529b596f 0
+91799082 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
+666660 org.jpc.emulator.peripheral.Keyboard KEYEDGE 28
!END
```

In a more familiar format like JSON, the file structurally represents:

```
{
    "header": [
        ["RERECORDS", "100"],
        ["AUTHORS", "Author 1", "Author 2"]
    ],
    "initialization": [
        ["INITIALTIME", "1000000000000"],
        ["CPUDIVIDER", "50"],
        ["MEMORYSIZE", "4096"]
    ],
    "events": [
        ["0", "OPTION", "RELATIVE"],
        ["0", "SAVESTATE", "9fc3745cb3973e276b3baac6e0f52989737c75dd529b596f", "0"],
        ["91799082", "org.jpc.emulator.peripheral.Keyboard", "KEYEDGE", "28"],
        ["666660", "org.jpc.emulator.peripheral.Keyboard", "KEYEDGE", "28"]
    ]
}
```

On top of this "structural" layer there is another "semantic" layer that ascribes meaning to the elements of the container, such as that `header.RERECORDS` must appear once, and that lines in the `events` section must begin with an integer timestamp token.

This sequence of commits does the following:

* Adds an internal class `JrsrSectionParser` for low-level structural parsing. The class has `NextSection`, `NextLine`, and `DecodeComponent` methods, but it does not do any interpretation of the contents of sections and lines.
* Rewrites the existing `Jrsr` parser to be in terms of `JrsrSectionParser` (incidentally fixes #889).
* Implements semantic features:
  * `RELATIVE` versus `ABSOLUTE` event timestamps (#890).
  * "Special" events not counting towards movie length (#1061).
* Enforces certain semantic constraints:
  * Section names may appear only once.
  * Some lines may appear only once.
  * Event timestamps must not decrease.
* Makes the parser stricter about error checking:
  * Raise an error for unknown "special" events instead of ignoring them.
  * Restrict the forms of integers that are allowed (like #850).
  * Check for arithmetic overflow (e.g. in timestamps).
  * Check for the correct number of tokens per line.

In adding additional error checks, I referred to the JPC-RR source code to try and ensure that the checks were not more restrictive than what JPC-RR allows. The important files are [JrsrArchiveReader.java](https://repo.or.cz/jpcrr.git/blob/6ab255ce10b2dd10b0ac3ab2e2be708e0b26eeaa:/org/jpc/jrsr/JRSRArchiveReader.java), [Misc.java](https://repo.or.cz/jpcrr.git/blob/6ab255ce10b2dd10b0ac3ab2e2be708e0b26eeaa:/org/jpc/Misc.java), [UTFInputLineStream.java](https://repo.or.cz/jpcrr.git/blob/6ab255ce10b2dd10b0ac3ab2e2be708e0b26eeaa:/org/jpc/jrsr/UTFInputLineStream.java), [PC.java](https://repo.or.cz/jpcrr.git/blob/6ab255ce10b2dd10b0ac3ab2e2be708e0b26eeaa:/org/jpc/emulator/PC.java), and [EventRecorder.java](https://repo.or.cz/jpcrr.git/blob/6ab255ce10b2dd10b0ac3ab2e2be708e0b26eeaa:/org/jpc/emulator/EventRecorder.java). For example, there was an existing test for a negative `RERECORDS` count, that it should result in a warning. I made it into an error, because [JPC-RR would treat it as an error](https://repo.or.cz/jpcrr.git/blob/6ab255ce10b2dd10b0ac3ab2e2be708e0b26eeaa:/org/jpc/emulator/PC.java#l1916).

I haven't programmed in C# before. Here are some points I was not sure about:

* `JrsrSectionParser` needs to read one char at a time and sometimes to put back a char it has already read. At first, I wrote the class using [`StreamReader.Read`](https://docs.microsoft.com/en-us/dotnet/api/system.io.streamreader.read?view=net-6.0#system-io-streamreader-read) and [`StreamReader.Peek`](https://docs.microsoft.com/en-us/dotnet/api/system.io.streamreader.peek?view=net-6.0#system-io-streamreader-peek). Then I saw that [parsers are supposed to be async](https://github.com/TASVideos/tasvideos/commit/acb04d99ae4d26982e4ee48a7240faab836da5cd), but I did not find any async equivalents of `Read` and `Peek`. So I added private [`ReadChar` and `UnreadChar` methods](https://github.com/TASVideos/tasvideos/commit/acb04d99ae4d26982e4ee48a7240faab836da5cd) that use 1-char buffers.
* In reading one char at a time, I'm relying on [`FileStream`](https://docs.microsoft.com/en-us/dotnet/api/system.io.filestream?view=net-6.0) (or whatever the underlying stream is) having some kind of buffering, for efficiency. The documentation says "`FileStream` buffers input and output for better performance," but I don't know if what I'm doing is sufficient.
* I used pragmas to [disable some style checks](https://github.com/SandTAS/tasvideos/blob/de673b9aff69dc10bd08e2c93bc3b071d4e3cfe5/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs#L13-L15) in the test class:
  * [SA1117ParametersMustBeOnSameLineOrSeparateLines](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/ae7faa74d662976d0de08c9df593f175fc7c9a84/documentation/SA1117.md)
  * [SA1137ElementsShouldHaveTheSameIndentation](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1137.md)
  * [SA1515SingleLineCommentMustBePrecededByBlankLine](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1515.md)

  This is because I added a lot of table-driven tests, where the line breaks and indentation are suggestive of the expected structure, and test cases are often preceded by an explanatory comment. For example, I have tests like this:

  ```
           [TestMethod]
           // Sections may be empty.
           [DataRow(
   @"JRSR
   !BEGIN foo
   !END
   !BEGIN bar
   !END
   ", "foo", null,
      "bar", null,
      null)]
           // Lines may contain section delimiters.
           [DataRow(
   @"JRSR
   !BEGIN foo
   +!BEGIN bar
   +!END
   !END
   ", "foo", "!BEGIN bar", "!END", null,
      null)]
           public async Task TestCase(string contents, params string?[] expected)
   ```

   To conform with the style requirements, it would have to be written in a way that I find less informative:

   ```
           [TestMethod]

           // Sections may be empty.
           [DataRow(
   @"JRSR
   !BEGIN foo
   !END
   !BEGIN bar
   !END
   ",
   "foo",
   null,
   "bar",
   null,
   null)]

           // Lines may contain section delimiters.
           [DataRow(
   @"JRSR
   !BEGIN foo
   +!BEGIN bar
   +!END
   !END
   ",
   "foo",
   "!BEGIN bar",
   "!END",
   null,
   null)]
           public async Task TestCase(string contents, params string?[] expected)
   ```
* I tried adding documentation comments, but I don't know how to actually view them to see that they are formatted correctly.
