### PR TITLE
When a user successfully resets their password, mark their email confirmed

### DIFF
--- a/TASVideos.Core/Services/UserManager.cs
+++ b/TASVideos.Core/Services/UserManager.cs
@@ -443,4 +443,20 @@ public class UserManager : UserManager<User>
 			"usuarios.lycos.es"
 		};
 	}
+
+	public async Task MarkEmailConfirmed(User user)
+	{
+		if (!user.EmailConfirmed)
+		{
+			user.EmailConfirmed = true;
+			try
+			{
+				await _db.SaveChangesAsync();
+			}
+			catch (DbUpdateException)
+			{
+				// Do nothing, we do not want to block the rest of the request
+			}
+		}
+	}
 }

--- a/TASVideos/Pages/Account/ResetPassword.cshtml.cs
+++ b/TASVideos/Pages/Account/ResetPassword.cshtml.cs
@@ -72,6 +72,7 @@ public class ResetPasswordModel : BasePageModel
 		var result = await _userManager.ResetPasswordAsync(user, code, Password);
 		if (result.Succeeded)
 		{
+			await _userManager.MarkEmailConfirmed(user);
 			return RedirectToPage("ResetPasswordConfirmation");
 		}
 


### PR DESCRIPTION
I think this makes sense.  If they got this far, they got an email and clicked a link so we know it is verified.

Maybe this can't happen in a normal workflow but with legacy users, they may have unconfirmed emails and no password from the password wipe.