### PR TITLE
Wiki engine - Use .AsSpan in some places

### DIFF
--- a/TASVideos.Parsers/Parsers/Jrsr.cs
+++ b/TASVideos.Parsers/Parsers/Jrsr.cs
@@ -410,37 +410,34 @@ internal class JrsrSectionParser : IDisposable
 	/// </summary>
 	private static bool IsSpace(char c)
 	{
-		switch (c)
+		return c switch
 		{
 			// https://tasvideos.org/EmulatorResources/JPC/JRSRFormat#Spaces
 			// https://repo.or.cz/jpcrr.git/blob/6ab255ce10b2dd10b0ac3ab2e2be708e0b26eeaa:/org/jpc/Misc.java#l100
 			// The tasvideos.org documentation, as of Revision 7, is
 			// missing one character from the reference implementation,
 			// "\u000c" == "\f" == form feed.
-			case '\u0009':
-			case '\u000c':
-			case '\u0020':
-			case '\u1680':
-			case '\u180e':
-			case '\u2028':
-			case '\u205f':
-			case '\u3000':
-			case '\u2000':
-			case '\u2001':
-			case '\u2002':
-			case '\u2003':
-			case '\u2004':
-			case '\u2005':
-			case '\u2006':
-			case '\u2007':
-			case '\u2008':
-			case '\u2009':
-			case '\u200a':
-				return true;
-
-			default:
-				return false;
-		}
+			'\u0009' => true,
+			'\u000c' => true,
+			'\u0020' => true,
+			'\u1680' => true,
+			'\u180e' => true,
+			'\u2028' => true,
+			'\u205f' => true,
+			'\u3000' => true,
+			'\u2000' => true,
+			'\u2001' => true,
+			'\u2002' => true,
+			'\u2003' => true,
+			'\u2004' => true,
+			'\u2005' => true,
+			'\u2006' => true,
+			'\u2007' => true,
+			'\u2008' => true,
+			'\u2009' => true,
+			'\u200a' => true,
+			_ => false
+		};
 	}
 
 	/// <summary>
@@ -449,22 +446,19 @@ internal class JrsrSectionParser : IDisposable
 	/// </summary>
 	private static bool IsLinefeed(char c)
 	{
-		switch (c)
+		return c switch
 		{
 			// https://tasvideos.org/EmulatorResources/JPC/JRSRFormat#LineFeeds
 			// https://repo.or.cz/jpcrr.git/blob/6ab255ce10b2dd10b0ac3ab2e2be708e0b26eeaa:/org/jpc/jrsr/UTFInputLineStream.java#l194
-			case '\u000a':
-			case '\u000d':
-			case '\u001c':
-			case '\u001d':
-			case '\u001e':
-			case '\u0085':
-			case '\u2029':
-				return true;
-
-			default:
-				return false;
-		}
+			'\u000a' => true,
+			'\u000d' => true,
+			'\u001c' => true,
+			'\u001d' => true,
+			'\u001e' => true,
+			'\u0085' => true,
+			'\u2029' => true,
+			_ => false
+		};
 	}
 
 	/// <summary>
@@ -806,7 +800,7 @@ internal class JrsrSectionParser : IDisposable
 					token.Append(c);
 				}
 
-				depth = depth - 1;
+				depth -= 1;
 			}
 			else if (c == '\\')
 			{

--- a/TASVideos.WikiEngine/MakeBracketed.cs
+++ b/TASVideos.WikiEngine/MakeBracketed.cs
@@ -114,7 +114,7 @@ public static partial class Builtins
 	{
 		if (text[0] == '=')
 		{
-			return "/" + text.Substring(text[1] == '/' ? 2 : 1);
+			return string.Concat("/", text.AsSpan(text[1] == '/' ? 2 : 1));
 		}
 
 		return text;
@@ -129,7 +129,7 @@ public static partial class Builtins
 				return "/";
 			}
 
-			return NormalizeInternalLink("/" + text.Substring(text[1] == '/' ? 2 : 1));
+			return NormalizeInternalLink(string.Concat("/", text.AsSpan(text[1] == '/' ? 2 : 1)));
 		}
 
 		if (text.StartsWith("user:"))
@@ -265,8 +265,10 @@ public static partial class Builtins
 
 	private static INode MakeImage(int charStart, int charEnd, string[] pp, int index)
 	{
-		var attrs = new List<KeyValuePair<string, string>>();
-		attrs.Add(Attr("src", NormalizeImageUrl(pp[index++])));
+		var attrs = new List<KeyValuePair<string, string>>
+		{
+			Attr("src", NormalizeImageUrl(pp[index++]))
+		};
 		StringBuilder classString = new("embed");
 		for (; index < pp.Length; index++)
 		{

--- a/TASVideos.WikiEngine/MakeErrorPage.cs
+++ b/TASVideos.WikiEngine/MakeErrorPage.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using TASVideos.WikiEngine.AST;
+using System;
 
 namespace TASVideos.WikiEngine;
 
@@ -13,7 +14,7 @@ public static partial class Builtins
 	/// <returns>Human-readable document showing the markup and the error.</returns>
 	public static List<INode> MakeErrorPage(string content, NewParser.SyntaxException e)
 	{
-		INode ClassedText(int at, string content, string? clazz = null)
+		static INode ClassedText(int at, string content, string? clazz = null)
 		{
 			var ret = new Element(at, "span");
 			if (clazz != null)
@@ -54,7 +55,7 @@ public static partial class Builtins
 					Attributes = { ["class"] = "error-marker" }
 				};
 				elt.Children.Add(marker);
-				elt.Children.Add(ClassedText(charAt, line.Substring(column) + '\n'));
+				elt.Children.Add(ClassedText(charAt, string.Concat(line.AsSpan(column), "\n")));
 			}
 			else
 			{

--- a/TASVideos.WikiEngine/NewParser.cs
+++ b/TASVideos.WikiEngine/NewParser.cs
@@ -971,7 +971,7 @@ public class NewParser
 
 	private static void AddIdsToHeadings(IEnumerable<INode> n)
 	{
-		IEnumerable<string> GeneratePossibleIds(IList<string> words)
+		static IEnumerable<string> GeneratePossibleIds(IList<string> words)
 		{
 			if (words.Count > 0 && (words[0] == "The" || words[0] == "A"))
 			{


### PR DESCRIPTION
With .NET 6 and Visual Studio 2022 I was getting these .AsSpan refactors that look like they would be overall more performant, at least with memory churn.  There were a few other inconsequential cleanups in there too