### PR TITLE
Playground Submission Status Minimal Implementation

### DIFF
--- a/TASVideos.Common/Constants.cs
+++ b/TASVideos.Common/Constants.cs
@@ -36,6 +36,7 @@ public static class SiteGlobalConstants
 	public const int GrueFoodForumId = 24;
 	public const int WorkbenchForumId = 7;
 	public const int PublishedMoviesForumId = 16;
+	public const int PlaygroundForumId = 74;
 
 	public const string NewPublicationPostSubject = "Movie published";
 	public const string NewPublicationPost = @"[b]This movie has been published.[/b]

--- a/TASVideos.Core/Services/QueueService.cs
+++ b/TASVideos.Core/Services/QueueService.cs
@@ -119,13 +119,14 @@ internal class QueueService : IQueueService
 			|| currentStatus == PublicationUnderway && isJudge // A judge can undo even if publication underway
 			|| isJudge && currentStatus == Delayed // Judges can set delayed -> new
 			|| isJudge && currentStatus == NeedsMoreInfo // Judges can set info -> new
-			|| (isJudge || isAuthorOrSubmitter) && currentStatus == Cancelled)
+			|| (isJudge || isAuthorOrSubmitter) && currentStatus == Cancelled
+			|| isJudge && currentStatus == Playground)
 		{
 			list.Add(New);
 		}
 
 		// A judge can claim a new run, unless they are not author or the submitter
-		if (new[] { New, JudgingUnderWay, Delayed, NeedsMoreInfo, Accepted, Rejected, PublicationUnderway, Cancelled }.Contains(currentStatus)
+		if (new[] { New, JudgingUnderWay, Delayed, NeedsMoreInfo, Accepted, Rejected, PublicationUnderway, Cancelled, Playground }.Contains(currentStatus)
 			&& canJudge
 			&& !isAuthorOrSubmitter)
 		{
@@ -174,6 +175,13 @@ internal class QueueService : IQueueService
 			&& new[] { New, JudgingUnderWay, Delayed, NeedsMoreInfo, Accepted, PublicationUnderway }.Contains(currentStatus))
 		{
 			list.Add(Cancelled);
+		}
+
+		if (new[] { JudgingUnderWay, Delayed, NeedsMoreInfo }.Contains(currentStatus)
+			&& isJudge
+			&& isAfterJudgmentWindow)
+		{
+			list.Add(Playground);
 		}
 
 		return list;

--- a/TASVideos.Core/Services/TASVideoAgent.cs
+++ b/TASVideos.Core/Services/TASVideoAgent.cs
@@ -90,6 +90,14 @@ internal class TASVideoAgent : ITASVideoAgent
 		if (topic is not null)
 		{
 			topic.ForumId = SiteGlobalConstants.PublishedMoviesForumId;
+			var postsToMove = await _db.ForumPosts
+				.ForTopic(topic.Id)
+				.ToListAsync();
+			foreach (var post in postsToMove)
+			{
+				post.ForumId = SiteGlobalConstants.PublishedMoviesForumId;
+			}
+
 			_db.ForumPosts.Add(new ForumPost
 			{
 				TopicId = topic.Id,
@@ -117,6 +125,14 @@ internal class TASVideoAgent : ITASVideoAgent
 		if (topic is not null)
 		{
 			topic.ForumId = SiteGlobalConstants.WorkbenchForumId;
+			var postsToMove = await _db.ForumPosts
+				.ForTopic(topic.Id)
+				.ToListAsync();
+			foreach (var post in postsToMove)
+			{
+				post.ForumId = SiteGlobalConstants.WorkbenchForumId;
+			}
+
 			_db.ForumPosts.Add(new ForumPost
 			{
 				TopicId = topic.Id,

--- a/TASVideos.Core/Services/TASVideosGrue.cs
+++ b/TASVideos.Core/Services/TASVideosGrue.cs
@@ -44,6 +44,14 @@ internal class TASVideosGrue : ITASVideosGrue
 		if (topic is not null)
 		{
 			topic.ForumId = SiteGlobalConstants.GrueFoodForumId;
+			var postsToMove = await _db.ForumPosts
+				.ForTopic(topic.Id)
+				.ToListAsync();
+			foreach (var post in postsToMove)
+			{
+				post.ForumId = SiteGlobalConstants.GrueFoodForumId;
+			}
+
 			var entry = _db.ForumPosts.Add(new ForumPost
 			{
 				TopicId = topic.Id,

--- a/TASVideos.Data/Entity/SubmissionStatus.cs
+++ b/TASVideos.Data/Entity/SubmissionStatus.cs
@@ -27,7 +27,10 @@ public enum SubmissionStatus
 	Rejected,
 
 	[Display(Name = "Cancelled")]
-	Cancelled
+	Cancelled,
+
+	[Display(Name = "Playground")]
+	Playground,
 }
 
 public static class SubmissionStatusExtensions

--- a/TASVideos/Pages/Submissions/Edit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Edit.cshtml.cs
@@ -285,9 +285,14 @@ public class EditModel : BasePageModel
 			statusHasChanged = true;
 			_db.SubmissionStatusHistory.Add(submission.Id, Submission.Status);
 
-			if (Submission.Status != SubmissionStatus.Rejected &&
+			if (Submission.Status == SubmissionStatus.Playground)
+			{
+				submission.Topic!.ForumId = SiteGlobalConstants.PlaygroundForumId;
+			}
+			else if (Submission.Status != SubmissionStatus.Rejected &&
 				Submission.Status != SubmissionStatus.Cancelled &&
-				submission.Topic!.ForumId == SiteGlobalConstants.GrueFoodForumId)
+				(submission.Topic!.ForumId == SiteGlobalConstants.GrueFoodForumId
+				|| submission.Topic!.ForumId == SiteGlobalConstants.PlaygroundForumId))
 			{
 				submission.Topic.ForumId = SiteGlobalConstants.WorkbenchForumId;
 			}
@@ -366,7 +371,8 @@ public class EditModel : BasePageModel
 					or SubmissionStatus.Rejected
 					or SubmissionStatus.Cancelled
 					or SubmissionStatus.Delayed
-					or SubmissionStatus.NeedsMoreInfo)
+					or SubmissionStatus.NeedsMoreInfo
+					or SubmissionStatus.Playground)
 				{
 					statusStr = statusStr.ToUpper();
 				}
@@ -382,7 +388,8 @@ public class EditModel : BasePageModel
 				}
 				else if (Submission.Status is SubmissionStatus.NeedsMoreInfo
 						or SubmissionStatus.New
-						or SubmissionStatus.PublicationUnderway)
+						or SubmissionStatus.PublicationUnderway
+						or SubmissionStatus.Playground)
 				{
 					statusStr = "set to " + statusStr;
 				}

--- a/TASVideos/Pages/Submissions/Edit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Edit.cshtml.cs
@@ -7,6 +7,7 @@ using TASVideos.Core.Services.ExternalMediaPublisher;
 using TASVideos.Core.Services.Youtube;
 using TASVideos.Data;
 using TASVideos.Data.Entity;
+using TASVideos.Data.Entity.Forum;
 using TASVideos.MovieParsers;
 using TASVideos.Pages.Submissions.Models;
 
@@ -24,6 +25,7 @@ public class EditModel : BasePageModel
 	private readonly IMovieFormatDeprecator _deprecator;
 	private readonly IQueueService _queueService;
 	private readonly IYoutubeSync _youtubeSync;
+	private readonly IForumService _forumService;
 
 	public EditModel(
 		ApplicationDbContext db,
@@ -33,7 +35,8 @@ public class EditModel : BasePageModel
 		ITASVideosGrue tasvideosGrue,
 		IMovieFormatDeprecator deprecator,
 		IQueueService queueService,
-		IYoutubeSync youtubeSync)
+		IYoutubeSync youtubeSync,
+		IForumService forumService)
 	{
 		_db = db;
 		_parser = parser;
@@ -43,6 +46,7 @@ public class EditModel : BasePageModel
 		_deprecator = deprecator;
 		_queueService = queueService;
 		_youtubeSync = youtubeSync;
+		_forumService = forumService;
 	}
 
 	[FromRoute]
@@ -279,22 +283,43 @@ public class EditModel : BasePageModel
 			submission.Publisher = null;
 		}
 
-		bool statusHasChanged = false;
-		if (submission.Status != Submission.Status)
+		bool statusHasChanged = submission.Status != Submission.Status;
+		bool moveTopic = false;
+		if (statusHasChanged)
 		{
-			statusHasChanged = true;
 			_db.SubmissionStatusHistory.Add(submission.Id, Submission.Status);
 
-			if (Submission.Status == SubmissionStatus.Playground)
+			int moveTopicTo = -1;
+
+			if (submission.Topic!.ForumId != SiteGlobalConstants.PlaygroundForumId &&
+				Submission.Status == SubmissionStatus.Playground)
 			{
-				submission.Topic!.ForumId = SiteGlobalConstants.PlaygroundForumId;
+				moveTopic = true;
+				moveTopicTo = SiteGlobalConstants.PlaygroundForumId;
 			}
-			else if (Submission.Status != SubmissionStatus.Rejected &&
-				Submission.Status != SubmissionStatus.Cancelled &&
-				(submission.Topic!.ForumId == SiteGlobalConstants.GrueFoodForumId
-				|| submission.Topic!.ForumId == SiteGlobalConstants.PlaygroundForumId))
+			else if (submission.Topic.ForumId != SiteGlobalConstants.WorkbenchForumId &&
+				(Submission.Status == SubmissionStatus.New ||
+				Submission.Status == SubmissionStatus.Delayed ||
+				Submission.Status == SubmissionStatus.NeedsMoreInfo ||
+				Submission.Status == SubmissionStatus.JudgingUnderWay ||
+				Submission.Status == SubmissionStatus.Accepted ||
+				Submission.Status == SubmissionStatus.PublicationUnderway))
 			{
-				submission.Topic.ForumId = SiteGlobalConstants.WorkbenchForumId;
+				moveTopic = true;
+				moveTopicTo = SiteGlobalConstants.WorkbenchForumId;
+			}
+
+			// reject/cancel topic move is handled later with TVG's post
+			if (moveTopic)
+			{
+				submission.Topic.ForumId = moveTopicTo;
+				var postsToMove = await _db.ForumPosts
+					.ForTopic(submission.Topic.Id)
+					.ToListAsync();
+				foreach (var post in postsToMove)
+				{
+					post.ForumId = moveTopicTo;
+				}
 			}
 		}
 
@@ -351,6 +376,12 @@ public class EditModel : BasePageModel
 		{
 			topic.Title = submission.Title;
 			await _db.SaveChangesAsync();
+		}
+
+		if (moveTopic)
+		{
+			_forumService.ClearLatestPostCache();
+			_forumService.ClearTopicActivityCache();
 		}
 
 		if (submission.Status is SubmissionStatus.Rejected or SubmissionStatus.Cancelled

--- a/tests/TASVideos.Core.Tests/Services/QueueServiceTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/QueueServiceTests.cs
@@ -65,6 +65,7 @@ public class QueueServiceTests
 	[DataRow(PublicationUnderway, new[] { Cancelled })]
 	[DataRow(Rejected, new SubmissionStatus[0])]
 	[DataRow(Cancelled, new[] { New })]
+	[DataRow(Playground, new SubmissionStatus[0])]
 	[TestMethod]
 	public void Submitter_BasicPerms(SubmissionStatus current, IEnumerable<SubmissionStatus> canChangeTo)
 	{
@@ -93,6 +94,7 @@ public class QueueServiceTests
 	[DataRow(PublicationUnderway, new[] { Cancelled })]
 	[DataRow(Rejected, new SubmissionStatus[0])]
 	[DataRow(Cancelled, new[] { New })]
+	[DataRow(Playground, new SubmissionStatus[0])]
 	[TestMethod]
 	public void Submitter_IsJudge(SubmissionStatus current, IEnumerable<SubmissionStatus> canChangeTo)
 	{
@@ -121,6 +123,7 @@ public class QueueServiceTests
 	[DataRow(PublicationUnderway, new[] { Cancelled })]
 	[DataRow(Rejected, new SubmissionStatus[0])]
 	[DataRow(Cancelled, new[] { New })]
+	[DataRow(Playground, new SubmissionStatus[0])]
 	[TestMethod]
 	public void Submitter_IsPublisher(SubmissionStatus current, IEnumerable<SubmissionStatus> canChangeTo)
 	{
@@ -149,6 +152,7 @@ public class QueueServiceTests
 	[DataRow(PublicationUnderway, new[] { New, JudgingUnderWay, Cancelled })]
 	[DataRow(Rejected, new[] { New, JudgingUnderWay })]
 	[DataRow(Cancelled, new[] { New, JudgingUnderWay })]
+	[DataRow(Playground, new[] { New, JudgingUnderWay })]
 	[TestMethod]
 	public void Judge_ButNotSubmitter_BeforeAllowedJudgmentWindow(SubmissionStatus current, IEnumerable<SubmissionStatus> canChangeTo)
 	{
@@ -170,13 +174,14 @@ public class QueueServiceTests
 	}
 
 	[DataRow(New, new[] { JudgingUnderWay, Cancelled })]
-	[DataRow(Delayed, new[] { New, NeedsMoreInfo, JudgingUnderWay, Accepted, Rejected, Cancelled })]
-	[DataRow(NeedsMoreInfo, new[] { New, Delayed, JudgingUnderWay, Accepted, Rejected, Cancelled })]
-	[DataRow(JudgingUnderWay, new[] { New, Delayed, NeedsMoreInfo, Accepted, Rejected, Cancelled })]
+	[DataRow(Delayed, new[] { New, NeedsMoreInfo, JudgingUnderWay, Accepted, Rejected, Cancelled, Playground })]
+	[DataRow(NeedsMoreInfo, new[] { New, Delayed, JudgingUnderWay, Accepted, Rejected, Cancelled, Playground })]
+	[DataRow(JudgingUnderWay, new[] { New, Delayed, NeedsMoreInfo, Accepted, Rejected, Cancelled, Playground })]
 	[DataRow(Accepted, new[] { New, Delayed, NeedsMoreInfo, JudgingUnderWay, Rejected, Cancelled })]
 	[DataRow(PublicationUnderway, new[] { New, Delayed, NeedsMoreInfo, JudgingUnderWay, Accepted, Rejected, Cancelled })]
 	[DataRow(Rejected, new[] { New, JudgingUnderWay })]
 	[DataRow(Cancelled, new[] { New, JudgingUnderWay })]
+	[DataRow(Playground, new[] { New, JudgingUnderWay })]
 	[TestMethod]
 	public void Judge_ButNotSubmitter_AfterAllowedJudgmentWindow(SubmissionStatus current, IEnumerable<SubmissionStatus> canChangeTo)
 	{
@@ -205,6 +210,7 @@ public class QueueServiceTests
 	[DataRow(PublicationUnderway, new[] { Accepted })]
 	[DataRow(Rejected, new SubmissionStatus[0])]
 	[DataRow(Cancelled, new SubmissionStatus[0])]
+	[DataRow(Playground, new SubmissionStatus[0])]
 	[TestMethod]
 	public void Publisher_ButNotSubmitter_BeforeAllowedJudgmentWindow_CanNotChangeStatus(SubmissionStatus current, IEnumerable<SubmissionStatus> canChangeTo)
 	{
@@ -233,6 +239,7 @@ public class QueueServiceTests
 	[DataRow(PublicationUnderway, new[] { Accepted })]
 	[DataRow(Rejected, new SubmissionStatus[0])]
 	[DataRow(Cancelled, new SubmissionStatus[0])]
+	[DataRow(Playground, new SubmissionStatus[0])]
 	[TestMethod]
 	public void Publisher_ButNotSubmitter_AfterAllowedJudgmentWindow(SubmissionStatus current, IEnumerable<SubmissionStatus> canChangeTo)
 	{

--- a/tests/TASVideos.Core.Tests/Services/TASVideoAgentTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/TASVideoAgentTests.cs
@@ -105,10 +105,19 @@ public class TASVideoAgentTests
 	[TestMethod]
 	public async Task PostSubmissionPublished_TopicCreated()
 	{
+		var topicId = 1;
+		var forumId = 1;
 		var topic = _db.ForumTopics.Add(new ForumTopic
 		{
+			Id = topicId,
+			ForumId = forumId,
 			Title = "Title",
 			SubmissionId = SubmissionId
+		});
+		var post = _db.ForumPosts.Add(new ForumPost
+		{
+			TopicId = topicId,
+			ForumId = forumId,
 		});
 		await _db.SaveChangesAsync();
 
@@ -117,6 +126,7 @@ public class TASVideoAgentTests
 
 		Assert.IsNotNull(actual);
 		Assert.AreEqual(SiteGlobalConstants.PublishedMoviesForumId, topic.Entity.ForumId);
+		Assert.AreEqual(SiteGlobalConstants.PublishedMoviesForumId, post.Entity.ForumId);
 		Assert.AreEqual(SiteGlobalConstants.TASVideoAgent, actual.CreateUserName);
 		Assert.AreEqual(SiteGlobalConstants.TASVideoAgent, actual.LastUpdateUserName);
 		Assert.AreEqual(SiteGlobalConstants.TASVideoAgentId, actual.PosterId);

--- a/tests/TASVideos.Core.Tests/Services/TASVideosGrueTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/TASVideosGrueTests.cs
@@ -30,10 +30,19 @@ public class TASVideosGrueTests
 	[TestMethod]
 	public async Task PostSubmissionRejection_TopicCreated()
 	{
+		var topicId = 1;
+		var forumId = 1;
 		var topic = _db.ForumTopics.Add(new ForumTopic
 		{
+			Id = topicId,
+			ForumId = forumId,
 			Title = "Title",
 			SubmissionId = SubmissionId
+		});
+		var post = _db.ForumPosts.Add(new ForumPost
+		{
+			TopicId = topicId,
+			ForumId = forumId,
 		});
 		await _db.SaveChangesAsync();
 
@@ -42,6 +51,7 @@ public class TASVideosGrueTests
 
 		Assert.IsNotNull(actual);
 		Assert.AreEqual(SiteGlobalConstants.GrueFoodForumId, topic.Entity.ForumId);
+		Assert.AreEqual(SiteGlobalConstants.GrueFoodForumId, post.Entity.ForumId);
 		Assert.AreEqual(SiteGlobalConstants.TASVideosGrue, actual.CreateUserName);
 		Assert.AreEqual(SiteGlobalConstants.TASVideosGrue, actual.LastUpdateUserName);
 		Assert.AreEqual(SiteGlobalConstants.TASVideosGrueId, actual.PosterId);


### PR DESCRIPTION
**Important**: Currently this PR assumes a Playground subforum to exist. It should be created before merging. The code assumes the ID to be 74 but it can be adjusted once the subforum is created.
<hr>

Implements a minimal working version of the suggested Playground submission status, aiming to resolve #1131.

Currently it only allows a judge to set the status if they claimed the submission. The submission topic will be moved automatically, without any post from TVA or TVG. The notification will be "Submission set to PLAYGROUND".

Once in the Playground judges have the ability to reclaim and judge the submission, it will then be moved into the workbench again. The designated judge can also reset it to New because that's what they can always do.

There are currently no shortcuts from or to Rejected/Cancelled and it will always have to go through JudgingUnderWay. This is because it can complicate things with the designated judge system we have (and which doesn't even have tests, so the code intent isn't always clear).