### PR TITLE
Fix nesting of list and table tags in forum (again)

### DIFF
--- a/TASVideos.ForumEngine/BbParser.cs
+++ b/TASVideos.ForumEngine/BbParser.cs
@@ -301,7 +301,7 @@ public class BbParser
 						options = options[1..^1];
 					}
 
-					if (KnownTags.TryGetValue(name, out var state) && state.RequiredParent == null || state.RequiredParent == _stack.Peek().Name)
+					if (KnownTags.TryGetValue(name, out var state) && (state.RequiredParent == null || state.RequiredParent == _stack.Peek().Name))
 					{
 						var e = new Element { Name = name, Options = options };
 						FlushText();


### PR DESCRIPTION
Repeat of #1259.  Closes #1257.

The first version of this PR would crash on non-tags like `[foo]` because the logic was wrong.  