### PR TITLE
Hide poll results until requested or voted

### DIFF
--- a/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
@@ -48,6 +48,9 @@ public class IndexModel : BaseForumModel
 	[FromQuery]
 	public TopicRequest Search { get; set; } = new();
 
+	[FromQuery]
+	public bool ViewPollResults { get; set; } = false;
+
 	public ForumTopicModel Topic { get; set; } = new();
 
 	public WikiPage? WikiPage { get; set; }
@@ -84,7 +87,8 @@ public class IndexModel : BaseForumModel
 						PollId = t.PollId.Value,
 						Question = t.Poll!.Question,
 						CloseDate = t.Poll!.CloseDate,
-						MultiSelect = t.Poll!.MultiSelect
+						MultiSelect = t.Poll!.MultiSelect,
+						ViewPollResults = ViewPollResults,
 					}
 					: null
 			})

--- a/TASVideos/Pages/Forum/Topics/Models/ForumTopicModel.cs
+++ b/TASVideos/Pages/Forum/Topics/Models/ForumTopicModel.cs
@@ -49,6 +49,7 @@ public class ForumTopicModel : IForumTopicActionBar, IForumTopicBreadCrumb
 		public string Question { get; set; } = "";
 		public DateTime? CloseDate { get; set; }
 		public bool MultiSelect { get; set; }
+		public bool ViewPollResults { get; set; }
 
 		public IEnumerable<PollOptionModel> Options { get; set; } = new List<PollOptionModel>();
 

--- a/TASVideos/Pages/Forum/Topics/_Poll.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_Poll.cshtml
@@ -1,6 +1,7 @@
 ﻿@model ForumTopicModel.PollModel
 @{
 	int totalVotes = Model!.Options.SelectMany(m => m.Voters).Count();
+	bool viewResults = Model.ViewPollResults;
 	bool canVote = false;
 	int userId = -1;
 	if (User.IsLoggedIn())
@@ -10,6 +11,10 @@
 		bool hasAlreadyVoted = Model.Options.Any(o => o.Voters.Any(v => v == userId));
 		bool pollIsClosed = Model.CloseDate <= DateTime.UtcNow;
 		canVote = votePermission && !hasAlreadyVoted && !pollIsClosed;
+	}
+	if (!canVote)
+	{
+		viewResults = true;
 	}
 }
 
@@ -26,14 +31,14 @@
 			}
 
 			<row class="align-items-center my-3">
-				<div class="col-12 col-md-3 col-lg-4 p-0 text-md-end">
+				<div class="col-12@(viewResults ? " col-md-3 col-lg-4 p-0 text-md-end" : "")">
 					<label for="_@option.Ordinal">
 						<span condition="option.Voters.Any(v => v == userId)" class="fa fa-check text-success"></span>
-						<span condition="canVote"><input type="@(Model.MultiSelect ? "checkbox" : "radio")" name="ordinal" id="_@option.Ordinal" value="@option.Ordinal" /></span>
+						<span condition="canVote && !viewResults"><input type="@(Model.MultiSelect ? "checkbox" : "radio")" name="ordinal" id="_@option.Ordinal" value="@option.Ordinal" /></span>
 						@option.Text
 					</label>
 				</div>
-				<div class="col-12 col-md-9 col-lg-8">
+				<div condition="viewResults" class="col-12 col-md-9 col-lg-8">
 					<row class="align-items-center justify-content-center">
 						<div class="col-6 col-md-8 col-lg-6"><span class="progress"><span class="progress-bar" role="progressbar" style="width: @(percent)%" aria-valuenow="@(percent)" aria-valuemin="0" aria-valuemax="100"></span></span></div>
 						<div class="col-3 col-md-4 col-lg-6 p-0 text-center text-md-start">
@@ -54,6 +59,16 @@
 		</script>
 		<button condition="canVote" hidden="hidden" type="submit" class="btn btn-sm btn-success" id="vote-btn">Vote!</button>
 	</form>
+	<a condition="!viewResults"
+		asp-route-ViewPollResults="True"
+		class="btn btn-sm btn-outline-info mt-2">
+		View Results
+	</a>
+	<a condition="viewResults && canVote"
+		asp-route-ViewPollResults=""
+		class="btn btn-sm btn-outline-info mt-2">
+		Return To Voting
+	</a>
 	<a condition="ViewData.UserHas(PermissionTo.SeePollResults) && totalVotes > 0"
 		asp-page="PollResults"
 		asp-route-id="@Model.PollId"


### PR DESCRIPTION
Resolves #1022.
If you're able to vote it hides the results by default. But also adds a button to view the results regardless.
Aligns with old site behavior.