### PR TITLE
fix missing padding in the mobile search icon

### DIFF
--- a/TASVideos/Pages/Shared/_LoginPartial.cshtml
+++ b/TASVideos/Pages/Shared/_LoginPartial.cshtml
@@ -32,7 +32,7 @@
         <nav-item activate="Search">
             <form method="GET" action="/Search/Index">
                 <div class="input-group mt-1">
-                    <button type="submit" class="btn btn-sm border border-secondary nav-link">
+                    <button type="submit" class="btn btn-sm border border-secondary nav-link px-2">
                         <i class="fa fa-search"></i>
                     </button>
                     <input type="text" name="SearchTerms" class="form-control" />


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/38826675/165024172-f2bade16-f19a-41fc-a05b-54ba7e71049e.png)
After
![image](https://user-images.githubusercontent.com/38826675/165024135-bebc303f-1413-4b16-be97-4a70f96c12f3.png)
