### PR TITLE
Fix stream length issue with parsing certain movie formats

### DIFF
--- a/TASVideos.Parsers/IMovieParser.cs
+++ b/TASVideos.Parsers/IMovieParser.cs
@@ -53,7 +53,7 @@ public sealed class MovieParser : IMovieParser
 			}
 
 			await using var movieFileStream = movieFile.Open();
-			return await parser.Parse(movieFileStream);
+			return await parser.Parse(movieFileStream, movieFile.Length);
 		}
 		catch (Exception)
 		{
@@ -71,7 +71,7 @@ public sealed class MovieParser : IMovieParser
 			var parser = GetParser(ext);
 			return parser == null
 				? Error($".{ext} files are not currently supported.")
-				: await parser.Parse(stream);
+				: await parser.Parse(stream, stream.Length);
 		}
 		catch (Exception)
 		{

--- a/TASVideos.Parsers/Parsers/Bk2.cs
+++ b/TASVideos.Parsers/Parsers/Bk2.cs
@@ -11,7 +11,7 @@ internal class Bk2 : ParserBase, IParser
 
 	public override string FileExtension => "bk2";
 
-	public async Task<IParseResult> Parse(Stream file)
+	public async Task<IParseResult> Parse(Stream file, long length)
 	{
 		var result = new ParseResult
 		{

--- a/TASVideos.Parsers/Parsers/Ctm.cs
+++ b/TASVideos.Parsers/Parsers/Ctm.cs
@@ -9,7 +9,7 @@ internal class Ctm : ParserBase, IParser
 	private const int InputRate = 234; // Rate at which inputs are polled per second
 	public override string FileExtension => "ctm";
 
-	public async Task<IParseResult> Parse(Stream file)
+	public async Task<IParseResult> Parse(Stream file, long length)
 	{
 		var result = new ParseResult
 		{

--- a/TASVideos.Parsers/Parsers/Dsm.cs
+++ b/TASVideos.Parsers/Parsers/Dsm.cs
@@ -8,7 +8,7 @@ internal class Dsm : IParser
 {
 	private const string FileExtension = "dsm";
 
-	public async Task<IParseResult> Parse(Stream file)
+	public async Task<IParseResult> Parse(Stream file, long length)
 	{
 		using var reader = new StreamReader(file);
 		var result = new ParseResult

--- a/TASVideos.Parsers/Parsers/Dtm.cs
+++ b/TASVideos.Parsers/Parsers/Dtm.cs
@@ -9,7 +9,7 @@ internal class Dtm : ParserBase, IParser
 	private const decimal WiiHertz = 729000000.0M;
 	public override string FileExtension => "dtm";
 
-	public async Task<IParseResult> Parse(Stream file)
+	public async Task<IParseResult> Parse(Stream file, long length)
 	{
 		var result = new ParseResult
 		{

--- a/TASVideos.Parsers/Parsers/Fbm.cs
+++ b/TASVideos.Parsers/Parsers/Fbm.cs
@@ -7,7 +7,7 @@ internal class Fbm : ParserBase, IParser
 {
 	public override string FileExtension => "fbm";
 
-	public async Task<IParseResult> Parse(Stream file)
+	public async Task<IParseResult> Parse(Stream file, long length)
 	{
 		var result = new ParseResult
 		{

--- a/TASVideos.Parsers/Parsers/Fm2.cs
+++ b/TASVideos.Parsers/Parsers/Fm2.cs
@@ -8,7 +8,7 @@ internal class Fm2 : IParser
 {
 	private const string FileExtension = "fm2";
 
-	public async Task<IParseResult> Parse(Stream file)
+	public async Task<IParseResult> Parse(Stream file, long length)
 	{
 		using var reader = new StreamReader(file);
 		var result = new ParseResult

--- a/TASVideos.Parsers/Parsers/Gmv.cs
+++ b/TASVideos.Parsers/Parsers/Gmv.cs
@@ -8,7 +8,7 @@ internal class Gmv : ParserBase, IParser
 {
 	public override string FileExtension => "gmv";
 
-	public async Task<IParseResult> Parse(Stream file)
+	public async Task<IParseResult> Parse(Stream file, long length)
 	{
 		var result = new ParseResult
 		{
@@ -38,7 +38,7 @@ internal class Gmv : ParserBase, IParser
 			result.StartType = MovieStartType.Savestate;
 		}
 
-		result.Frames = (int)(file.Length - 64) / 3;
+		result.Frames = (int)(length - 64) / 3;
 
 		return await Task.FromResult(result);
 	}

--- a/TASVideos.Parsers/Parsers/IParser.cs
+++ b/TASVideos.Parsers/Parsers/IParser.cs
@@ -4,5 +4,5 @@ namespace TASVideos.MovieParsers.Parsers;
 
 internal interface IParser
 {
-	Task<IParseResult> Parse(Stream file);
+	Task<IParseResult> Parse(Stream file, long length);
 }

--- a/TASVideos.Parsers/Parsers/Jrsr.cs
+++ b/TASVideos.Parsers/Parsers/Jrsr.cs
@@ -60,7 +60,7 @@ public class Jrsr : IParser
 	private const NumberStyles IntegerStyle = NumberStyles.AllowLeadingSign;
 
 	private const string FileExtension = "jrsr";
-	public async Task<IParseResult> Parse(Stream file)
+	public async Task<IParseResult> Parse(Stream file, long length)
 	{
 		var result = new ParseResult
 		{

--- a/TASVideos.Parsers/Parsers/Lsmv.cs
+++ b/TASVideos.Parsers/Parsers/Lsmv.cs
@@ -15,7 +15,7 @@ internal class Lsmv : ParserBase, IParser
 
 	public override string FileExtension => "lsmv";
 
-	public async Task<IParseResult> Parse(Stream file)
+	public async Task<IParseResult> Parse(Stream file, long length)
 	{
 		var result = new ParseResult
 		{

--- a/TASVideos.Parsers/Parsers/Ltm.cs
+++ b/TASVideos.Parsers/Parsers/Ltm.cs
@@ -19,7 +19,7 @@ internal class Ltm : ParserBase, IParser
 
 	public override string FileExtension => "ltm";
 
-	public async Task<IParseResult> Parse(Stream file)
+	public async Task<IParseResult> Parse(Stream file, long length)
 	{
 		var result = new ParseResult
 		{

--- a/TASVideos.Parsers/Parsers/M64.cs
+++ b/TASVideos.Parsers/Parsers/M64.cs
@@ -8,7 +8,7 @@ internal class M64 : ParserBase, IParser
 {
 	public override string FileExtension => "m64";
 
-	public async Task<IParseResult> Parse(Stream file)
+	public async Task<IParseResult> Parse(Stream file, long length)
 	{
 		var result = new ParseResult
 		{

--- a/TASVideos.Parsers/Parsers/Mar.cs
+++ b/TASVideos.Parsers/Parsers/Mar.cs
@@ -7,7 +7,7 @@ internal class Mar : ParserBase, IParser
 {
 	public override string FileExtension => "mar";
 
-	public async Task<IParseResult> Parse(Stream file)
+	public async Task<IParseResult> Parse(Stream file, long length)
 	{
 		var result = new ParseResult
 		{

--- a/TASVideos.Parsers/Parsers/Omr.cs
+++ b/TASVideos.Parsers/Parsers/Omr.cs
@@ -10,7 +10,7 @@ internal class Omr : ParserBase, IParser
 {
 	public override string FileExtension => "omr";
 
-	public async Task<IParseResult> Parse(Stream file)
+	public async Task<IParseResult> Parse(Stream file, long length)
 	{
 		var result = new ParseResult
 		{

--- a/TASVideos.Parsers/Parsers/Vbm.cs
+++ b/TASVideos.Parsers/Parsers/Vbm.cs
@@ -8,7 +8,7 @@ internal class Vbm : ParserBase, IParser
 {
 	public override string FileExtension => "vbm";
 
-	public async Task<IParseResult> Parse(Stream file)
+	public async Task<IParseResult> Parse(Stream file, long length)
 	{
 		var result = new ParseResult
 		{

--- a/TASVideos.Parsers/Parsers/Wtf.cs
+++ b/TASVideos.Parsers/Parsers/Wtf.cs
@@ -6,14 +6,14 @@ internal class Wtf : ParserBase, IParser
 {
 	public override string FileExtension => "wtf";
 
-	public async Task<IParseResult> Parse(Stream file)
+	public async Task<IParseResult> Parse(Stream file, long length)
 	{
 		var result = new ParseResult
 		{
 			Region = RegionType.Ntsc,
 			FileExtension = FileExtension,
 			SystemCode = SystemCodes.Windows,
-			Frames = (int)((file.Length - 1024) / 8)
+			Frames = (int)((length - 1024) / 8)
 		};
 
 		using var br = new BinaryReader(file);

--- a/tests/TASVideos.MovieParsers.Tests/Bk2ParserTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/Bk2ParserTests.cs
@@ -17,7 +17,7 @@ public class Bk2ParserTests : BaseParserTests
 	[DataRow("MissingInputLog.bk2", DisplayName = "Missing InputLog creates error")]
 	public async Task Errors(string filename)
 	{
-		var result = await _bk2Parser.Parse(Embedded(filename));
+		var result = await _bk2Parser.Parse(Embedded(filename), EmbeddedLength(filename));
 		Assert.AreEqual(false, result.Success);
 		AssertNoWarnings(result);
 		Assert.IsNotNull(result.Errors);
@@ -27,7 +27,7 @@ public class Bk2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task Frames_CorrectResult()
 	{
-		var result = await _bk2Parser.Parse(Embedded("2Frames.bk2"));
+		var result = await _bk2Parser.Parse(Embedded("2Frames.bk2"), EmbeddedLength("2Frames.bk2"));
 		Assert.AreEqual(true, result.Success);
 		Assert.AreEqual(2, result.Frames);
 		AssertNoWarningsOrErrors(result);
@@ -36,7 +36,7 @@ public class Bk2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task Frames_NoInputFrames_Returns0()
 	{
-		var result = await _bk2Parser.Parse(Embedded("0Frames.bk2"));
+		var result = await _bk2Parser.Parse(Embedded("0Frames.bk2"), EmbeddedLength("0Frames.bk2"));
 		Assert.AreEqual(true, result.Success);
 		Assert.AreEqual(0, result.Frames);
 		AssertNoWarningsOrErrors(result);
@@ -45,7 +45,7 @@ public class Bk2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task ValidRerecordCount()
 	{
-		var result = await _bk2Parser.Parse(Embedded("RerecordCount1.bk2"));
+		var result = await _bk2Parser.Parse(Embedded("RerecordCount1.bk2"), EmbeddedLength("RerecordCount1.bk2"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(1, result.RerecordCount);
 		AssertNoWarningsOrErrors(result);
@@ -54,7 +54,7 @@ public class Bk2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task InvalidRerecordCount_Warning()
 	{
-		var result = await _bk2Parser.Parse(Embedded("RerecordCountMissing.bk2"));
+		var result = await _bk2Parser.Parse(Embedded("RerecordCountMissing.bk2"), EmbeddedLength("RerecordCountMissing.bk2"));
 		Assert.IsTrue(result.Success);
 		Assert.IsNotNull(result.Warnings);
 		Assert.AreEqual(1, result.Warnings.Count());
@@ -65,7 +65,7 @@ public class Bk2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task InvalidRerecordNegative_Warning()
 	{
-		var result = await _bk2Parser.Parse(Embedded("RerecordCountNegative.bk2"));
+		var result = await _bk2Parser.Parse(Embedded("RerecordCountNegative.bk2"), EmbeddedLength("RerecordCountNegative.bk2"));
 		Assert.IsTrue(result.Success);
 		Assert.IsNotNull(result.Warnings);
 		Assert.AreEqual(1, result.Warnings.Count());
@@ -78,7 +78,7 @@ public class Bk2ParserTests : BaseParserTests
 	[DataRow("0Frames.bk2", RegionType.Ntsc, DisplayName = "Missing flag defaults to Ntsc")]
 	public async Task PalFlag_True(string fileName, RegionType expected)
 	{
-		var result = await _bk2Parser.Parse(Embedded(fileName));
+		var result = await _bk2Parser.Parse(Embedded(fileName), EmbeddedLength(fileName));
 		Assert.AreEqual(expected, result.Region);
 		AssertNoWarningsOrErrors(result);
 	}
@@ -125,7 +125,7 @@ public class Bk2ParserTests : BaseParserTests
 	[DataRow("System-Zxs.bk2", SystemCodes.ZxSpectrum)]
 	public async Task Systems(string filename, string expectedSystem)
 	{
-		var result = await _bk2Parser.Parse(Embedded(filename));
+		var result = await _bk2Parser.Parse(Embedded(filename), EmbeddedLength(filename));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(expectedSystem, result.SystemCode);
 		AssertNoWarningsOrErrors(result);
@@ -137,7 +137,7 @@ public class Bk2ParserTests : BaseParserTests
 	[DataRow("savestate.bk2", MovieStartType.Savestate)]
 	public async Task StartType(string filename, MovieStartType expected)
 	{
-		var result = await _bk2Parser.Parse(Embedded(filename));
+		var result = await _bk2Parser.Parse(Embedded(filename), EmbeddedLength(filename));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(expected, result.StartType);
 	}
@@ -145,7 +145,7 @@ public class Bk2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task InnerFileExtensions_AreNotChecked()
 	{
-		var result = await _bk2Parser.Parse(Embedded("NoFileExts.bk2"));
+		var result = await _bk2Parser.Parse(Embedded("NoFileExts.bk2"), EmbeddedLength("NoFileExts.bk2"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual("nes", result.SystemCode);
 		Assert.AreEqual(1, result.Frames);
@@ -155,7 +155,7 @@ public class Bk2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task SubNes_ReportsCorrectFrameCount()
 	{
-		var result = await _bk2Parser.Parse(Embedded("SubNes.bk2"));
+		var result = await _bk2Parser.Parse(Embedded("SubNes.bk2"), EmbeddedLength("SubNes.bk2"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual("nes", result.SystemCode);
 		Assert.AreEqual(12, result.Frames);
@@ -165,7 +165,7 @@ public class Bk2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task SubNes_MissingVBlank_Error()
 	{
-		var result = await _bk2Parser.Parse(Embedded("SubNesMissingVBlank.bk2"));
+		var result = await _bk2Parser.Parse(Embedded("SubNesMissingVBlank.bk2"), EmbeddedLength("SubNesMissingVBlank.bk2"));
 
 		Assert.IsFalse(result.Success);
 		Assert.IsNotNull(result.Errors);
@@ -175,7 +175,7 @@ public class Bk2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task SubNes_NegativeVBlank_Error()
 	{
-		var result = await _bk2Parser.Parse(Embedded("SubNesNegativeVBlank.bk2"));
+		var result = await _bk2Parser.Parse(Embedded("SubNesNegativeVBlank.bk2"), EmbeddedLength("SubNesNegativeVBlank.bk2"));
 
 		Assert.IsFalse(result.Success);
 		Assert.IsNotNull(result.Errors);
@@ -185,7 +185,7 @@ public class Bk2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task Gambatte_UsesCycleCount()
 	{
-		var result = await _bk2Parser.Parse(Embedded("Gambatte-CycleCount.bk2"));
+		var result = await _bk2Parser.Parse(Embedded("Gambatte-CycleCount.bk2"), EmbeddedLength("Gambatte-CycleCount.bk2"));
 
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
@@ -196,7 +196,7 @@ public class Bk2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task Gambatte_MissingCycleCount_FallsBackToInputLog()
 	{
-		var result = await _bk2Parser.Parse(Embedded("Gambatte-NoCycleCount.bk2"));
+		var result = await _bk2Parser.Parse(Embedded("Gambatte-NoCycleCount.bk2"), EmbeddedLength("Gambatte-NoCycleCount.bk2"));
 
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
@@ -207,7 +207,7 @@ public class Bk2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task Gambatte_InvalidCycleCountFormat_FallsBackToInputLog()
 	{
-		var result = await _bk2Parser.Parse(Embedded("Gambatte-InvalidCycleCount.bk2"));
+		var result = await _bk2Parser.Parse(Embedded("Gambatte-InvalidCycleCount.bk2"), EmbeddedLength("Gambatte-InvalidCycleCount.bk2"));
 
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
@@ -218,7 +218,7 @@ public class Bk2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task Gambatte_NegativeCycleCountFormat_FallsBackToInputLog()
 	{
-		var result = await _bk2Parser.Parse(Embedded("Gambatte-NegativeCycleCount.bk2"));
+		var result = await _bk2Parser.Parse(Embedded("Gambatte-NegativeCycleCount.bk2"), EmbeddedLength("Gambatte-NegativeCycleCount.bk2"));
 
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
@@ -229,7 +229,7 @@ public class Bk2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task SubGbHawk_UsesCycleCount()
 	{
-		var result = await _bk2Parser.Parse(Embedded("SubGbHawk-CycleCount.bk2"));
+		var result = await _bk2Parser.Parse(Embedded("SubGbHawk-CycleCount.bk2"), EmbeddedLength("SubGbHawk-CycleCount.bk2"));
 
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);

--- a/tests/TASVideos.MovieParsers.Tests/CtmTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/CtmTests.cs
@@ -16,7 +16,7 @@ public class CtmTests : BaseParserTests
 	[TestMethod]
 	public async Task InvalidHeader()
 	{
-		var result = await _ctmParser.Parse(Embedded("wrongheader.ctm"));
+		var result = await _ctmParser.Parse(Embedded("wrongheader.ctm"), EmbeddedLength("wrongheader.ctm"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.IsNotNull(result.Errors);
@@ -26,7 +26,7 @@ public class CtmTests : BaseParserTests
 	[TestMethod]
 	public async Task ValidHeader()
 	{
-		var result = await _ctmParser.Parse(Embedded("2frames.ctm"));
+		var result = await _ctmParser.Parse(Embedded("2frames.ctm"), EmbeddedLength("2frames.ctm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 	}
@@ -34,7 +34,7 @@ public class CtmTests : BaseParserTests
 	[TestMethod]
 	public async Task System()
 	{
-		var result = await _ctmParser.Parse(Embedded("2frames.ctm"));
+		var result = await _ctmParser.Parse(Embedded("2frames.ctm"), EmbeddedLength("2frames.ctm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(SystemCodes.N3ds, result.SystemCode);
@@ -43,7 +43,7 @@ public class CtmTests : BaseParserTests
 	[TestMethod]
 	public async Task RerecordCount()
 	{
-		var result = await _ctmParser.Parse(Embedded("2frames.ctm"));
+		var result = await _ctmParser.Parse(Embedded("2frames.ctm"), EmbeddedLength("2frames.ctm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(1, result.RerecordCount);
@@ -52,7 +52,7 @@ public class CtmTests : BaseParserTests
 	[TestMethod]
 	public async Task Ntsc()
 	{
-		var result = await _ctmParser.Parse(Embedded("2frames.ctm"));
+		var result = await _ctmParser.Parse(Embedded("2frames.ctm"), EmbeddedLength("2frames.ctm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(RegionType.Ntsc, result.Region);
@@ -61,7 +61,7 @@ public class CtmTests : BaseParserTests
 	[TestMethod]
 	public async Task Length()
 	{
-		var result = await _ctmParser.Parse(Embedded("2frames.ctm"));
+		var result = await _ctmParser.Parse(Embedded("2frames.ctm"), EmbeddedLength("2frames.ctm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(2, result.Frames);

--- a/tests/TASVideos.MovieParsers.Tests/DsmParserTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/DsmParserTests.cs
@@ -15,7 +15,7 @@ public class DsmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task System()
 	{
-		var result = await _dsmParser.Parse(Embedded("2frames.dsm"));
+		var result = await _dsmParser.Parse(Embedded("2frames.dsm"), EmbeddedLength("2frames.dsm"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(SystemCodes.Ds, result.SystemCode);
 		AssertNoWarningsOrErrors(result);
@@ -24,7 +24,7 @@ public class DsmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task MultipleFrames()
 	{
-		var result = await _dsmParser.Parse(Embedded("2frames.dsm"));
+		var result = await _dsmParser.Parse(Embedded("2frames.dsm"), EmbeddedLength("2frames.dsm"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(2, result.Frames);
 		AssertNoWarningsOrErrors(result);
@@ -33,7 +33,7 @@ public class DsmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task ZeroFrames()
 	{
-		var result = await _dsmParser.Parse(Embedded("0frames.dsm"));
+		var result = await _dsmParser.Parse(Embedded("0frames.dsm"), EmbeddedLength("0frames.dsm"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(0, result.Frames);
 		AssertNoWarningsOrErrors(result);
@@ -42,7 +42,7 @@ public class DsmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task RerecordCount()
 	{
-		var result = await _dsmParser.Parse(Embedded("2frames.dsm"));
+		var result = await _dsmParser.Parse(Embedded("2frames.dsm"), EmbeddedLength("2frames.dsm"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(1, result.RerecordCount);
 		AssertNoWarningsOrErrors(result);
@@ -51,7 +51,7 @@ public class DsmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task NoRerecordCount()
 	{
-		var result = await _dsmParser.Parse(Embedded("norerecords.dsm"));
+		var result = await _dsmParser.Parse(Embedded("norerecords.dsm"), EmbeddedLength("norerecords.dsm"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(0, result.RerecordCount, "Rerecord count is assumed to be 0");
 		Assert.IsNotNull(result.Warnings);
@@ -62,7 +62,7 @@ public class DsmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task PowerOn()
 	{
-		var result = await _dsmParser.Parse(Embedded("2frames.dsm"));
+		var result = await _dsmParser.Parse(Embedded("2frames.dsm"), EmbeddedLength("2frames.dsm"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
 		AssertNoWarningsOrErrors(result);
@@ -71,7 +71,7 @@ public class DsmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task Sram()
 	{
-		var result = await _dsmParser.Parse(Embedded("sram.dsm"));
+		var result = await _dsmParser.Parse(Embedded("sram.dsm"), EmbeddedLength("sram.dsm"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(MovieStartType.Sram, result.StartType);
 		AssertNoWarningsOrErrors(result);
@@ -80,7 +80,7 @@ public class DsmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task Savestate()
 	{
-		var result = await _dsmParser.Parse(Embedded("savestate.dsm"));
+		var result = await _dsmParser.Parse(Embedded("savestate.dsm"), EmbeddedLength("savestate.dsm"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(MovieStartType.Savestate, result.StartType);
 		AssertNoWarningsOrErrors(result);
@@ -89,7 +89,7 @@ public class DsmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task NegativeRerecords()
 	{
-		var result = await _dsmParser.Parse(Embedded("negativererecords.dsm"));
+		var result = await _dsmParser.Parse(Embedded("negativererecords.dsm"), EmbeddedLength("negativererecords.dsm"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(0, result.RerecordCount, "Rerecord count assumed to be 0");
 		AssertNoErrors(result);

--- a/tests/TASVideos.MovieParsers.Tests/DtmParserTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/DtmParserTests.cs
@@ -16,7 +16,7 @@ public class DtmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task InvalidHeader()
 	{
-		var result = await _dtmParser.Parse(Embedded("wrongheader.dtm"));
+		var result = await _dtmParser.Parse(Embedded("wrongheader.dtm"), EmbeddedLength("wrongheader.dtm"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.IsNotNull(result.Errors);
@@ -26,7 +26,7 @@ public class DtmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task ValidHeader()
 	{
-		var result = await _dtmParser.Parse(Embedded("2frames-gc.dtm"));
+		var result = await _dtmParser.Parse(Embedded("2frames-gc.dtm"), EmbeddedLength("2frames-gc.dtm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 	}
@@ -34,7 +34,7 @@ public class DtmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task SystemGc()
 	{
-		var result = await _dtmParser.Parse(Embedded("2frames-gc.dtm"));
+		var result = await _dtmParser.Parse(Embedded("2frames-gc.dtm"), EmbeddedLength("2frames-gc.dtm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(SystemCodes.GameCube, result.SystemCode);
@@ -43,7 +43,7 @@ public class DtmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task SystemWii()
 	{
-		var result = await _dtmParser.Parse(Embedded("2frames-wii.dtm"));
+		var result = await _dtmParser.Parse(Embedded("2frames-wii.dtm"), EmbeddedLength("2frames-wii.dtm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(SystemCodes.Wii, result.SystemCode);
@@ -52,7 +52,7 @@ public class DtmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task PowerOn()
 	{
-		var result = await _dtmParser.Parse(Embedded("2frames-gc.dtm"));
+		var result = await _dtmParser.Parse(Embedded("2frames-gc.dtm"), EmbeddedLength("2frames-gc.dtm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
@@ -61,7 +61,7 @@ public class DtmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task Savestate()
 	{
-		var result = await _dtmParser.Parse(Embedded("savestate.dtm"));
+		var result = await _dtmParser.Parse(Embedded("savestate.dtm"), EmbeddedLength("savestate.dtm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.Savestate, result.StartType);
@@ -70,7 +70,7 @@ public class DtmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task Sram()
 	{
-		var result = await _dtmParser.Parse(Embedded("sram.dtm"));
+		var result = await _dtmParser.Parse(Embedded("sram.dtm"), EmbeddedLength("sram.dtm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.Sram, result.StartType);
@@ -79,7 +79,7 @@ public class DtmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task RerecordCount()
 	{
-		var result = await _dtmParser.Parse(Embedded("2frames-gc.dtm"));
+		var result = await _dtmParser.Parse(Embedded("2frames-gc.dtm"), EmbeddedLength("2frames-gc.dtm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(347, result.RerecordCount);
@@ -88,7 +88,7 @@ public class DtmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task NoTicks_FallbackAndWarn()
 	{
-		var result = await _dtmParser.Parse(Embedded("2frames-legacy.dtm"));
+		var result = await _dtmParser.Parse(Embedded("2frames-legacy.dtm"), EmbeddedLength("2frames-legacy.dtm"));
 		Assert.IsTrue(result.Success);
 		AssertNoErrors(result);
 		Assert.IsNotNull(result.Warnings);
@@ -100,7 +100,7 @@ public class DtmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task GcFrames()
 	{
-		var result = await _dtmParser.Parse(Embedded("2frames-gc.dtm"));
+		var result = await _dtmParser.Parse(Embedded("2frames-gc.dtm"), EmbeddedLength("2frames-gc.dtm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(283, result.Frames);
@@ -109,7 +109,7 @@ public class DtmParserTests : BaseParserTests
 	[TestMethod]
 	public async Task WiiFrames()
 	{
-		var result = await _dtmParser.Parse(Embedded("2frames-wii.dtm"));
+		var result = await _dtmParser.Parse(Embedded("2frames-wii.dtm"), EmbeddedLength("2frames-wii.dtm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(189, result.Frames);

--- a/tests/TASVideos.MovieParsers.Tests/FbmTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/FbmTests.cs
@@ -16,7 +16,7 @@ public class FbmTests : BaseParserTests
 	[TestMethod]
 	public async Task InvalidHeader()
 	{
-		var result = await _fbmParser.Parse(Embedded("wrongmarker.fbm"));
+		var result = await _fbmParser.Parse(Embedded("wrongmarker.fbm"), EmbeddedLength("wrongmarker.fbm"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.IsNotNull(result.Errors);
@@ -26,7 +26,7 @@ public class FbmTests : BaseParserTests
 	[TestMethod]
 	public async Task NoInputSection()
 	{
-		var result = await _fbmParser.Parse(Embedded("missinginput.fbm"));
+		var result = await _fbmParser.Parse(Embedded("missinginput.fbm"), EmbeddedLength("missinginput.fbm"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.IsNotNull(result.Errors);
@@ -36,7 +36,7 @@ public class FbmTests : BaseParserTests
 	[TestMethod]
 	public async Task Rerecords()
 	{
-		var result = await _fbmParser.Parse(Embedded("basictest.fbm"));
+		var result = await _fbmParser.Parse(Embedded("basictest.fbm"), EmbeddedLength("basictest.fbm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(12298, result.RerecordCount);
@@ -45,7 +45,7 @@ public class FbmTests : BaseParserTests
 	[TestMethod]
 	public async Task Frames()
 	{
-		var result = await _fbmParser.Parse(Embedded("basictest.fbm"));
+		var result = await _fbmParser.Parse(Embedded("basictest.fbm"), EmbeddedLength("basictest.fbm"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
 		AssertNoWarningsOrErrors(result);
@@ -55,7 +55,7 @@ public class FbmTests : BaseParserTests
 	[TestMethod]
 	public async Task PowerOn()
 	{
-		var result = await _fbmParser.Parse(Embedded("basictest.fbm"));
+		var result = await _fbmParser.Parse(Embedded("basictest.fbm"), EmbeddedLength("basictest.fbm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
@@ -64,7 +64,7 @@ public class FbmTests : BaseParserTests
 	[TestMethod]
 	public async Task Savestate()
 	{
-		var result = await _fbmParser.Parse(Embedded("savestate.fbm"));
+		var result = await _fbmParser.Parse(Embedded("savestate.fbm"), EmbeddedLength("savestate.fbm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.Savestate, result.StartType);

--- a/tests/TASVideos.MovieParsers.Tests/Fm2ParserTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/Fm2ParserTests.cs
@@ -15,7 +15,7 @@ public class Fm2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task Ntsc()
 	{
-		var result = await _fm2Parser.Parse(Embedded("ntsc.fm2"));
+		var result = await _fm2Parser.Parse(Embedded("ntsc.fm2"), EmbeddedLength("ntsc.fm2"));
 		Assert.IsTrue(result.Success, "Result is successful");
 		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
 		Assert.AreEqual(RegionType.Ntsc, result.Region);
@@ -28,7 +28,7 @@ public class Fm2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task Pal()
 	{
-		var result = await _fm2Parser.Parse(Embedded("pal.fm2"));
+		var result = await _fm2Parser.Parse(Embedded("pal.fm2"), EmbeddedLength("pal.fm2"));
 		Assert.IsTrue(result.Success, "Result is successful");
 		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
 		Assert.AreEqual(RegionType.Pal, result.Region);
@@ -41,7 +41,7 @@ public class Fm2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task Fds()
 	{
-		var result = await _fm2Parser.Parse(Embedded("fds.fm2"));
+		var result = await _fm2Parser.Parse(Embedded("fds.fm2"), EmbeddedLength("fds.fm2"));
 		Assert.IsTrue(result.Success, "Result is successful");
 		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
 		Assert.AreEqual(RegionType.Ntsc, result.Region);
@@ -54,7 +54,7 @@ public class Fm2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task Savestate()
 	{
-		var result = await _fm2Parser.Parse(Embedded("savestate.fm2"));
+		var result = await _fm2Parser.Parse(Embedded("savestate.fm2"), EmbeddedLength("savestate.fm2"));
 		Assert.IsTrue(result.Success, "Result is successful");
 		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
 		Assert.AreEqual(RegionType.Ntsc, result.Region);
@@ -67,7 +67,7 @@ public class Fm2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task NoRerecords()
 	{
-		var result = await _fm2Parser.Parse(Embedded("norerecords.fm2"));
+		var result = await _fm2Parser.Parse(Embedded("norerecords.fm2"), EmbeddedLength("norerecords.fm2"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(0, result.RerecordCount, "Rerecord count is assumed to be 0");
 		Assert.IsNotNull(result.Warnings);
@@ -78,7 +78,7 @@ public class Fm2ParserTests : BaseParserTests
 	[TestMethod]
 	public async Task NegativeRerecords()
 	{
-		var result = await _fm2Parser.Parse(Embedded("negativererecords.fm2"));
+		var result = await _fm2Parser.Parse(Embedded("negativererecords.fm2"), EmbeddedLength("negativererecords.fm2"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(0, result.RerecordCount, "Rerecord count assumed to be 0");
 		AssertNoErrors(result);

--- a/tests/TASVideos.MovieParsers.Tests/GmvTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/GmvTests.cs
@@ -16,7 +16,7 @@ public class GmvTests : BaseParserTests
 	[TestMethod]
 	public async Task InvalidHeader()
 	{
-		var result = await _gmvParser.Parse(Embedded("wrongheader.gmv"));
+		var result = await _gmvParser.Parse(Embedded("wrongheader.gmv"), EmbeddedLength("wrongheader.gmv"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.IsNotNull(result.Errors);
@@ -26,7 +26,7 @@ public class GmvTests : BaseParserTests
 	[TestMethod]
 	public async Task ValidHeader()
 	{
-		var result = await _gmvParser.Parse(Embedded("2frames.gmv"));
+		var result = await _gmvParser.Parse(Embedded("2frames.gmv"), EmbeddedLength("2frames.gmv"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 	}
@@ -34,7 +34,7 @@ public class GmvTests : BaseParserTests
 	[TestMethod]
 	public async Task System()
 	{
-		var result = await _gmvParser.Parse(Embedded("2frames.gmv"));
+		var result = await _gmvParser.Parse(Embedded("2frames.gmv"), EmbeddedLength("2frames.gmv"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(SystemCodes.Genesis, result.SystemCode);
@@ -43,7 +43,7 @@ public class GmvTests : BaseParserTests
 	[TestMethod]
 	public async Task RerecordCount()
 	{
-		var result = await _gmvParser.Parse(Embedded("2frames.gmv"));
+		var result = await _gmvParser.Parse(Embedded("2frames.gmv"), EmbeddedLength("2frames.gmv"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(10319, result.RerecordCount);
@@ -52,7 +52,7 @@ public class GmvTests : BaseParserTests
 	[TestMethod]
 	public async Task Ntsc()
 	{
-		var result = await _gmvParser.Parse(Embedded("2frames.gmv"));
+		var result = await _gmvParser.Parse(Embedded("2frames.gmv"), EmbeddedLength("2frames.gmv"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(RegionType.Ntsc, result.Region);
@@ -61,7 +61,7 @@ public class GmvTests : BaseParserTests
 	[TestMethod]
 	public async Task Pal()
 	{
-		var result = await _gmvParser.Parse(Embedded("pal.gmv"));
+		var result = await _gmvParser.Parse(Embedded("pal.gmv"), EmbeddedLength("pal.gmv"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(RegionType.Pal, result.Region);
@@ -70,7 +70,7 @@ public class GmvTests : BaseParserTests
 	[TestMethod]
 	public async Task PowerOn()
 	{
-		var result = await _gmvParser.Parse(Embedded("2frames.gmv"));
+		var result = await _gmvParser.Parse(Embedded("2frames.gmv"), EmbeddedLength("2frames.gmv"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
@@ -79,7 +79,7 @@ public class GmvTests : BaseParserTests
 	[TestMethod]
 	public async Task Savestate()
 	{
-		var result = await _gmvParser.Parse(Embedded("savestate.gmv"));
+		var result = await _gmvParser.Parse(Embedded("savestate.gmv"), EmbeddedLength("savestate.gmv"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.Savestate, result.StartType);
@@ -88,7 +88,7 @@ public class GmvTests : BaseParserTests
 	[TestMethod]
 	public async Task Length()
 	{
-		var result = await _gmvParser.Parse(Embedded("2frames.gmv"));
+		var result = await _gmvParser.Parse(Embedded("2frames.gmv"), EmbeddedLength("2frames.gmv"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(2, result.Frames);

--- a/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/JrsrTests.cs
@@ -20,14 +20,14 @@ public class JrsrTests : BaseParserTests
 	[TestMethod]
 	public async Task EmptyFile()
 	{
-		var result = await _jrsrParser.Parse(Embedded("emptyfile.jrsr"));
+		var result = await _jrsrParser.Parse(Embedded("emptyfile.jrsr"), EmbeddedLength("emptyfile.jrsr"));
 		Assert.IsFalse(result.Success);
 	}
 
 	[TestMethod]
 	public async Task CorrectMagic()
 	{
-		var result = await _jrsrParser.Parse(Embedded("correctmagic.jrsr"));
+		var result = await _jrsrParser.Parse(Embedded("correctmagic.jrsr"), EmbeddedLength("correctmagic.jrsr"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(result.FileExtension, "jrsr");
 		AssertNoWarningsOrErrors(result);
@@ -36,7 +36,7 @@ public class JrsrTests : BaseParserTests
 	[TestMethod]
 	public async Task WrongLineMagic()
 	{
-		var result = await _jrsrParser.Parse(Embedded("wronglinemagic.jrsr"));
+		var result = await _jrsrParser.Parse(Embedded("wronglinemagic.jrsr"), EmbeddedLength("wronglinemagic.jrsr"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.AreEqual(1, result.Errors.Count());
@@ -45,7 +45,7 @@ public class JrsrTests : BaseParserTests
 	[TestMethod]
 	public async Task WrongMagic()
 	{
-		var result = await _jrsrParser.Parse(Embedded("wrongmagic.jrsr"));
+		var result = await _jrsrParser.Parse(Embedded("wrongmagic.jrsr"), EmbeddedLength("wrongmagic.jrsr"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.AreEqual(1, result.Errors.Count());
@@ -54,7 +54,7 @@ public class JrsrTests : BaseParserTests
 	[TestMethod]
 	public async Task NoBeginHeader()
 	{
-		var result = await _jrsrParser.Parse(Embedded("nobeginheader.jrsr"));
+		var result = await _jrsrParser.Parse(Embedded("nobeginheader.jrsr"), EmbeddedLength("nobeginheader.jrsr"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.AreEqual(1, result.Errors.Count());
@@ -63,7 +63,7 @@ public class JrsrTests : BaseParserTests
 	[TestMethod]
 	public async Task Rerecords()
 	{
-		var result = await _jrsrParser.Parse(Embedded("correctmagic.jrsr"));
+		var result = await _jrsrParser.Parse(Embedded("correctmagic.jrsr"), EmbeddedLength("correctmagic.jrsr"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(17984, result.RerecordCount);
 		AssertNoWarningsOrErrors(result);
@@ -72,7 +72,7 @@ public class JrsrTests : BaseParserTests
 	[TestMethod]
 	public async Task Savestate()
 	{
-		var result = await _jrsrParser.Parse(Embedded("savestate.jrsr"));
+		var result = await _jrsrParser.Parse(Embedded("savestate.jrsr"), EmbeddedLength("savestate.jrsr"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(MovieStartType.Savestate, result.StartType);
 		AssertNoWarningsOrErrors(result);
@@ -81,7 +81,7 @@ public class JrsrTests : BaseParserTests
 	[TestMethod]
 	public async Task ContainsSavestate_ReturnError()
 	{
-		var result = await _jrsrParser.Parse(Embedded("containssavestate.jrsr"));
+		var result = await _jrsrParser.Parse(Embedded("containssavestate.jrsr"), EmbeddedLength("containssavestate.jrsr"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.AreEqual(1, result.Errors.Count());
@@ -90,7 +90,7 @@ public class JrsrTests : BaseParserTests
 	[TestMethod]
 	public async Task Frames()
 	{
-		var result = await _jrsrParser.Parse(Embedded("frames.jrsr"));
+		var result = await _jrsrParser.Parse(Embedded("frames.jrsr"), EmbeddedLength("frames.jrsr"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(147789, result.Frames);
 		Assert.AreEqual(60, result.FrameRateOverride);
@@ -100,7 +100,7 @@ public class JrsrTests : BaseParserTests
 	[TestMethod]
 	public async Task MissingRerecords()
 	{
-		var result = await _jrsrParser.Parse(Embedded("missingrerecords.jrsr"));
+		var result = await _jrsrParser.Parse(Embedded("missingrerecords.jrsr"), EmbeddedLength("missingrerecords.jrsr"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(0, result.RerecordCount, "Rerecord count assumed to be 0");
 		AssertNoErrors(result);
@@ -110,7 +110,7 @@ public class JrsrTests : BaseParserTests
 	[TestMethod]
 	public async Task NegativeRerecords()
 	{
-		var result = await _jrsrParser.Parse(Embedded("negativererecords.jrsr"));
+		var result = await _jrsrParser.Parse(Embedded("negativererecords.jrsr"), EmbeddedLength("negativererecords.jrsr"));
 		Assert.IsFalse(result.Success);
 		Assert.AreEqual(-1, result.RerecordCount, "Rerecord count assumed to be -1");
 		AssertNoWarnings(result);
@@ -124,7 +124,7 @@ public class JrsrTests : BaseParserTests
 	private static async Task<IParseResult> ParseFromString(string contents)
 	{
 		await using var reader = new MemoryStream(new UTF8Encoding(false, true).GetBytes(contents));
-		return await new Jrsr().Parse(reader);
+		return await new Jrsr().Parse(reader, reader.Length);
 	}
 
 	// It should be an error if RERECORDS appears more than once, even if

--- a/tests/TASVideos.MovieParsers.Tests/LsmvTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/LsmvTests.cs
@@ -16,7 +16,7 @@ public class LsmvTests : BaseParserTests
 	[TestMethod]
 	public async Task Errors()
 	{
-		var result = await _lsmvParser.Parse(Embedded("noinputlog.lsmv"));
+		var result = await _lsmvParser.Parse(Embedded("noinputlog.lsmv"), EmbeddedLength("noinputlog.lsmv"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.IsNotNull(result.Errors);
@@ -26,7 +26,7 @@ public class LsmvTests : BaseParserTests
 	[TestMethod]
 	public async Task SavestateCheck_Error()
 	{
-		var result = await _lsmvParser.Parse(Embedded("savestate.lsmv"));
+		var result = await _lsmvParser.Parse(Embedded("savestate.lsmv"), EmbeddedLength("savestate.lsmv"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.IsNotNull(result.Errors);
@@ -36,7 +36,7 @@ public class LsmvTests : BaseParserTests
 	[TestMethod]
 	public async Task Frames_WithSubFrames()
 	{
-		var result = await _lsmvParser.Parse(Embedded("2frameswithsub.lsmv"));
+		var result = await _lsmvParser.Parse(Embedded("2frameswithsub.lsmv"), EmbeddedLength("2frameswithsub.lsmv"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(2, result.Frames);
 		AssertNoWarningsOrErrors(result);
@@ -45,7 +45,7 @@ public class LsmvTests : BaseParserTests
 	[TestMethod]
 	public async Task Frames_NoInputFrames_Returns0()
 	{
-		var result = await _lsmvParser.Parse(Embedded("0frameswithsub.lsmv"));
+		var result = await _lsmvParser.Parse(Embedded("0frameswithsub.lsmv"), EmbeddedLength("0frameswithsub.lsmv"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(0, result.Frames);
 		AssertNoWarningsOrErrors(result);
@@ -54,7 +54,7 @@ public class LsmvTests : BaseParserTests
 	[TestMethod]
 	public async Task NoRerecordEntry_Warning()
 	{
-		var result = await _lsmvParser.Parse(Embedded("norerecordentry.lsmv"));
+		var result = await _lsmvParser.Parse(Embedded("norerecordentry.lsmv"), EmbeddedLength("norerecordentry.lsmv"));
 		Assert.IsTrue(result.Success);
 		AssertNoErrors(result);
 		Assert.IsNotNull(result.Warnings);
@@ -64,7 +64,7 @@ public class LsmvTests : BaseParserTests
 	[TestMethod]
 	public async Task EmptyRerecordEntry_Warning()
 	{
-		var result = await _lsmvParser.Parse(Embedded("emptyrerecordentry.lsmv"));
+		var result = await _lsmvParser.Parse(Embedded("emptyrerecordentry.lsmv"), EmbeddedLength("emptyrerecordentry.lsmv"));
 		Assert.IsTrue(result.Success);
 		AssertNoErrors(result);
 		Assert.IsNotNull(result.Warnings);
@@ -74,7 +74,7 @@ public class LsmvTests : BaseParserTests
 	[TestMethod]
 	public async Task InvalidRerecordEntry_Warning()
 	{
-		var result = await _lsmvParser.Parse(Embedded("invalidrerecordentry.lsmv"));
+		var result = await _lsmvParser.Parse(Embedded("invalidrerecordentry.lsmv"), EmbeddedLength("invalidrerecordentry.lsmv"));
 		Assert.IsTrue(result.Success);
 		AssertNoErrors(result);
 		Assert.IsNotNull(result.Warnings);
@@ -84,7 +84,7 @@ public class LsmvTests : BaseParserTests
 	[TestMethod]
 	public async Task ValidRerecordEntry()
 	{
-		var result = await _lsmvParser.Parse(Embedded("2frameswithsub.lsmv"));
+		var result = await _lsmvParser.Parse(Embedded("2frameswithsub.lsmv"), EmbeddedLength("2frameswithsub.lsmv"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(1, result.RerecordCount);
 		AssertNoWarningsOrErrors(result);
@@ -93,7 +93,7 @@ public class LsmvTests : BaseParserTests
 	[TestMethod]
 	public async Task MissingGameType_Error()
 	{
-		var result = await _lsmvParser.Parse(Embedded("gametype-missing.lsmv"));
+		var result = await _lsmvParser.Parse(Embedded("gametype-missing.lsmv"), EmbeddedLength("gametype-missing.lsmv"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.IsNotNull(result.Errors);
@@ -103,7 +103,7 @@ public class LsmvTests : BaseParserTests
 	[TestMethod]
 	public async Task InvalidGameType_DefaultsSnesNtsc()
 	{
-		var result = await _lsmvParser.Parse(Embedded("gametype-empty.lsmv"));
+		var result = await _lsmvParser.Parse(Embedded("gametype-empty.lsmv"), EmbeddedLength("gametype-empty.lsmv"));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(SystemCodes.Snes, result.SystemCode);
 		Assert.AreEqual(RegionType.Ntsc, result.Region);
@@ -125,7 +125,7 @@ public class LsmvTests : BaseParserTests
 	[DataRow("gametype-ggbca.lsmv", SystemCodes.Gbc, RegionType.Ntsc)]
 	public async Task SystemAndRegion(string file, string expectedSystem, RegionType expectedRegion)
 	{
-		var result = await _lsmvParser.Parse(Embedded(file));
+		var result = await _lsmvParser.Parse(Embedded(file), EmbeddedLength(file));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(expectedSystem, result.SystemCode);
 		Assert.AreEqual(expectedRegion, result.Region);
@@ -139,7 +139,7 @@ public class LsmvTests : BaseParserTests
 	[DataRow("moviesram-zerosrm.lsmv", MovieStartType.PowerOn)]
 	public async Task StartType(string file, MovieStartType expectedStartType)
 	{
-		var result = await _lsmvParser.Parse(Embedded(file));
+		var result = await _lsmvParser.Parse(Embedded(file), EmbeddedLength(file));
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(expectedStartType, result.StartType);
 		AssertNoWarningsOrErrors(result);

--- a/tests/TASVideos.MovieParsers.Tests/LtmTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/LtmTests.cs
@@ -22,7 +22,7 @@ public class LtmTests : BaseParserTests
 	[DataRow("dos.ltm", SystemCodes.Dos)]
 	public async Task SystemId(string filename, string expectedSystemCode)
 	{
-		var actual = await _ltmParser.Parse(Embedded(filename));
+		var actual = await _ltmParser.Parse(Embedded(filename), EmbeddedLength(filename));
 		Assert.IsNotNull(actual);
 		Assert.AreEqual(expectedSystemCode, actual.SystemCode);
 	}
@@ -30,7 +30,7 @@ public class LtmTests : BaseParserTests
 	[TestMethod]
 	public async Task Region()
 	{
-		var result = await _ltmParser.Parse(Embedded("2frames.ltm"));
+		var result = await _ltmParser.Parse(Embedded("2frames.ltm"), EmbeddedLength("2frames.ltm"));
 
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(RegionType.Ntsc, result.Region);
@@ -39,7 +39,7 @@ public class LtmTests : BaseParserTests
 	[TestMethod]
 	public async Task FrameCount()
 	{
-		var result = await _ltmParser.Parse(Embedded("2frames.ltm"));
+		var result = await _ltmParser.Parse(Embedded("2frames.ltm"), EmbeddedLength("2frames.ltm"));
 
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(SystemCodes.Linux, result.SystemCode);
@@ -49,7 +49,7 @@ public class LtmTests : BaseParserTests
 	[TestMethod]
 	public async Task RerecordCount()
 	{
-		var result = await _ltmParser.Parse(Embedded("2frames.ltm"));
+		var result = await _ltmParser.Parse(Embedded("2frames.ltm"), EmbeddedLength("2frames.ltm"));
 
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(SystemCodes.Linux, result.SystemCode);
@@ -60,7 +60,7 @@ public class LtmTests : BaseParserTests
 	[TestMethod]
 	public async Task FrameRate()
 	{
-		var result = await _ltmParser.Parse(Embedded("2frames.ltm"));
+		var result = await _ltmParser.Parse(Embedded("2frames.ltm"), EmbeddedLength("2frames.ltm"));
 
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(SystemCodes.Linux, result.SystemCode);
@@ -71,7 +71,7 @@ public class LtmTests : BaseParserTests
 	[TestMethod]
 	public async Task MissingFrameRate_Defaults()
 	{
-		var result = await _ltmParser.Parse(Embedded("noframerate.ltm"));
+		var result = await _ltmParser.Parse(Embedded("noframerate.ltm"), EmbeddedLength("noframerate.ltm"));
 
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(Ltm.DefaultFrameRate, result.FrameRateOverride);
@@ -83,7 +83,7 @@ public class LtmTests : BaseParserTests
 	[TestMethod]
 	public async Task PowerOn()
 	{
-		var result = await _ltmParser.Parse(Embedded("2frames.ltm"));
+		var result = await _ltmParser.Parse(Embedded("2frames.ltm"), EmbeddedLength("2frames.ltm"));
 
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(SystemCodes.Linux, result.SystemCode);
@@ -94,7 +94,7 @@ public class LtmTests : BaseParserTests
 	[TestMethod]
 	public async Task Savestate()
 	{
-		var result = await _ltmParser.Parse(Embedded("savestate.ltm"));
+		var result = await _ltmParser.Parse(Embedded("savestate.ltm"), EmbeddedLength("savestate.ltm"));
 
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(SystemCodes.Linux, result.SystemCode);
@@ -105,7 +105,7 @@ public class LtmTests : BaseParserTests
 	[TestMethod]
 	public async Task VariableFramerate()
 	{
-		var result = await _ltmParser.Parse(Embedded("variableframerate.ltm"));
+		var result = await _ltmParser.Parse(Embedded("variableframerate.ltm"), EmbeddedLength("variableframerate.ltm"));
 
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(SystemCodes.Linux, result.SystemCode);

--- a/tests/TASVideos.MovieParsers.Tests/M64Tests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/M64Tests.cs
@@ -16,7 +16,7 @@ public class M64Tests : BaseParserTests
 	[TestMethod]
 	public async Task InvalidHeader()
 	{
-		var result = await _m64Parser.Parse(Embedded("wrongheader.m64"));
+		var result = await _m64Parser.Parse(Embedded("wrongheader.m64"), EmbeddedLength("wrongheader.m64"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.IsNotNull(result.Errors);
@@ -26,7 +26,7 @@ public class M64Tests : BaseParserTests
 	[TestMethod]
 	public async Task ValidHeader()
 	{
-		var result = await _m64Parser.Parse(Embedded("2frames.m64"));
+		var result = await _m64Parser.Parse(Embedded("2frames.m64"), EmbeddedLength("2frames.m64"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 	}
@@ -34,7 +34,7 @@ public class M64Tests : BaseParserTests
 	[TestMethod]
 	public async Task System()
 	{
-		var result = await _m64Parser.Parse(Embedded("2frames.m64"));
+		var result = await _m64Parser.Parse(Embedded("2frames.m64"), EmbeddedLength("2frames.m64"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(SystemCodes.N64, result.SystemCode);
@@ -43,7 +43,7 @@ public class M64Tests : BaseParserTests
 	[TestMethod]
 	public async Task RerecordCount()
 	{
-		var result = await _m64Parser.Parse(Embedded("2frames.m64"));
+		var result = await _m64Parser.Parse(Embedded("2frames.m64"), EmbeddedLength("2frames.m64"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(1, result.RerecordCount);
@@ -52,7 +52,7 @@ public class M64Tests : BaseParserTests
 	[TestMethod]
 	public async Task Ntsc()
 	{
-		var result = await _m64Parser.Parse(Embedded("2frames.m64"));
+		var result = await _m64Parser.Parse(Embedded("2frames.m64"), EmbeddedLength("2frames.m64"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(RegionType.Ntsc, result.Region);
@@ -61,7 +61,7 @@ public class M64Tests : BaseParserTests
 	[TestMethod]
 	public async Task Pal()
 	{
-		var result = await _m64Parser.Parse(Embedded("pal.m64"));
+		var result = await _m64Parser.Parse(Embedded("pal.m64"), EmbeddedLength("pal.m64"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(RegionType.Pal, result.Region);
@@ -70,7 +70,7 @@ public class M64Tests : BaseParserTests
 	[TestMethod]
 	public async Task Length()
 	{
-		var result = await _m64Parser.Parse(Embedded("2frames.m64"));
+		var result = await _m64Parser.Parse(Embedded("2frames.m64"), EmbeddedLength("2frames.m64"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(2, result.Frames);
@@ -79,7 +79,7 @@ public class M64Tests : BaseParserTests
 	[TestMethod]
 	public async Task PowerOn()
 	{
-		var result = await _m64Parser.Parse(Embedded("2frames.m64"));
+		var result = await _m64Parser.Parse(Embedded("2frames.m64"), EmbeddedLength("2frames.m64"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
@@ -88,7 +88,7 @@ public class M64Tests : BaseParserTests
 	[TestMethod]
 	public async Task Sram()
 	{
-		var result = await _m64Parser.Parse(Embedded("sram.m64"));
+		var result = await _m64Parser.Parse(Embedded("sram.m64"), EmbeddedLength("sram.m64"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.Sram, result.StartType);
@@ -97,7 +97,7 @@ public class M64Tests : BaseParserTests
 	[TestMethod]
 	public async Task Savestate()
 	{
-		var result = await _m64Parser.Parse(Embedded("savestate.m64"));
+		var result = await _m64Parser.Parse(Embedded("savestate.m64"), EmbeddedLength("savestate.m64"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.Savestate, result.StartType);

--- a/tests/TASVideos.MovieParsers.Tests/MarTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/MarTests.cs
@@ -16,7 +16,7 @@ public class MarTests : BaseParserTests
 	[TestMethod]
 	public async Task InvalidHeader()
 	{
-		var result = await _marParser.Parse(Embedded("wrongheader.mar"));
+		var result = await _marParser.Parse(Embedded("wrongheader.mar"), EmbeddedLength("wrongheader.mar"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.IsNotNull(result.Errors);
@@ -26,7 +26,7 @@ public class MarTests : BaseParserTests
 	[TestMethod]
 	public async Task ValidHeader()
 	{
-		var result = await _marParser.Parse(Embedded("2frames.mar"));
+		var result = await _marParser.Parse(Embedded("2frames.mar"), EmbeddedLength("2frames.mar"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 	}
@@ -34,7 +34,7 @@ public class MarTests : BaseParserTests
 	[TestMethod]
 	public async Task System()
 	{
-		var result = await _marParser.Parse(Embedded("2frames.mar"));
+		var result = await _marParser.Parse(Embedded("2frames.mar"), EmbeddedLength("2frames.mar"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(SystemCodes.Arcade, result.SystemCode);
@@ -43,7 +43,7 @@ public class MarTests : BaseParserTests
 	[TestMethod]
 	public async Task Region()
 	{
-		var result = await _marParser.Parse(Embedded("2frames.mar"));
+		var result = await _marParser.Parse(Embedded("2frames.mar"), EmbeddedLength("2frames.mar"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(RegionType.Ntsc, result.Region);
@@ -52,7 +52,7 @@ public class MarTests : BaseParserTests
 	[TestMethod]
 	public async Task RerecordCount()
 	{
-		var result = await _marParser.Parse(Embedded("2frames.mar"));
+		var result = await _marParser.Parse(Embedded("2frames.mar"), EmbeddedLength("2frames.mar"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(33686018, result.RerecordCount);
@@ -61,7 +61,7 @@ public class MarTests : BaseParserTests
 	[TestMethod]
 	public async Task Length()
 	{
-		var result = await _marParser.Parse(Embedded("2frames.mar"));
+		var result = await _marParser.Parse(Embedded("2frames.mar"), EmbeddedLength("2frames.mar"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(16843009, result.Frames);
@@ -70,7 +70,7 @@ public class MarTests : BaseParserTests
 	[TestMethod]
 	public async Task FrameRate()
 	{
-		var result = await _marParser.Parse(Embedded("2frames.mar"));
+		var result = await _marParser.Parse(Embedded("2frames.mar"), EmbeddedLength("2frames.mar"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.IsNotNull(result.FrameRateOverride);
@@ -80,7 +80,7 @@ public class MarTests : BaseParserTests
 	[TestMethod]
 	public async Task WhenFrameRateIsZero_NoOverride()
 	{
-		var result = await _marParser.Parse(Embedded("noframerate.mar"));
+		var result = await _marParser.Parse(Embedded("noframerate.mar"), EmbeddedLength("noframerate.mar"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.IsNull(result.FrameRateOverride);

--- a/tests/TASVideos.MovieParsers.Tests/OmrTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/OmrTests.cs
@@ -16,7 +16,7 @@ public class OmrTests : BaseParserTests
 	[TestMethod]
 	public async Task SystemMsx()
 	{
-		var result = await _omrParser.Parse(Embedded("2seconds.omr"));
+		var result = await _omrParser.Parse(Embedded("2seconds.omr"), EmbeddedLength("2seconds.omr"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(SystemCodes.Msx, result.SystemCode);
@@ -25,7 +25,7 @@ public class OmrTests : BaseParserTests
 	[TestMethod]
 	public async Task SystemSvi()
 	{
-		var result = await _omrParser.Parse(Embedded("svi.omr"));
+		var result = await _omrParser.Parse(Embedded("svi.omr"), EmbeddedLength("svi.omr"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(SystemCodes.Svi, result.SystemCode);
@@ -34,7 +34,7 @@ public class OmrTests : BaseParserTests
 	[TestMethod]
 	public async Task SystemColeco()
 	{
-		var result = await _omrParser.Parse(Embedded("coleco.omr"));
+		var result = await _omrParser.Parse(Embedded("coleco.omr"), EmbeddedLength("coleco.omr"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(SystemCodes.Coleco, result.SystemCode);
@@ -43,7 +43,7 @@ public class OmrTests : BaseParserTests
 	[TestMethod]
 	public async Task Rerecords()
 	{
-		var result = await _omrParser.Parse(Embedded("2seconds.omr"));
+		var result = await _omrParser.Parse(Embedded("2seconds.omr"), EmbeddedLength("2seconds.omr"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(140, result.RerecordCount);
@@ -52,7 +52,7 @@ public class OmrTests : BaseParserTests
 	[TestMethod]
 	public async Task PowerOn()
 	{
-		var result = await _omrParser.Parse(Embedded("2seconds.omr"));
+		var result = await _omrParser.Parse(Embedded("2seconds.omr"), EmbeddedLength("2seconds.omr"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
@@ -61,7 +61,7 @@ public class OmrTests : BaseParserTests
 	[TestMethod]
 	public async Task Savestate()
 	{
-		var result = await _omrParser.Parse(Embedded("savestate.omr"));
+		var result = await _omrParser.Parse(Embedded("savestate.omr"), EmbeddedLength("savestate.omr"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.Savestate, result.StartType);
@@ -70,7 +70,7 @@ public class OmrTests : BaseParserTests
 	[TestMethod]
 	public async Task Ntsc()
 	{
-		var result = await _omrParser.Parse(Embedded("2seconds.omr"));
+		var result = await _omrParser.Parse(Embedded("2seconds.omr"), EmbeddedLength("2seconds.omr"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(RegionType.Ntsc, result.Region);
@@ -79,7 +79,7 @@ public class OmrTests : BaseParserTests
 	[TestMethod]
 	public async Task Pal()
 	{
-		var result = await _omrParser.Parse(Embedded("pal.omr"));
+		var result = await _omrParser.Parse(Embedded("pal.omr"), EmbeddedLength("pal.omr"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(RegionType.Pal, result.Region);
@@ -88,7 +88,7 @@ public class OmrTests : BaseParserTests
 	[TestMethod]
 	public async Task Frames()
 	{
-		var result = await _omrParser.Parse(Embedded("2seconds.omr"));
+		var result = await _omrParser.Parse(Embedded("2seconds.omr"), EmbeddedLength("2seconds.omr"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(120, result.Frames);

--- a/tests/TASVideos.MovieParsers.Tests/VbmTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/VbmTests.cs
@@ -16,7 +16,7 @@ public class VbmTests : BaseParserTests
 	[TestMethod]
 	public async Task InvalidHeader()
 	{
-		var result = await _vbmParser.Parse(Embedded("wrongheader.vbm"));
+		var result = await _vbmParser.Parse(Embedded("wrongheader.vbm"), EmbeddedLength("wrongheader.vbm"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.IsNotNull(result.Errors);
@@ -26,7 +26,7 @@ public class VbmTests : BaseParserTests
 	[TestMethod]
 	public async Task ValidHeader()
 	{
-		var result = await _vbmParser.Parse(Embedded("2frames.vbm"));
+		var result = await _vbmParser.Parse(Embedded("2frames.vbm"), EmbeddedLength("2frames.vbm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 	}
@@ -34,7 +34,7 @@ public class VbmTests : BaseParserTests
 	[TestMethod]
 	public async Task Ntsc()
 	{
-		var result = await _vbmParser.Parse(Embedded("2frames.vbm"));
+		var result = await _vbmParser.Parse(Embedded("2frames.vbm"), EmbeddedLength("2frames.vbm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(RegionType.Ntsc, result.Region);
@@ -43,7 +43,7 @@ public class VbmTests : BaseParserTests
 	[TestMethod]
 	public async Task RerecordCount()
 	{
-		var result = await _vbmParser.Parse(Embedded("2frames.vbm"));
+		var result = await _vbmParser.Parse(Embedded("2frames.vbm"), EmbeddedLength("2frames.vbm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(39098, result.RerecordCount);
@@ -52,7 +52,7 @@ public class VbmTests : BaseParserTests
 	[TestMethod]
 	public async Task Length()
 	{
-		var result = await _vbmParser.Parse(Embedded("2frames.vbm"));
+		var result = await _vbmParser.Parse(Embedded("2frames.vbm"), EmbeddedLength("2frames.vbm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(95490, result.Frames);
@@ -61,7 +61,7 @@ public class VbmTests : BaseParserTests
 	[TestMethod]
 	public async Task PowerOn()
 	{
-		var result = await _vbmParser.Parse(Embedded("2frames.vbm"));
+		var result = await _vbmParser.Parse(Embedded("2frames.vbm"), EmbeddedLength("2frames.vbm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
@@ -70,7 +70,7 @@ public class VbmTests : BaseParserTests
 	[TestMethod]
 	public async Task Savestate()
 	{
-		var result = await _vbmParser.Parse(Embedded("savestate.vbm"));
+		var result = await _vbmParser.Parse(Embedded("savestate.vbm"), EmbeddedLength("savestate.vbm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.Savestate, result.StartType);
@@ -79,7 +79,7 @@ public class VbmTests : BaseParserTests
 	[TestMethod]
 	public async Task Sram()
 	{
-		var result = await _vbmParser.Parse(Embedded("sram.vbm"));
+		var result = await _vbmParser.Parse(Embedded("sram.vbm"), EmbeddedLength("sram.vbm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.Sram, result.StartType);
@@ -88,7 +88,7 @@ public class VbmTests : BaseParserTests
 	[TestMethod]
 	public async Task Gba()
 	{
-		var result = await _vbmParser.Parse(Embedded("2frames.vbm"));
+		var result = await _vbmParser.Parse(Embedded("2frames.vbm"), EmbeddedLength("2frames.vbm"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(SystemCodes.Gba, result.SystemCode);

--- a/tests/TASVideos.MovieParsers.Tests/WtfTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/WtfTests.cs
@@ -16,7 +16,7 @@ public class WtfTests : BaseParserTests
 	[TestMethod]
 	public async Task InvalidHeader()
 	{
-		var result = await _wtfParser.Parse(Embedded("wrongheader.wtf"));
+		var result = await _wtfParser.Parse(Embedded("wrongheader.wtf"), EmbeddedLength("wrongheader.wtf"));
 		Assert.IsFalse(result.Success);
 		AssertNoWarnings(result);
 		Assert.IsNotNull(result.Errors);
@@ -26,7 +26,7 @@ public class WtfTests : BaseParserTests
 	[TestMethod]
 	public async Task ValidHeader()
 	{
-		var result = await _wtfParser.Parse(Embedded("2frames.wtf"));
+		var result = await _wtfParser.Parse(Embedded("2frames.wtf"), EmbeddedLength("2frames.wtf"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 	}
@@ -34,7 +34,7 @@ public class WtfTests : BaseParserTests
 	[TestMethod]
 	public async Task System()
 	{
-		var result = await _wtfParser.Parse(Embedded("2frames.wtf"));
+		var result = await _wtfParser.Parse(Embedded("2frames.wtf"), EmbeddedLength("2frames.wtf"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(SystemCodes.Windows, result.SystemCode);
@@ -43,7 +43,7 @@ public class WtfTests : BaseParserTests
 	[TestMethod]
 	public async Task RerecordCount()
 	{
-		var result = await _wtfParser.Parse(Embedded("2frames.wtf"));
+		var result = await _wtfParser.Parse(Embedded("2frames.wtf"), EmbeddedLength("2frames.wtf"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(984, result.RerecordCount);
@@ -52,7 +52,7 @@ public class WtfTests : BaseParserTests
 	[TestMethod]
 	public async Task Ntsc()
 	{
-		var result = await _wtfParser.Parse(Embedded("2frames.wtf"));
+		var result = await _wtfParser.Parse(Embedded("2frames.wtf"), EmbeddedLength("2frames.wtf"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(RegionType.Ntsc, result.Region);
@@ -61,7 +61,7 @@ public class WtfTests : BaseParserTests
 	[TestMethod]
 	public async Task PowerOn()
 	{
-		var result = await _wtfParser.Parse(Embedded("2frames.wtf"));
+		var result = await _wtfParser.Parse(Embedded("2frames.wtf"), EmbeddedLength("2frames.wtf"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
@@ -70,7 +70,7 @@ public class WtfTests : BaseParserTests
 	[TestMethod]
 	public async Task FrameRate()
 	{
-		var result = await _wtfParser.Parse(Embedded("2frames.wtf"));
+		var result = await _wtfParser.Parse(Embedded("2frames.wtf"), EmbeddedLength("2frames.wtf"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.IsNotNull(result.FrameRateOverride);
@@ -80,7 +80,7 @@ public class WtfTests : BaseParserTests
 	[TestMethod]
 	public async Task WhenFrameRateIsZero_NoOverride()
 	{
-		var result = await _wtfParser.Parse(Embedded("noframerate.wtf"));
+		var result = await _wtfParser.Parse(Embedded("noframerate.wtf"), EmbeddedLength("noframerate.wtf"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.IsNull(result.FrameRateOverride);
@@ -89,7 +89,7 @@ public class WtfTests : BaseParserTests
 	[TestMethod]
 	public async Task Length()
 	{
-		var result = await _wtfParser.Parse(Embedded("2frames.wtf"));
+		var result = await _wtfParser.Parse(Embedded("2frames.wtf"), EmbeddedLength("2frames.wtf"));
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(2, result.Frames);


### PR DESCRIPTION
In their infinite wisdom, MS designed their ZipArchive's streams to not always support reading the length, even though it's always known when reading?

Change the tests to spot this, and then fix everywhere they were failing.

Closes #1175