### PR TITLE
Adds a TitleOverride to GameRoms, replacing the Game title if necessary

### DIFF
--- a/TASVideos.Data/Entity/Game/GameRom.cs
+++ b/TASVideos.Data/Entity/Game/GameRom.cs
@@ -37,6 +37,9 @@ public class GameRom : BaseEntity
 
 	[StringLength(50)]
 	public string? Version { get; set; }
+
+	[StringLength(255)]
+	public string? TitleOverride { get; set; }
 }
 
 public static class RomExtensions

--- a/TASVideos.Data/Entity/Publication.cs
+++ b/TASVideos.Data/Entity/Publication.cs
@@ -117,8 +117,14 @@ public class Publication : BaseEntity, ITimeable
 			throw new InvalidOperationException($"{nameof(Game)} must not be lazy loaded!");
 		}
 
+		var gameName = Game.DisplayName;
+		if (Rom is not null && !string.IsNullOrWhiteSpace(Rom.TitleOverride))
+		{
+			gameName = Rom.TitleOverride;
+		}
+
 		Title =
-			$"{System.Code} {Game.DisplayName}"
+			$"{System.Code} {gameName}"
 			+ (!string.IsNullOrWhiteSpace(Branch) ? $" \"{Branch}\"" : "")
 			+ $" by {string.Join(", ", authorList).LastCommaToAmpersand()}"
 			+ $" in {this.Time().ToStringWithOptionalDaysAndHours()}";

--- a/TASVideos.Data/Entity/Submission.cs
+++ b/TASVideos.Data/Entity/Submission.cs
@@ -131,6 +131,11 @@ public class Submission : BaseEntity, ITimeable
 			gameName = Game.DisplayName;
 		}
 
+		if (Rom is not null && !string.IsNullOrWhiteSpace(Rom.TitleOverride))
+		{
+			gameName = Rom.TitleOverride;
+		}
+
 		Title =
 		$"#{Id}: {string.Join(", ", authorList).LastCommaToAmpersand()}'s {System.Code} {gameName}"
 			+ (!string.IsNullOrWhiteSpace(Branch) ? $" \"{Branch}\"" : "")

--- a/TASVideos.Data/Entity/Submission.cs
+++ b/TASVideos.Data/Entity/Submission.cs
@@ -125,8 +125,14 @@ public class Submission : BaseEntity, ITimeable
 			authorList = authorList.Concat(AdditionalAuthors.SplitWithEmpty(","));
 		}
 
+		var gameName = GameName;
+		if (Game is not null)
+		{
+			gameName = Game.DisplayName;
+		}
+
 		Title =
-		$"#{Id}: {string.Join(", ", authorList).LastCommaToAmpersand()}'s {System.Code} {GameName}"
+		$"#{Id}: {string.Join(", ", authorList).LastCommaToAmpersand()}'s {System.Code} {gameName}"
 			+ (!string.IsNullOrWhiteSpace(Branch) ? $" \"{Branch}\"" : "")
 			+ $" in {this.Time().ToStringWithOptionalDaysAndHours()}";
 	}

--- a/TASVideos.Data/Migrations/20220511230059_GameNameTitleOverride.Designer.cs
+++ b/TASVideos.Data/Migrations/20220511230059_GameNameTitleOverride.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,10 @@ using TASVideos.Data;
 namespace TASVideos.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220511230059_GameNameTitleOverride")]
+    partial class GameNameTitleOverride
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TASVideos.Data/Migrations/20220511230059_GameNameTitleOverride.cs
+++ b/TASVideos.Data/Migrations/20220511230059_GameNameTitleOverride.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TASVideos.Data.Migrations;
+
+public partial class GameNameTitleOverride : Migration
+{
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.AddColumn<string>(
+			name: "title_override",
+			table: "game_roms",
+			type: "citext",
+			maxLength: 255,
+			nullable: true);
+	}
+
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropColumn(
+			name: "title_override",
+			table: "game_roms");
+	}
+}

--- a/TASVideos/Pages/Games/Index.cshtml
+++ b/TASVideos/Pages/Games/Index.cshtml
@@ -143,6 +143,7 @@
 		<tr>
 			<th>Type</th>
 			<th>Name</th>
+			<th>Title Override</th>
 			<th>Region</th>
 			<th>Version</th>
 			<th>Sha1</th>
@@ -154,6 +155,7 @@
 			<tr>
 				<td>@rom.Type.ToString()</td>
 				<td>@rom.Name</td>
+				<td>@rom.TitleOverride</td>
 				<td>@rom.Region</td>
 				<td>@rom.Version</td>
 				<td>@rom.Sha1</td>

--- a/TASVideos/Pages/Games/Models/GameDisplayModel.cs
+++ b/TASVideos/Pages/Games/Models/GameDisplayModel.cs
@@ -24,6 +24,7 @@ public class GameDisplayModel
 		public string? Region { get; set; }
 		public string? Version { get; set; }
 		public string? SystemCode { get; set; }
+		public string? TitleOverride { get; set; }
 	}
 
 	public ICollection<GameGroup> GameGroups { get; set; } = new List<GameGroup>();

--- a/TASVideos/Pages/Games/Roms/Edit.cshtml
+++ b/TASVideos/Pages/Games/Roms/Edit.cshtml
@@ -50,6 +50,11 @@
 				<span asp-validation-for="Rom.Type" class="text-danger"></span>
 			</form-group>
 			<form-group>
+				<label asp-for="Rom.TitleOverride"></label>
+				<input type="text" asp-for="Rom.TitleOverride" class="form-control" />
+				<span asp-validation-for="Rom.TitleOverride" class="text-danger"></span>
+			</form-group>
+			<form-group>
 				<label asp-for="Rom.Version"></label>
 				<input type="text" asp-for="Rom.Version" class="form-control" autocomplete="off" spellcheck="false" />
 				<span asp-validation-for="Rom.Version" class="text-danger"></span>

--- a/TASVideos/Pages/Games/Roms/List.cshtml
+++ b/TASVideos/Pages/Games/Roms/List.cshtml
@@ -10,6 +10,7 @@
 <table class="table table-bordered table-striped">
 	<tr>
 		<th>@Html.DisplayNameFor(m => m.Roms.Roms.First().DisplayName)</th>
+		<th>@Html.DisplayNameFor(m => m.Roms.Roms.First().TitleOverride)</th>
 		<th>@Html.DisplayNameFor(m => m.Roms.Roms.First().Version)</th>
 		<th>@Html.DisplayNameFor(m => m.Roms.Roms.First().Region)</th>
 		<th>@Html.DisplayNameFor(m => m.Roms.Roms.First().RomType)</th>
@@ -22,6 +23,7 @@
 	{
 		<tr>
 			<td>@rom.DisplayName</td>
+			<td>@rom.TitleOverride</td>
 			<td>@rom.Version</td>
 			<td>@rom.Region</td>
 			<td>@rom.RomType</td>

--- a/TASVideos/Pages/Games/Roms/List.cshtml.cs
+++ b/TASVideos/Pages/Games/Roms/List.cshtml.cs
@@ -37,6 +37,7 @@ public class ListModel : BasePageModel
 					Region = r.Region,
 					RomType = r.Type,
 					SystemCode = r.System!.Code,
+					TitleOverride = r.TitleOverride,
 				})
 				.ToList()
 			})

--- a/TASVideos/Pages/Games/Roms/Models/RomEditModel.cs
+++ b/TASVideos/Pages/Games/Roms/Models/RomEditModel.cs
@@ -38,4 +38,8 @@ public class RomEditModel
 
 	[Required]
 	public RomTypes Type { get; set; }
+
+	[StringLength(255)]
+	[Display(Name = "Title Override")]
+	public string? TitleOverride { get; set; }
 }

--- a/TASVideos/Pages/Games/Roms/Models/RomListModel.cs
+++ b/TASVideos/Pages/Games/Roms/Models/RomListModel.cs
@@ -35,5 +35,8 @@ public class RomListModel
 
 		[Display(Name = "System")]
 		public string SystemCode { get; set; } = "";
+
+		[Display(Name = "Title Override")]
+		public string? TitleOverride { get; set; }
 	}
 }

--- a/TASVideos/Pages/Publications/Edit.cshtml.cs
+++ b/TASVideos/Pages/Publications/Edit.cshtml.cs
@@ -163,6 +163,7 @@ public class EditModel : BasePageModel
 			.Include(p => p.System)
 			.Include(p => p.SystemFrameRate)
 			.Include(p => p.Game)
+			.Include(p => p.Rom)
 			.Include(p => p.Authors)
 			.ThenInclude(pa => pa.Author)
 			.SingleOrDefaultAsync(p => p.Id == id);

--- a/TASVideos/Pages/Submissions/Catalog.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Catalog.cshtml.cs
@@ -96,6 +96,8 @@ public class CatalogModel : BasePageModel
 			.Include(s => s.SystemFrameRate)
 			.Include(s => s.Game)
 			.Include(s => s.Rom)
+			.Include(s => s.SubmissionAuthors)
+			.ThenInclude(sa => sa.Author)
 			.SingleOrDefaultAsync(s => s.Id == Id);
 		if (submission is null)
 		{
@@ -115,6 +117,7 @@ public class CatalogModel : BasePageModel
 			{
 				externalMessages.Add($"System changed from {submission.System?.Code ?? ""} to {system.Code}");
 				submission.SystemId = Catalog.SystemId!.Value;
+				submission.System = system;
 			}
 		}
 
@@ -129,6 +132,7 @@ public class CatalogModel : BasePageModel
 			{
 				externalMessages.Add($"Framerate changed from {submission.SystemFrameRate?.FrameRate ?? 0.0} to {systemFramerate.FrameRate}");
 				submission.SystemFrameRateId = Catalog.SystemFrameRateId!.Value;
+				submission.SystemFrameRate = systemFramerate;
 			}
 		}
 
@@ -145,12 +149,14 @@ public class CatalogModel : BasePageModel
 				{
 					externalMessages.Add($"Game changed from {submission.Game?.DisplayName ?? "\"\""} to {game.DisplayName}");
 					submission.GameId = Catalog.GameId.Value;
+					submission.Game = game;
 				}
 			}
 			else if (submission.GameId.HasValue)
 			{
 				externalMessages.Add("Game removed");
 				submission.GameId = null;
+				submission.Game = null;
 			}
 		}
 
@@ -167,12 +173,14 @@ public class CatalogModel : BasePageModel
 				{
 					externalMessages.Add($"Rom Hash changed from {submission.Rom?.Name ?? "\"\""} to {rom.Name}");
 					submission.RomId = Catalog.RomId.Value;
+					submission.Rom = rom;
 				}
 			}
 			else
 			{
 				externalMessages.Add("Rom removed");
 				submission.RomId = null;
+				submission.Rom = null;
 			}
 		}
 
@@ -181,6 +189,8 @@ public class CatalogModel : BasePageModel
 			await PopulateCatalogDropDowns();
 			return Page();
 		}
+
+		submission.GenerateTitle();
 
 		var result = await ConcurrentSave(_db, $"{Id}S catalog updated", $"Unable to save {Id}S catalog");
 		if (result)

--- a/TASVideos/Pages/Submissions/Edit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Edit.cshtml.cs
@@ -228,6 +228,7 @@ public class EditModel : BasePageModel
 			.Include(s => s.SubmissionAuthors)
 			.ThenInclude(sa => sa.Author)
 			.Include(s => s.Game)
+			.Include(s => s.Rom)
 			.SingleAsync(s => s.Id == Id);
 
 		if (Submission.MovieFile is not null)

--- a/TASVideos/Pages/Submissions/Edit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Edit.cshtml.cs
@@ -227,6 +227,7 @@ public class EditModel : BasePageModel
 			.Include(s => s.SystemFrameRate)
 			.Include(s => s.SubmissionAuthors)
 			.ThenInclude(sa => sa.Author)
+			.Include(s => s.Game)
 			.SingleAsync(s => s.Id == Id);
 
 		if (Submission.MovieFile is not null)


### PR DESCRIPTION
For example, this allows GameRoms that are grouped in one Game called `Pokemon RGBY` to be listed as `Pokemon Red`, `Pokemon Green`, etc. instead of having `Pokemon RGBY` in submission/publication titles.

If this field is empty, it will default to the Game name.