### PR TITLE
Userfiles: Content-Length is always physical length

### DIFF
--- a/TASVideos/Pages/UserFiles/Info.cshtml.cs
+++ b/TASVideos/Pages/UserFiles/Info.cshtml.cs
@@ -90,7 +90,7 @@ public class InfoModel : BasePageModel
 		{
 			var res = context.HttpContext.Response;
 
-			res.Headers.Add("Content-Length", _file.LogicalLength.ToString());
+			res.Headers.Add("Content-Length", _file.PhysicalLength.ToString());
 			if (_file.CompressionType == Compression.Gzip)
 			{
 				res.Headers.Add("Content-Encoding", "gzip");


### PR DESCRIPTION
Fixes the userfile downloads and Content-Length mismatches in the log.