### PR TITLE
Fix downloads of old userfiles

### DIFF
--- a/TASVideos/Pages/UserFiles/Info.cshtml.cs
+++ b/TASVideos/Pages/UserFiles/Info.cshtml.cs
@@ -90,7 +90,7 @@ public class InfoModel : BasePageModel
 		{
 			var res = context.HttpContext.Response;
 
-			res.Headers.Add("Content-Length", _file.PhysicalLength.ToString());
+			res.Headers.Add("Content-Length", _file.Content.Length.ToString());
 			if (_file.CompressionType == Compression.Gzip)
 			{
 				res.Headers.Add("Content-Encoding", "gzip");


### PR DESCRIPTION
For files that were converted from the old system, `File.PhysicalLength` was mistakenly set to the actual file length of the compressed stream that existed in the old database.  We need the actual file length of the compressed stream now.