### PR TITLE
Only load prism.js on pages needing it

### DIFF
--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -127,7 +127,13 @@
 			integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
 			crossorigin="anonymous"></script>
 	<script src="~/js/site.js"></script>
-	<script src="~/js/prism.js"></script>
+	<script>
+		if (document.querySelector('code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code') !== null){
+			let prism = document.createElement('script')
+			prism.src = '/js/prism.js'
+			document.body.appendChild(prism)
+		}
+	</script>
 	@await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>


### PR DESCRIPTION
This uses the selector used in prism.js itself to check whether loading it is needed.
Resolves #1130.

Before | After:
![image](https://user-images.githubusercontent.com/22375320/159196216-6d3d1ab0-b593-484a-979a-9626ce0c7ab4.png)
