### PR TITLE
Movie module - Show RomHash Region, if not null

### DIFF
--- a/TASVideos/Extensions/EntityExtensions.cs
+++ b/TASVideos/Extensions/EntityExtensions.cs
@@ -181,7 +181,8 @@ public static class EntityExtensions
 				OverallRating = p.PublicationRatings
 					.Where(pr => !pr.Publication!.Authors.Select(a => a.UserId).Contains(pr.UserId))
 					.Where(pr => pr.User!.UseRatings)
-					.Average(pr => pr.Value)
+					.Average(pr => pr.Value),
+				Region = p.Rom != null ? p.Rom.Region : null
 			});
 
 		if (ratingSort)

--- a/TASVideos/Extensions/EntityExtensions.cs
+++ b/TASVideos/Extensions/EntityExtensions.cs
@@ -182,7 +182,8 @@ public static class EntityExtensions
 					.Where(pr => !pr.Publication!.Authors.Select(a => a.UserId).Contains(pr.UserId))
 					.Where(pr => pr.User!.UseRatings)
 					.Average(pr => pr.Value),
-				Region = p.Rom != null ? p.Rom.Region : null
+				Region = p.Rom != null ? p.Rom.Region : null,
+				RomVersion = p.Rom != null ? p.Rom.Version : null
 			});
 
 		if (ratingSort)

--- a/TASVideos/Pages/Publications/Models/PublicationDisplayModel.cs
+++ b/TASVideos/Pages/Publications/Models/PublicationDisplayModel.cs
@@ -36,6 +36,7 @@ public class PublicationDisplayModel
 	public int RatingCount { get; set; }
 	public double? OverallRating { get; set; }
 	public string? Region { get; set; }
+	public string? RomVersion { get; set; }
 
 	public class TagModel
 	{

--- a/TASVideos/Pages/Publications/Models/PublicationDisplayModel.cs
+++ b/TASVideos/Pages/Publications/Models/PublicationDisplayModel.cs
@@ -35,6 +35,7 @@ public class PublicationDisplayModel
 
 	public int RatingCount { get; set; }
 	public double? OverallRating { get; set; }
+	public string? Region { get; set; }
 
 	public class TagModel
 	{

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -15,6 +15,13 @@
 }
 
 @functions{
+	static string VersionDisplay(string? version)
+	{
+		return string.IsNullOrWhiteSpace(version)
+			? ""
+			: $"v{version}";
+	}
+
 	static string RegionDisplay(string? region)
 	{
 		if (string.IsNullOrWhiteSpace(region))
@@ -51,7 +58,9 @@
 			</div>
 			<h4>
 				<a asp-page="/Publications/View" asp-route-id="@Model.Id" class="text-decoration-none"><span class="text-dark">
-					<small condition="!string.IsNullOrWhiteSpace(Model.Region)">@RegionDisplay(Model.Region)</small> @Model.Title
+					<small condition="!string.IsNullOrWhiteSpace(Model.Region)">@RegionDisplay(Model.Region)</small>
+					<small condition="!string.IsNullOrWhiteSpace(Model.RomVersion)"> (@VersionDisplay(Model.RomVersion))</small>
+					@Model.Title
 				</span></a>
 			</h4>
 		</div>

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -14,6 +14,24 @@
 	var publicationAwards = await _awards.ForPublication(Model.Id);
 }
 
+@functions{
+	static string RegionDisplay(string? region)
+	{
+		if (string.IsNullOrWhiteSpace(region))
+		{
+			return "";
+		}
+
+		return region switch
+		{
+			"J" => "(JPN)",
+			"E" => "(Europe)",
+			"EU" => "(USA/Europe)",
+			_ => ""
+		};
+	}
+}
+
 <card class="border border-primary">
 	<cardheader class="bg-cardprimary p-2">
 		<div class="gx-3 clearfix">
@@ -32,7 +50,9 @@
 				}
 			</div>
 			<h4>
-				<a asp-page="/Publications/View" asp-route-id="@Model.Id" class="text-decoration-none"><span class="text-dark">@Model.Title </span></a>
+				<a asp-page="/Publications/View" asp-route-id="@Model.Id" class="text-decoration-none"><span class="text-dark">
+					<small condition="!string.IsNullOrWhiteSpace(Model.Region)">@RegionDisplay(Model.Region)</small> @Model.Title
+				</span></a>
 			</h4>
 		</div>
 	</cardheader>

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -24,7 +24,7 @@
 
 		return region switch
 		{
-			"J" => "(JPN)",
+			"J" => "(Japan)",
 			"E" => "(Europe)",
 			"EU" => "(USA/Europe)",
 			_ => ""

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -15,11 +15,19 @@
 }
 
 @functions{
-	static string VersionDisplay(string? version)
+	static string RomAndVersionDisplay(string? version, string? region)
 	{
-		return string.IsNullOrWhiteSpace(version)
-			? ""
-			: version;
+		if (string.IsNullOrWhiteSpace(version) && string.IsNullOrWhiteSpace(region))
+		{
+			return "";
+		}
+
+		if (string.IsNullOrWhiteSpace(region))
+		{
+			return version ?? "";
+		}
+
+		return $"{RegionDisplay(region)}, {version}";
 	}
 
 	static string RegionDisplay(string? region)
@@ -31,9 +39,9 @@
 
 		return region switch
 		{
-			"J" => "(Japan)",
-			"E" => "(Europe)",
-			"EU" => "(USA/Europe)",
+			"J" => "Japan",
+			"E" => "Europe",
+			"EU" => "USA/Europe",
 			_ => ""
 		};
 	}
@@ -58,8 +66,10 @@
 			</div>
 			<h4>
 				<a asp-page="/Publications/View" asp-route-id="@Model.Id" class="text-decoration-none"><span class="text-dark">
-					<small condition="!string.IsNullOrWhiteSpace(Model.Region)">@RegionDisplay(Model.Region)</small>
-					<small condition="!string.IsNullOrWhiteSpace(Model.RomVersion)"> (@VersionDisplay(Model.RomVersion))</small>
+						@{
+							var regionAndVersion = RomAndVersionDisplay(Model.RomVersion, Model.Region);
+						}
+					<small condition="!string.IsNullOrWhiteSpace(regionAndVersion)"> (@regionAndVersion)</small>
 					@Model.Title
 				</span></a>
 			</h4>

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -19,7 +19,7 @@
 	{
 		return string.IsNullOrWhiteSpace(version)
 			? ""
-			: $"v{version}";
+			: version;
 	}
 
 	static string RegionDisplay(string? region)

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -17,22 +17,23 @@
 @functions{
 	static string RomAndVersionDisplay(string? version, string? region)
 	{
-		if (string.IsNullOrWhiteSpace(version) && string.IsNullOrWhiteSpace(region))
+		string regionDisplay = RegionDisplay(region);
+		if (string.IsNullOrWhiteSpace(version) && string.IsNullOrWhiteSpace(regionDisplay))
 		{
 			return "";
 		}
 
-		if (string.IsNullOrWhiteSpace(region))
+		if (string.IsNullOrWhiteSpace(regionDisplay))
 		{
 			return version ?? "";
 		}
 
 		if (string.IsNullOrWhiteSpace(version))
 		{
-			return RegionDisplay(region);
+			return regionDisplay;
 		}
 
-		return $"{RegionDisplay(region)}, {version}";
+		return $"{regionDisplay}, {version}";
 	}
 
 	static string RegionDisplay(string? region)

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -27,6 +27,11 @@
 			return version ?? "";
 		}
 
+		if (string.IsNullOrWhiteSpace(version))
+		{
+			return RegionDisplay(region);
+		}
+
 		return $"{RegionDisplay(region)}, {version}";
 	}
 


### PR DESCRIPTION
Conditionally shows the region, if the rom hash entry is added
The value needs to not be in the title so that it can be styled independently, so I put it all the way to the left.  I also only show it if it is relevant, which currently are these values:
J => (JPN),
E => (Europe),
EU => (USA/Europe)

We can easily configure these values if want different examples.

![image](https://user-images.githubusercontent.com/1679846/153107570-d54a0550-c65e-4212-853b-33ef3f0c9572.png)

![image](https://user-images.githubusercontent.com/1679846/153107880-db964797-2379-4efc-afbb-e0c7608c8e3d.png)

