### PR TITLE
Add System column to GameRom and remove hash requirement

### DIFF
--- a/TASVideos.Data/ApplicationDbContext.cs
+++ b/TASVideos.Data/ApplicationDbContext.cs
@@ -252,12 +252,6 @@ public class ApplicationDbContext : IdentityDbContext<User, Role, int, UserClaim
 			entity.Property(e => e.Obsolete).HasDefaultValue(false);
 		});
 
-		builder.Entity<GameRom>(entity =>
-		{
-			entity.HasIndex(e => e.Md5).IsUnique();
-			entity.HasIndex(e => e.Sha1).IsUnique();
-		});
-
 		builder.Entity<SubmissionAuthor>(entity =>
 		{
 			entity.HasKey(e => new { e.UserId, e.SubmissionId });

--- a/TASVideos.Data/Entity/Game/GameRom.cs
+++ b/TASVideos.Data/Entity/Game/GameRom.cs
@@ -14,15 +14,15 @@ public class GameRom : BaseEntity
 
 	public int GameId { get; set; }
 	public virtual Game? Game { get; set; }
+	public int? SystemId { get; set; }
+	public virtual GameSystem? System { get; set; }
 
 	public ICollection<Publication> Publications { get; set; } = new HashSet<Publication>();
 	public ICollection<Submission> Submissions { get; set; } = new HashSet<Submission>();
 
-	[Required]
 	[StringLength(32)]
 	public string Md5 { get; set; } = "";
 
-	[Required]
 	[StringLength(40)]
 	public string Sha1 { get; set; } = "";
 

--- a/TASVideos.Data/Entity/Game/GameSystem.cs
+++ b/TASVideos.Data/Entity/Game/GameSystem.cs
@@ -10,6 +10,7 @@ public class GameSystem : BaseEntity
 	public virtual ICollection<GameSystemFrameRate> SystemFrameRates { get; set; } = new HashSet<GameSystemFrameRate>();
 
 	public virtual ICollection<Game> Games { get; set; } = new HashSet<Game>();
+	public virtual ICollection<GameRom> GameRoms { get; set; } = new HashSet<GameRom>();
 
 	public virtual ICollection<Publication> Publications { get; set; } = new HashSet<Publication>();
 	public virtual ICollection<Submission> Submissions { get; set; } = new HashSet<Submission>();

--- a/TASVideos.Data/Migrations/20220509202254_GameRomAddSystem.Designer.cs
+++ b/TASVideos.Data/Migrations/20220509202254_GameRomAddSystem.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,10 @@ using TASVideos.Data;
 namespace TASVideos.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220509202254_GameRomAddSystem")]
+    partial class GameRomAddSystem
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TASVideos.Data/Migrations/20220509202254_GameRomAddSystem.cs
+++ b/TASVideos.Data/Migrations/20220509202254_GameRomAddSystem.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TASVideos.Data.Migrations;
+
+public partial class GameRomAddSystem : Migration
+{
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropIndex(
+			name: "ix_game_roms_md5",
+			table: "game_roms");
+
+		migrationBuilder.DropIndex(
+			name: "ix_game_roms_sha1",
+			table: "game_roms");
+
+		migrationBuilder.AddColumn<int>(
+			name: "system_id",
+			table: "game_roms",
+			type: "integer",
+			nullable: true);
+
+		migrationBuilder.CreateIndex(
+			name: "ix_game_roms_system_id",
+			table: "game_roms",
+			column: "system_id");
+
+		migrationBuilder.AddForeignKey(
+			name: "fk_game_roms_game_systems_system_id",
+			table: "game_roms",
+			column: "system_id",
+			principalTable: "game_systems",
+			principalColumn: "id");
+	}
+
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropForeignKey(
+			name: "fk_game_roms_game_systems_system_id",
+			table: "game_roms");
+
+		migrationBuilder.DropIndex(
+			name: "ix_game_roms_system_id",
+			table: "game_roms");
+
+		migrationBuilder.DropColumn(
+			name: "system_id",
+			table: "game_roms");
+
+		migrationBuilder.CreateIndex(
+			name: "ix_game_roms_md5",
+			table: "game_roms",
+			column: "md5",
+			unique: true);
+
+		migrationBuilder.CreateIndex(
+			name: "ix_game_roms_sha1",
+			table: "game_roms",
+			column: "sha1",
+			unique: true);
+	}
+}


### PR DESCRIPTION
Part of the Game Entity Revamp #1188.
This does the first step of adding the column and removing the md5 and sha1 requirement, meaning we can continue with the next step of filling up the system column with a query.