### PR TITLE
Ability to remove someone's claim to a submission

### DIFF
--- a/TASVideos.Data/Entity/PermissionTo.cs
+++ b/TASVideos.Data/Entity/PermissionTo.cs
@@ -118,6 +118,10 @@ public enum PermissionTo
 	[Description("The ability to deprecate an existing movie parser. When deprecated, a movie will no longer be eligible for submission")]
 	DeprecateMovieParsers = 205,
 
+	[Group("Queue Maintenance")]
+	[Description("The ability to remove another's claim on a submission (either for judging or publishing)")]
+	RemoveQueueClaim = 206,
+
 	#endregion
 
 	#region Publication Maintenance 300

--- a/TASVideos/Pages/Submissions/View.cshtml
+++ b/TASVideos/Pages/Submissions/View.cshtml
@@ -22,6 +22,10 @@
 	bool canClaimAsPublisher = ViewData.UserHas(PermissionTo.PublishMovies)
 		&& ViewData.UserHas(PermissionTo.EditSubmissions)
 		&& Model.Submission.Status == SubmissionStatus.Accepted;
+
+	bool canRemoveClaim = ViewData.UserHas(PermissionTo.RemoveQueueClaim)
+		&& (Model.Submission.Status is SubmissionStatus.JudgingUnderWay or SubmissionStatus.PublicationUnderway);
+
 	string youtubeEmbedImage = "";
 	if (Model.Submission.EncodeEmbedLink is not null)
 	{
@@ -179,6 +183,7 @@
 		<div class="btn-toolbar">
 			<a condition="@canClaimAsJudge" asp-page="Edit" asp-route-id="@Model.Id" asp-page-handler="ClaimForJudging" class="btn btn-success mt-2 me-1">Claim</a>
 			<a condition="@canClaimAsPublisher" asp-page="Edit" asp-route-id="@Model.Id" asp-page-handler="ClaimForPublishing" class="btn btn-success mt-2 me-1">Claim</a>
+			<a condition="@canRemoveClaim" asp-page="Edit" asp-route-id="@Model.Id" asp-page-handler="RemoveClaim" class="btn btn-warning mt-2 me-1">Remove Claim</a>
 			<a asp-page="View" asp-page-handler="Download" asp-route-id="@Model.Id" class="btn btn-primary mt-2"><i class="fa fa-download"></i> Download</a>
 			<a condition="@Model.Submission.TopicId > 0" asp-page="/Forum/Topics/Index" asp-route-id="@Model.Submission.TopicId" class="btn btn-secondary ms-1 mt-2"><i class="fa fa-comments-o"></i> Discuss and Vote</a>
 			<span permission="EditSubmissions" class="btn-separator mt-2"></span>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1679846/151865644-7137bb93-e247-4c56-b235-ad77d3997902.png)

Adds a new permission: RemoveQueueClaim
If a user has it, and they view a submission that is Judging Underway to Publication Underway, they will see a Remove Claim button that will reset the status, remove the judge or publish, and add a status message.

![image](https://user-images.githubusercontent.com/1679846/151865857-7196a8d8-ab77-4e98-b8fc-86d2ac40e8df.png)
