### PR TITLE
Rough in for viewing deleted pages, fixes #735

### DIFF
--- a/TASVideos/Pages/Wiki/DeletedPages.cshtml
+++ b/TASVideos/Pages/Wiki/DeletedPages.cshtml
@@ -15,7 +15,10 @@
 		@foreach (var item in Model.DeletedPages.OrderByDescending(m => m.PageName))
 		{
 			<tr>
-				<td>@item.PageName</td>
+				<td>
+					<a condition="!item.HasExistingRevisions" asp-page="/Wiki/RenderDeleted" asp-route-url="@item.PageName">@item.PageName</a>
+					<span condition="item.HasExistingRevisions">@item.PageName</span>
+				</td>
 				<td>@item.RevisionCount</td>
 				<td>
 					<a condition="@item.HasExistingRevisions" href="/@item.PageName">@item.PageName</a>

--- a/TASVideos/Pages/Wiki/RenderDeleted.cshtml
+++ b/TASVideos/Pages/Wiki/RenderDeleted.cshtml
@@ -1,0 +1,29 @@
+﻿@page
+@model RenderDeletedModel
+@{
+	ViewData["Title"] = $"Viewing Deleted Page: {Model.WikiPage.PageName}";
+}
+<h4>Revision: @Model.WikiPage.Revision</h4>
+
+<ul>
+	<li>
+		Revision: @Model.WikiPage.Revision
+	</li>
+	<li>
+		Latest? @((!Model.WikiPage.ChildId.HasValue).ToYesNo())
+	</li>
+	<li>
+		Author: <profile-link username="@Model.WikiPage.Author!.UserName"></profile-link>
+	</li>
+	<li>
+		Revision Message: @Model.WikiPage.RevisionMessage
+	</li>
+	<li>
+		Minor Edit? @Model.WikiPage.MinorEdit.ToYesNo()
+	</li>
+</ul>
+
+<h4>Markup</h4>
+<info-alert>
+	@Model.WikiPage.Markup
+</info-alert>

--- a/TASVideos/Pages/Wiki/RenderDeleted.cshtml.cs
+++ b/TASVideos/Pages/Wiki/RenderDeleted.cshtml.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TASVideos.Core.Services;
+using TASVideos.Data.Entity;
+
+namespace TASVideos.Pages.Wiki;
+
+[RequirePermission(PermissionTo.SeeDeletedWikiPages)]
+public class RenderDeletedModel : PageModel
+{
+	private readonly IWikiPages _wikiPages;
+
+	public RenderDeletedModel(IWikiPages wikiPages)
+	{
+		_wikiPages = wikiPages;
+	}
+
+	public WikiPage WikiPage { get; set; } = new();
+
+	public async Task<IActionResult> OnGet(string? url, int? revision = null)
+	{
+		if (string.IsNullOrWhiteSpace(url))
+		{
+			return NotFound();
+		}
+
+		var query = _wikiPages.Query
+			.Include(wp => wp.Author)
+			.ThatAreDeleted()
+			.Where(wp => wp.PageName == url);
+
+		if (revision.HasValue)
+		{
+			query = query.Where(wp => wp.Revision == revision);
+		}
+		else
+		{
+			query = query.WithNoChildren();
+		}
+
+		var page = await query.FirstOrDefaultAsync();
+		if (page is null)
+		{
+			return NotFound();
+		}
+
+		WikiPage = page;
+
+		return Page();
+	}
+}


### PR DESCRIPTION
Allows one to see the details of any deleted page or specific revision.

Currently no link to specific revision, just on /Wiki/DeletedPages, any page that is "fully" deleted will have a link to the latest deleted revision.  Note that it show the markup not the rendering.  I'm thinking safety here, the rendered page may likely be inappropriate, but also possibly with dangerous links or malicious markup.  Plus, you only need a rough idea of what was on the page.