### PR TITLE
Fix forum video tags in various situations, especially preview

### DIFF
--- a/TASVideos.ForumEngine/Node.cs
+++ b/TASVideos.ForumEngine/Node.cs
@@ -422,6 +422,9 @@ public class Element : INode
 							pp.Height = height;
 						}
 
+						// Bit of a hack:  Since the videowriter uses the htmlwriter's base writer, we need to get it into
+						// the right state first
+						w.Text("");
 						WriteVideo.Write(w.BaseWriter, pp);
 					}
 


### PR DESCRIPTION
The video writer expects the text writer to be in a node content state, but nothing is enforcing that.

Closes #1214 
