### PR TITLE
Remove Tech Ratings (Round 1)

### DIFF
--- a/TASVideos.Core/Dtos/RatingDto.cs
+++ b/TASVideos.Core/Dtos/RatingDto.cs
@@ -1,10 +1,3 @@
 ﻿namespace TASVideos.Core.Services;
 
-public class RatingDto
-{
-	public double? Overall { get; set; }
-	public double? Entertainment { get; init; }
-	public double? TechQuality { get; init; }
-	public int TotalEntertainmentVotes { get; init; }
-	public int TotalTechQualityVotes { get; init; }
-}
+public record RatingDto(double? Overall, int TotalVotes);

--- a/TASVideos.Core/Dtos/UserRatings.cs
+++ b/TASVideos.Core/Dtos/UserRatings.cs
@@ -16,9 +16,6 @@ public class UserRatings
 		public int PublicationId { get; init; }
 		public string PublicationTitle { get; init; } = "";
 		public bool IsObsolete { get; init; }
-		public double? Entertainment { get; init; }
-		public double Tech { get; init; }
-
-		public double Average => ((Entertainment ?? 0) + (Entertainment ?? 0) + Tech) / 3.0;
+		public double Value { get; init; }
 	}
 }

--- a/TASVideos.Core/Services/PointsService/PointsService.cs
+++ b/TASVideos.Core/Services/PointsService/PointsService.cs
@@ -146,33 +146,11 @@ internal class PointsService : IPointsService
 			.Select(r => r.Value)
 			.ToList();
 
-		var techRatings = ratings
-			.Where(r => r.Type == PublicationRatingType.TechQuality)
-			.Select(r => r.Value)
-			.ToList();
-
-		var rating = new RatingDto
-		{
-			Entertainment = entRatings.Any()
+		return new RatingDto(
+			entRatings.Any()
 				? entRatings.Average()
 				: null,
-			TechQuality = techRatings.Any()
-				? techRatings.Average()
-				: null,
-			TotalEntertainmentVotes = entRatings.Count,
-			TotalTechQualityVotes = techRatings.Count
-		};
-
-		if (entRatings.Any() || techRatings.Any())
-		{
-			// Entertainment counts 2:1 over Tech
-			rating.Overall = entRatings
-				.Concat(entRatings)
-				.Concat(techRatings)
-				.Average();
-		}
-
-		return rating;
+			entRatings.Count);
 	}
 
 	// total ratings / (2 * total publications)
@@ -188,8 +166,7 @@ internal class PointsService : IPointsService
 		double avg = 0;
 		if (totalPublications > 0)
 		{
-			var totalRatings = await _db.PublicationRatings.CountAsync();
-			avg = totalRatings / (double)(2 * totalPublications);
+			avg = await _db.PublicationRatings.CountAsync();
 		}
 
 		_cache.Set(AverageNumberOfRatingsKey, avg);

--- a/TASVideos.Core/Services/UserManager.cs
+++ b/TASVideos.Core/Services/UserManager.cs
@@ -129,31 +129,13 @@ public class UserManager : UserManager<User>
 
 		model.Ratings = await _db.PublicationRatings
 			.ForUser(model.Id)
-			.GroupBy(
-				gkey => new
-				{
-					gkey.PublicationId,
-					gkey.Publication!.Title,
-					gkey.Publication.ObsoletedById
-				},
-				gvalue => new
-				{
-					gvalue.Type,
-					gvalue.Value
-				})
+			.Where(pr => pr.Type == PublicationRatingType.Entertainment)
 			.Select(pr => new UserRatings.Rating
 			{
-				PublicationId = pr.Key.PublicationId,
-				PublicationTitle = pr.Key.Title,
-				IsObsolete = pr.Key.ObsoletedById.HasValue,
-				Entertainment = pr
-					.Where(a => a.Type == PublicationRatingType.Entertainment)
-					.Select(a => a.Value)
-					.Sum(),
-				Tech = pr
-					.Where(a => a.Type == PublicationRatingType.TechQuality)
-					.Select(a => a.Value)
-					.Sum()
+				PublicationId = pr.PublicationId,
+				PublicationTitle = pr.Publication!.Title,
+				IsObsolete = pr.Publication.ObsoletedById.HasValue,
+				Value = pr.Value
 			})
 			.ToListAsync();
 

--- a/TASVideos.sln.DotSettings
+++ b/TASVideos.sln.DotSettings
@@ -216,6 +216,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=supercedes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=tabset/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tasvideos/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=textbox/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Timeable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=tkey/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tocs/@EntryIndexedValue">True</s:Boolean>

--- a/TASVideos/Pages/Publications/Models/PublicationRateModel.cs
+++ b/TASVideos/Pages/Publications/Models/PublicationRateModel.cs
@@ -47,14 +47,9 @@ public class PublicationRateModel
 
 	public string Title { get; set; } = "";
 
-	[Display(Name = "Technical Rating")]
-	[RatingString(ErrorMessage = "{0} must be between 0 and 10.")]
-	public string? TechRating { get; set; }
-
-	[Display(Name = "Entertainment Rating")]
+	[Display(Name = "Rating")]
 	[RatingString(ErrorMessage = "{0} must be between 0 and 10.")]
 	public string? EntertainmentRating { get; set; }
 
-	public bool TechUnrated { get; set; }
 	public bool EntertainmentUnrated { get; set; }
 }

--- a/TASVideos/Pages/Publications/Rate.cshtml
+++ b/TASVideos/Pages/Publications/Rate.cshtml
@@ -18,43 +18,48 @@
 				<input asp-for="Rating.EntertainmentRating" type="number" class="form-control fs-4 d-inline-block" style="width:4em;" min="0" max="10" value="@Model.Rating.EntertainmentRating" step="0.1" />
 				<input id="entertainmentSlider" type="range" class="form-range mw-100 h-auto" style="width:15rem;" min="0" max="10" value="@Model.Rating.EntertainmentRating" step="0.1" />
 			</form-group>
-			<form-group>
-				<span class="fs-4">@Html.DisplayNameFor(m => m.Rating.TechRating)</span>
-				<span class="text-nowrap">
-					( <input asp-for="Rating.TechUnrated" />
-					<label asp-for="Rating.TechUnrated">Unrated</label> )
-				</span>
-				<br />
-				<input asp-for="Rating.TechRating" type="number" class="form-control fs-4 d-inline-block" style="width:4em;" min="0" max="10" value="@Model.Rating.TechRating" step="0.1" />
-				<input id="techSlider" type="range" class="form-range mw-100 h-auto" style="width:15rem;" min="0" max="10" value="@Model.Rating.TechRating" step="0.1" />
-			</form-group>
 		</div>
 		<script>
-			function ratingConnect(checkbox, textbox, slider)
-			{
+			function disableSubmit() {
+				const btn = document.getElementById("submit-btn");
+				btn.classList.add("disabled");
+				btn.disabled = true;
+				btn.setAttribute("aria-disabled", true);
+			}
+
+			function enableSubmit() {
+				const btn = document.getElementById("submit-btn");
+				btn.classList.remove("disabled");
+				btn.disabled = false;
+				btn.removeAttribute("aria-disabled");
+			}
+
+			function ratingConnect(checkbox, textbox, slider) {
 				checkbox.onchange = function () {
 					if (checkbox.checked) {
 						textbox.value = '';
+						disableSubmit();
 					}
 				};
 				textbox.oninput = function () {
 					slider.value = textbox.value;
 					checkbox.checked = false;
+					enableSubmit();
 				};
 				slider.oninput = function () {
 					slider.value = Math.round(Number(this.value) * 2) / 2;
 					textbox.value = slider.value;
 					checkbox.checked = false;
+					enableSubmit();
 				};
 			}
 			ratingConnect(document.getElementById('Rating_EntertainmentUnrated'), document.getElementById('Rating_EntertainmentRating'), document.getElementById('entertainmentSlider'));
-			ratingConnect(document.getElementById('Rating_TechUnrated'), document.getElementById('Rating_TechRating'), document.getElementById('techSlider'));
 		</script>
 	</row>
 	<row>
 	</row>
 	<form-button-bar>
-		<button type="submit" class="btn btn-primary"><span class="fa fa-save"></span> Rate</button>
+		<button disable="@Model.Rating.EntertainmentRating == null" type="submit" class="btn btn-primary" id="submit-btn"><span class="fa fa-save"></span> Rate</button>
 		<a asp-page="/Publications/View" asp-route-id="@Model.Id" class="btn btn-secondary"><span class="fa fa-arrow-left"></span> Back to Publication</a>
 	</form-button-bar>
 </form>

--- a/TASVideos/Pages/Publications/Rate.cshtml.cs
+++ b/TASVideos/Pages/Publications/Rate.cshtml.cs
@@ -40,15 +40,11 @@ public class RateModel : BasePageModel
 		Rating = new PublicationRateModel
 		{
 			Title = publication.Title,
-			TechRating = ratings
-				.SingleOrDefault(r => r.Type == PublicationRatingType.TechQuality)
-				?.Value.ToString(CultureInfo.InvariantCulture),
 			EntertainmentRating = ratings
 				.SingleOrDefault(r => r.Type == PublicationRatingType.Entertainment)
 				?.Value.ToString(CultureInfo.InvariantCulture)
 		};
 
-		Rating.TechUnrated = Rating.TechRating == null;
 		Rating.EntertainmentUnrated = Rating.EntertainmentRating == null;
 
 		return Page();
@@ -68,13 +64,9 @@ public class RateModel : BasePageModel
 			.ForUser(userId)
 			.ToListAsync();
 
-		var tech = ratings
-			.SingleOrDefault(r => r.Type == PublicationRatingType.TechQuality);
-
 		var entertainment = ratings
 			.SingleOrDefault(r => r.Type == PublicationRatingType.Entertainment);
 
-		UpdateRating(tech, Id, userId, PublicationRatingType.TechQuality, PublicationRateModel.RatingString.AsRatingDouble(Rating.TechRating), Rating.TechUnrated);
 		UpdateRating(entertainment, Id, userId, PublicationRatingType.Entertainment, PublicationRateModel.RatingString.AsRatingDouble(Rating.EntertainmentRating), Rating.EntertainmentUnrated);
 
 		await _db.SaveChangesAsync();

--- a/TASVideos/Pages/Ratings/Index.cshtml
+++ b/TASVideos/Pages/Ratings/Index.cshtml
@@ -18,24 +18,15 @@
 		<table class="table table-striped table-bordered">
 			<tr>
 				<th>@Html.DisplayNameFor(m => m.Publication.Ratings.First().UserName)</th>
-				<th>@Html.DisplayNameFor(m => m.Publication.Ratings.First().Entertainment)</th>
-				<th>@Html.DisplayNameFor(m => m.Publication.Ratings.First().TechQuality)</th>
+				<th>@Html.DisplayNameFor(m => m.Publication.Ratings.First().Rating)</th>
 			</tr>
 			@foreach (var ratings in Model.VisibleRatings.OrderBy(r => r.UserName))
 			{
 				<tr @Html.Raw(!ratings.IsPublic ? "style=\"opacity: 0.50\"" : "")>
 					<td>@(ratings.IsPublic ? "" : "*") @ratings.UserName</td>
-					<td>@ratings.Entertainment</td>
-					<td>@ratings.TechQuality</td>
+					<td>@ratings.Rating</td>
 				</tr>
 			}
-			<tfoot>
-				<tr>
-					<th>Average</th>
-					<td>@Model.Publication.AverageEntertainmentRating</td>
-					<td>@Model.Publication.AverageTechRating</td>
-				</tr>
-			</tfoot>
 		</table>
 	</div>
 }

--- a/TASVideos/Pages/Ratings/Index.cshtml.cs
+++ b/TASVideos/Pages/Ratings/Index.cshtml.cs
@@ -61,8 +61,7 @@ public class IndexModel : BasePageModel
 				{
 					UserName = g.Key.UserName,
 					IsPublic = g.Key.PublicRatings,
-					Entertainment = g.FirstOrDefault(v => v.Type == PublicationRatingType.Entertainment)?.Value,
-					TechQuality = g.FirstOrDefault(v => v.Type == PublicationRatingType.TechQuality)?.Value
+					Entertainment = g.FirstOrDefault(v => v.Type == PublicationRatingType.Entertainment)?.Value
 				})
 				.ToList()
 		};
@@ -72,26 +71,9 @@ public class IndexModel : BasePageModel
 			.Select(r => r.Entertainment!.Value)
 			.ToList();
 
-		var techRatings = Publication.Ratings
-			.Where(r => r.TechQuality.HasValue)
-			.Select(r => r.TechQuality!.Value)
-			.ToList();
-
-		var overallRatings = entertainmentRatings
-			.Concat(techRatings)
-			.ToList();
-
-		Publication.AverageEntertainmentRating = entertainmentRatings.Any()
-			? Math.Round(entertainmentRatings.Average(), 2)
-			: 0;
-
-		Publication.AverageTechRating = techRatings.Any()
-			? Math.Round(techRatings.Average(), 2)
-			: 0;
-
 		// Entertainment counts 2:1 over Tech
-		Publication.OverallRating = overallRatings.Any()
-			? Math.Round(overallRatings.Average(), 2)
+		Publication.OverallRating = entertainmentRatings.Any()
+			? Math.Round(entertainmentRatings.Average(), 2)
 			: 0;
 
 		_cache.Set(CacheKeys.MovieRatingKey + Id, Publication);

--- a/TASVideos/Pages/Ratings/Index.cshtml.cs
+++ b/TASVideos/Pages/Ratings/Index.cshtml.cs
@@ -61,14 +61,14 @@ public class IndexModel : BasePageModel
 				{
 					UserName = g.Key.UserName,
 					IsPublic = g.Key.PublicRatings,
-					Entertainment = g.FirstOrDefault(v => v.Type == PublicationRatingType.Entertainment)?.Value
+					Rating = g.FirstOrDefault(v => v.Type == PublicationRatingType.Entertainment)?.Value
 				})
 				.ToList()
 		};
 
 		var entertainmentRatings = Publication.Ratings
-			.Where(r => r.Entertainment.HasValue)
-			.Select(r => r.Entertainment!.Value)
+			.Where(r => r.Rating.HasValue)
+			.Select(r => r.Rating!.Value)
 			.ToList();
 
 		// Entertainment counts 2:1 over Tech

--- a/TASVideos/Pages/Ratings/Models/PublicationRatingsModel.cs
+++ b/TASVideos/Pages/Ratings/Models/PublicationRatingsModel.cs
@@ -8,10 +8,6 @@ public class PublicationRatingsModel
 
 	public IEnumerable<RatingEntry> Ratings { get; set; } = new List<RatingEntry>();
 
-	public double AverageEntertainmentRating { get; set; }
-
-	public double AverageTechRating { get; set; }
-
 	public double OverallRating { get; set; }
 
 	public class RatingEntry
@@ -19,11 +15,8 @@ public class PublicationRatingsModel
 		[Display(Name = "UserName")]
 		public string UserName { get; set; } = "";
 
-		[Display(Name = "Entertainment")]
-		public double? Entertainment { get; set; }
-
-		[Display(Name = "Tech Quality")]
-		public double? TechQuality { get; set; }
+		[Display(Name = "Rating")]
+		public double? Rating { get; set; }
 
 		public bool IsPublic { get; set; }
 	}

--- a/TASVideos/Pages/RssFeeds/Models/RssPublication.cs
+++ b/TASVideos/Pages/RssFeeds/Models/RssPublication.cs
@@ -22,16 +22,11 @@ public class RssPublication
 	{
 		get
 		{
-			var ent = Ratings
+			var all = Ratings
 				.Where(r => r.Type == PublicationRatingType.Entertainment)
 				.Select(r => r.Value)
 				.ToList();
 
-			var tech = Ratings
-				.Where(r => r.Type == PublicationRatingType.TechQuality)
-				.Select(r => r.Value);
-
-			var all = ent.Concat(ent).Concat(tech).ToList();
 			if (all.Any())
 			{
 				return Math.Round(all.Average(), 2);

--- a/TASVideos/Pages/Shared/_Ratings.cshtml
+++ b/TASVideos/Pages/Shared/_Ratings.cshtml
@@ -32,17 +32,13 @@
 			<table class="table table-bordered">
 				<tr>
 					<th>Movie</th>
-					<th>Average</th>
-					<th>Entertainment</th>
-					<th>Tech Quality</th>
+					<th>Rating</th>
 				</tr>
-				@foreach (var rating in Model.Ratings.Where(r => !r.IsObsolete).OrderByDescending(r => r.Average))
+				@foreach (var rating in Model.Ratings.Where(r => !r.IsObsolete).OrderByDescending(r => r.Value))
 				{
 					<tr>
 						<td><a href="/@(rating.PublicationId)M">@rating.PublicationTitle</a></td>
-						<td>@(Math.Round(rating.Average, 1))</td>
-						<td>@rating.Entertainment</td>
-						<td>@rating.Tech</td>
+						<td>@(Math.Round(rating.Value, 1))</td>
 					</tr>
 				}
 			</table>
@@ -51,17 +47,13 @@
 			<table class="table table-bordered">
 				<tr>
 					<th>Movie</th>
-					<th>Average</th>
-					<th>Entertainment</th>
-					<th>Tech Quality</th>
+					<th>Rating</th>
 				</tr>
-				@foreach (var rating in Model.Ratings.Where(r => r.IsObsolete).OrderByDescending(r => r.Average))
+				@foreach (var rating in Model.Ratings.Where(r => r.IsObsolete).OrderByDescending(r => r.Value))
 				{
 					<tr>
 						<td><a href="/@(rating.PublicationId)M">@rating.PublicationTitle</a></td>
-						<td>@(Math.Round(rating.Average, 1))</td>
-						<td>@rating.Entertainment</td>
-						<td>@rating.Tech</td>
+						<td>@(Math.Round(rating.Value, 1))</td>
 					</tr>
 				}
 			</table>

--- a/TASVideos/ViewComponents/MovieStatistics.cs
+++ b/TASVideos/ViewComponents/MovieStatistics.cs
@@ -32,8 +32,6 @@ public class MovieStatistics : ViewComponent
 
 		// Rating data
 		AverageRating,
-		EntertainmentRating,
-		TechnicalRating,
 		VoteCount
 	}
 
@@ -52,8 +50,6 @@ public class MovieStatistics : ViewComponent
 		["desclen"] = MovieStatisticComparison.DescriptionLength,
 		["udesclen"] = MovieStatisticComparison.SubmissionDescriptionLength,
 		["averageRating"] = MovieStatisticComparison.AverageRating,
-		["entertainmentRating"] = MovieStatisticComparison.EntertainmentRating,
-		["qualityRating"] = MovieStatisticComparison.TechnicalRating,
 		["numberOfVotes"] = MovieStatisticComparison.VoteCount
 	};
 
@@ -228,40 +224,7 @@ public class MovieStatistics : ViewComponent
 						Title = p.Title,
 						FloatValue =
 						(float)Math.Round(
-							((float)p.PublicationRatings.Where(r => r.Type == PublicationRatingType.Entertainment).Average(r => r.Value) * (2f / 3f))
-						+ ((float)p.PublicationRatings.Where(r => r.Type == PublicationRatingType.TechQuality).Average(r => r.Value) * (1f / 3f)), 2)
-					})
-					.ToListAsync();
-				break;
-
-			case MovieStatisticComparison.EntertainmentRating:
-				fieldHeader = "Entertainment rating";
-				movieList = await _db.Publications
-					.ThatAreCurrent()
-					.Where(p => p.PublicationRatings.Count >= minimumVotes)
-					.Select(p =>
-					(MovieStatisticsModel.MovieStatisticsEntry)new MovieStatisticsModel.MovieStatisticsFloatEntry
-					{
-						Id = p.Id,
-						Title = p.Title,
-						FloatValue =
-						(float)Math.Round(p.PublicationRatings.Where(r => r.Type == PublicationRatingType.Entertainment).Average(r => r.Value), 2)
-					})
-					.ToListAsync();
-				break;
-
-			case MovieStatisticComparison.TechnicalRating:
-				fieldHeader = "Technical rating";
-				movieList = await _db.Publications
-					.ThatAreCurrent()
-					.Where(p => p.PublicationRatings.Count >= minVotes)
-					.Select(p =>
-					(MovieStatisticsModel.MovieStatisticsEntry)new MovieStatisticsModel.MovieStatisticsFloatEntry
-					{
-						Id = p.Id,
-						Title = p.Title,
-						FloatValue =
-						(float)Math.Round(p.PublicationRatings.Where(r => r.Type == PublicationRatingType.TechQuality).Average(r => r.Value), 2)
+							(float)p.PublicationRatings.Where(r => r.Type == PublicationRatingType.Entertainment).Average(r => r.Value))
 					})
 					.ToListAsync();
 				break;

--- a/tests/TASVideos.Core.Tests/Services/PointsServiceTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/PointsServiceTests.cs
@@ -2,7 +2,7 @@
 using TASVideos.Data;
 using TASVideos.Data.Entity;
 
-namespace TASVideos.Test.Services;
+namespace TASVideos.Core.Tests.Services;
 
 [TestClass]
 public class PointsServiceTests


### PR DESCRIPTION
This PR removes all references to Tech rating, and calculates ratings as simply the average of entertainment ratings.

With this change, assume all entertainment ratings have been updated to be the average rating.  That will be a script/program that will be developed in conjunction with this change.

In later deploys, we will want to remove the Type column from the Ratings table and any filtering to Entertainment types.  More simplifications of the code should be possible at that point as well