### PR TITLE
Change Email Workflow

### DIFF
--- a/TASVideos.Core/Services/UserManager.cs
+++ b/TASVideos.Core/Services/UserManager.cs
@@ -476,4 +476,19 @@ public class UserManager : UserManager<User>
 			})
 			.ToListAsync();
 	}
+
+	/// <summary>
+	/// Sets the user email from code and if successful, sets it to confirmed. You would think the built in code would do this.
+	/// </summary>
+	public async Task<IdentityResult> SetAndConfirmEmailAsync(User user, string newEmail)
+	{
+		var result = await SetEmailAsync(user, newEmail);
+		if (result.Succeeded)
+		{
+			user.EmailConfirmed = true;
+			await _db.SaveChangesAsync();
+		}
+
+		return result;
+	}
 }

--- a/TASVideos.Core/Services/UserManager.cs
+++ b/TASVideos.Core/Services/UserManager.cs
@@ -476,19 +476,4 @@ public class UserManager : UserManager<User>
 			})
 			.ToListAsync();
 	}
-
-	/// <summary>
-	/// Sets the user email from code and if successful, sets it to confirmed. You would think the built in code would do this.
-	/// </summary>
-	public async Task<IdentityResult> SetAndConfirmEmailAsync(User user, string newEmail)
-	{
-		var result = await SetEmailAsync(user, newEmail);
-		if (result.Succeeded)
-		{
-			user.EmailConfirmed = true;
-			await _db.SaveChangesAsync();
-		}
-
-		return result;
-	}
 }

--- a/TASVideos/Extensions/UrlHelperExtensions.cs
+++ b/TASVideos/Extensions/UrlHelperExtensions.cs
@@ -7,9 +7,9 @@ public static class UrlHelperExtensions
 		return urlHelper.Page("/Account/ConfirmEmail", null, new { userId, code }, scheme) ?? "";
 	}
 
-	public static string EmailChangeConfirmationLink(this IUrlHelper urlHelper, string userId, string code, string scheme)
+	public static string EmailChangeConfirmationLink(this IUrlHelper urlHelper, string code, string scheme)
 	{
-		return urlHelper.Page("/Account/ConfirmEmailChange", null, new { userId, code }, scheme) ?? "";
+		return urlHelper.Page("/Account/ConfirmEmailChange", null, new { code }, scheme) ?? "";
 	}
 
 	public static string ResetPasswordCallbackLink(this IUrlHelper urlHelper, string userId, string code, string scheme)

--- a/TASVideos/Extensions/UrlHelperExtensions.cs
+++ b/TASVideos/Extensions/UrlHelperExtensions.cs
@@ -7,6 +7,11 @@ public static class UrlHelperExtensions
 		return urlHelper.Page("/Account/ConfirmEmail", null, new { userId, code }, scheme) ?? "";
 	}
 
+	public static string EmailChangeConfirmationLink(this IUrlHelper urlHelper, string userId, string code, string scheme)
+	{
+		return urlHelper.Page("/Account/ConfirmEmailChange", null, new { userId, code }, scheme) ?? "";
+	}
+
 	public static string ResetPasswordCallbackLink(this IUrlHelper urlHelper, string userId, string code, string scheme)
 	{
 		return urlHelper.Page("/Account/ResetPassword", null, new { userId, code }, scheme) ?? "";

--- a/TASVideos/Pages/Account/ConfirmEmailChange.cshtml
+++ b/TASVideos/Pages/Account/ConfirmEmailChange.cshtml
@@ -1,0 +1,12 @@
+﻿@page
+@model ConfirmEmailModel
+@{
+	ViewData["Title"] = "Confirm email";
+}
+
+<h2>@ViewData["Title"]</h2>
+<div>
+	<p>
+		Thank you for confirming your email.
+	</p>
+</div>

--- a/TASVideos/Pages/Account/ConfirmEmailChange.cshtml
+++ b/TASVideos/Pages/Account/ConfirmEmailChange.cshtml
@@ -1,5 +1,5 @@
 ﻿@page
-@model ConfirmEmailModel
+@model ConfirmEmailChangeModel
 @{
 	ViewData["Title"] = "Confirm email";
 }

--- a/TASVideos/Pages/Account/ConfirmEmailChange.cshtml.cs
+++ b/TASVideos/Pages/Account/ConfirmEmailChange.cshtml.cs
@@ -46,7 +46,8 @@ public class ConfirmEmailChangeModel : BasePageModel
 			return RedirectToPage("/Error");
 		}
 
+		_cache.Remove(code);
 		await _userMaintenanceLogger.Log(user.Id, $"User changed email from {IpAddress}");
-		return Page();
+		return RedirectToPage("/Profile/Settings");
 	}
 }

--- a/TASVideos/Pages/Account/ConfirmEmailChange.cshtml.cs
+++ b/TASVideos/Pages/Account/ConfirmEmailChange.cshtml.cs
@@ -21,24 +21,14 @@ public class ConfirmEmailChangeModel : BasePageModel
 		_cache = cache;
 	}
 
-	public async Task<IActionResult> OnGet(string? userId, string? code)
+	public async Task<IActionResult> OnGet(string? code)
 	{
-		if (userId is null || string.IsNullOrWhiteSpace(code))
-		{
-			return AccessDenied();
-		}
-
-		var parseResult = int.TryParse(userId, out int receivedUserId);
-		if (!parseResult)
+		if (string.IsNullOrWhiteSpace(code))
 		{
 			return AccessDenied();
 		}
 
 		var user = await _userManager.GetUserAsync(User);
-		if (user.Id != receivedUserId)
-		{
-			return AccessDenied();
-		}
 
 		var cacheResult = _cache.TryGetValue(code, out string newEmail);
 		if (!cacheResult)

--- a/TASVideos/Pages/Account/ConfirmEmailChange.cshtml.cs
+++ b/TASVideos/Pages/Account/ConfirmEmailChange.cshtml.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TASVideos.Core.Services;
+
+namespace TASVideos.Pages.Account;
+
+[AllowAnonymous]
+public class ConfirmEmailChangeModel : BasePageModel
+{
+	private readonly UserManager _userManager;
+	private readonly IUserMaintenanceLogger _userMaintenanceLogger;
+	private readonly ICacheService _cache;
+
+	public ConfirmEmailChangeModel(
+		UserManager userManager,
+		IUserMaintenanceLogger userMaintenanceLogger,
+		ICacheService cache)
+	{
+		_userManager = userManager;
+		_userMaintenanceLogger = userMaintenanceLogger;
+		_cache = cache;
+	}
+
+	public async Task<IActionResult> OnGet(string? userId, string? code)
+	{
+		if (userId is null || code is null)
+		{
+			return Home();
+		}
+
+		var user = await _userManager.FindByIdAsync(userId);
+		if (user is null)
+		{
+			return Home();
+		}
+
+		var cacheResult = _cache.TryGetValue(code, out string newEmail);
+		if (!cacheResult)
+		{
+			return BadRequest("Unrecognized or expired code.");
+		}
+
+		var result = await _userManager.SetEmailAsync(user, newEmail);
+		if (!result.Succeeded)
+		{
+			return RedirectToPage("/Error");
+		}
+
+		await _userMaintenanceLogger.Log(user.Id, $"User changed email from {IpAddress}");
+		return Page();
+	}
+}

--- a/TASVideos/Pages/Account/ConfirmEmailChange.cshtml.cs
+++ b/TASVideos/Pages/Account/ConfirmEmailChange.cshtml.cs
@@ -40,7 +40,7 @@ public class ConfirmEmailChangeModel : BasePageModel
 			return BadRequest("Unrecognized or expired code.");
 		}
 
-		var result = await _userManager.SetEmailAsync(user, newEmail);
+		var result = await _userManager.SetAndConfirmEmailAsync(user, newEmail);
 		if (!result.Succeeded)
 		{
 			return RedirectToPage("/Error");

--- a/TASVideos/Pages/Profile/ChangeEmail.cshtml
+++ b/TASVideos/Pages/Profile/ChangeEmail.cshtml
@@ -1,0 +1,30 @@
+﻿@page
+@model ChangeEmailModel
+@{
+}
+
+<form method="post">
+	<row>
+		<column lg="6">
+			<form-group>
+				<form-group>
+					<label asp-for="CurrentEmail"></label>
+					<div class="input-group">
+						<input asp-for="CurrentEmail" class="form-control" readonly />
+						<div class="input-group-text">
+							<span class="fa fa-check-square text-success"></span>
+						</div>
+					</div>
+				</form-group>
+				<form-group>
+					<label asp-for="NewEmail"></label>
+					<input asp-for="NewEmail" class="form-control" />
+					<span asp-validation-for="NewEmail" class="text-danger"></span>
+				</form-group>
+			</form-group>
+			<form-button-bar>
+				<button type="submit" class="btn btn-primary">Send Verification Email</button>
+			</form-button-bar>
+		</column>
+	</row>
+</form>

--- a/TASVideos/Pages/Profile/ChangeEmail.cshtml
+++ b/TASVideos/Pages/Profile/ChangeEmail.cshtml
@@ -6,21 +6,25 @@
 }
 
 <form method="post">
+	<input type="hidden" asp-for="IsEmailConfirmed" />
 	<row>
 		<column lg="6">
 			<form-group>
 				<form-group>
 					<label asp-for="CurrentEmail"></label>
 					<div class="input-group">
-						<input asp-for="CurrentEmail" class="form-control" readonly />
-						<div class="input-group-text">
+						<input asp-for="CurrentEmail" class="form-control" readonly/>
+						<div condition="Model.IsEmailConfirmed" class="input-group-text">
 							<span class="fa fa-check-square text-success"></span>
+						</div>
+						<div condition="!Model.IsEmailConfirmed" class="input-group-text" aria-disabled="true" title="Email not confirmed">
+							<span class="fa fa-exclamation text-warning"></span>
 						</div>
 					</div>
 				</form-group>
 				<form-group>
 					<label asp-for="NewEmail"></label>
-					<input asp-for="NewEmail" class="form-control" />
+					<input asp-for="NewEmail" class="form-control"/>
 					<span asp-validation-for="NewEmail" class="text-danger"></span>
 				</form-group>
 			</form-group>

--- a/TASVideos/Pages/Profile/ChangeEmail.cshtml
+++ b/TASVideos/Pages/Profile/ChangeEmail.cshtml
@@ -1,6 +1,8 @@
 ﻿@page
 @model ChangeEmailModel
 @{
+	ViewData["Title"] = "Email Change Request";
+	ViewData.AddActivePage(ProfileNavPages.ChangeEmail);
 }
 
 <form method="post">

--- a/TASVideos/Pages/Profile/ChangeEmail.cshtml.cs
+++ b/TASVideos/Pages/Profile/ChangeEmail.cshtml.cs
@@ -72,7 +72,7 @@ public class ChangeEmailModel : BasePageModel
 
 		_cache.Set(token, NewEmail);
 
-		var callbackUrl = Url.EmailChangeConfirmationLink(user.Id.ToString(), token, Request.Scheme);
+		var callbackUrl = Url.EmailChangeConfirmationLink(token, Request.Scheme);
 		await _emailService.EmailConfirmation(NewEmail!, callbackUrl);
 
 		return RedirectToPage("EmailConfirmationSent");

--- a/TASVideos/Pages/Profile/ChangeEmail.cshtml.cs
+++ b/TASVideos/Pages/Profile/ChangeEmail.cshtml.cs
@@ -1,0 +1,58 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TASVideos.Core.Services;
+
+namespace TASVideos.Pages.Profile;
+
+[Authorize]
+public class ChangeEmailModel : BasePageModel
+{
+	private readonly UserManager _userManager;
+
+	public ChangeEmailModel(UserManager userManager)
+	{
+		_userManager = userManager;
+	}
+
+	[BindProperty]
+	[Display(Name = "Current Email")]
+	public string CurrentEmail { get; set; } = "";
+
+	[Required]
+	[EmailAddress]
+	[BindProperty]
+	[Display(Name = "New Email")]
+	public string? NewEmail { get; set; }
+
+	public async Task<IActionResult> OnGet()
+	{
+		var user = await _userManager.GetUserAsync(User);
+		if (user is null)
+		{
+			return AccessDenied();
+		}
+
+		CurrentEmail = user.Email;
+		return Page();
+	}
+
+	public async Task<IActionResult> OnPost()
+	{
+		if (!ModelState.IsValid)
+		{
+			return Page();
+		}
+
+		var user = await _userManager.GetUserAsync(User);
+		if (user is null)
+		{
+			return AccessDenied();
+		}
+
+		await _userManager.GenerateChangeEmailTokenAsync(user, NewEmail);
+
+		// TODO:
+		return Home();
+	}
+}

--- a/TASVideos/Pages/Profile/ChangeEmail.cshtml.cs
+++ b/TASVideos/Pages/Profile/ChangeEmail.cshtml.cs
@@ -27,6 +27,9 @@ public class ChangeEmailModel : BasePageModel
 	[Display(Name = "Current Email")]
 	public string CurrentEmail { get; set; } = "";
 
+	[BindProperty]
+	public bool IsEmailConfirmed { get; set; }
+
 	[Required]
 	[EmailAddress]
 	[BindProperty]
@@ -42,6 +45,8 @@ public class ChangeEmailModel : BasePageModel
 		}
 
 		CurrentEmail = user.Email;
+		IsEmailConfirmed = user.EmailConfirmed;
+
 		return Page();
 	}
 

--- a/TASVideos/Pages/Profile/EmailConfirmationSent.cshtml
+++ b/TASVideos/Pages/Profile/EmailConfirmationSent.cshtml
@@ -1,0 +1,7 @@
+﻿@page
+@{
+	ViewData["Title"] = "Email Change Request Sent";
+}
+
+<h4>Your verification Email has been sent</h4>
+<p>To complete the email change process, look for an email in your inbox that will provide further instructions.</p>

--- a/TASVideos/Pages/Profile/ProfileNavPages.cs
+++ b/TASVideos/Pages/Profile/ProfileNavPages.cs
@@ -16,6 +16,9 @@ public static class ProfileNavPages
 	public static string ChangePassword => "ChangePassword";
 	public static string ChangePasswordNavClass(ViewContext viewContext) => PageNavClass(viewContext, ChangePassword);
 
+	public static string ChangeEmail => "ChangeEmail";
+	public static string ChangeEmailNavClass(ViewContext viewContext) => PageNavClass(viewContext, ChangeEmail);
+
 	public static string HomePage => "HomePage";
 	public static string HomePageNavClass(ViewContext viewContext) => PageNavClass(viewContext, HomePage);
 

--- a/TASVideos/Pages/Profile/Settings.cshtml
+++ b/TASVideos/Pages/Profile/Settings.cshtml
@@ -16,6 +16,7 @@
 					@await Component.RenderWiki("System/NameChanges")
 				</div>
 			</form-group>
+			<a asp-page="ChangeEmail">Change Email</a>
 			@if (Model.Settings.IsEmailConfirmed)
 			{
 				<form-group disabled>
@@ -25,6 +26,7 @@
 						<div class="input-group-text" aria-disabled="true"><span class="fa fa-check-square text-success"></span></div>
 					</div>
 				</form-group>
+				
 			}
 			else
 			{
@@ -36,6 +38,7 @@
 					<button asp-page="Settings" asp-page-handler="SendVerificationEmail" class="btn btn-link">Send verification email</button>
 				</form-group>
 			}
+			
 			<form-group>
 				<label asp-for="Settings.PublicRatings"></label>
 				<div class="btn-group btn-group-toggle" data-bs-toggle="buttons">

--- a/TASVideos/Pages/Profile/_ProfileNav.cshtml
+++ b/TASVideos/Pages/Profile/_ProfileNav.cshtml
@@ -9,6 +9,9 @@
 		<a class="nav-link @ProfileNavPages.ChangePasswordNavClass(ViewContext)" asp-page="ChangePassword">Password</a>
 	</li>
 	<li class="nav-item">
+		<a class="nav-link @ProfileNavPages.ChangeEmailNavClass(ViewContext)" asp-page="ChangeEmail">Change Email</a>
+	</li>
+	<li class="nav-item">
 		<a class="nav-link @ProfileNavPages.HomePageNavClass(ViewContext)" asp-page="HomePage">Home Page</a>
 	</li>
 	<li class="nav-item">


### PR DESCRIPTION
Allows user to change email in profile, sends a verification email, email is not changed until successful email confirmation.

It persists the code in cache, which limits the lifetime of it to 1 hour, but I think the token itself only lasts that long.  Won't survive a reboot on memory cache, but it's unlikely that the user will be doing this during a reboot and can always try again.