### PR TITLE
Add Game Rewire Page

### DIFF
--- a/TASVideos.Data/Entity/PermissionTo.cs
+++ b/TASVideos.Data/Entity/PermissionTo.cs
@@ -174,6 +174,10 @@ public enum PermissionTo
 	[Description("The ability to add, edit, and remove game systems")]
 	GameSystemMaintenance = 393,
 
+	[Group("Publication Maintenance")]
+	[Description("The ability to rewire games into other games")]
+	RewireGames = 394,
+
 	#endregion
 
 	#region Forum Moderation 400

--- a/TASVideos/Pages/Games/List.cshtml
+++ b/TASVideos/Pages/Games/List.cshtml
@@ -7,6 +7,7 @@
 }
 
 <a asp-page="Edit" permission="CatalogMovies" class="btn btn-primary mb-3 float-end"><i class="fa fa-plus"></i> Create</a>
+<a asp-page="Rewire" permission="RewireGames" class="btn btn-primary mb-3 float-end me-1"><i class="fa fa-wrench"></i> Rewire</a>
 <form class="row">
 	<div class="col-lg-5 col-12 mb-1">
 		<div class="input-group">

--- a/TASVideos/Pages/Games/Rewire.cshtml
+++ b/TASVideos/Pages/Games/Rewire.cshtml
@@ -1,0 +1,181 @@
+﻿@page
+@model TASVideos.Pages.Games.RewireModel
+@{
+	ViewData["Title"] = "Rewire Games";
+}
+<form method="get">
+	<row>
+		<div class="col-auto">
+			<form-group>
+				<label asp-for="FromGameId" class="form-control-label"></label>
+				<input asp-for="FromGameId" class="form-control" />
+			</form-group>
+		</div>
+		<div class="col-auto">
+			<row>
+			<div class="col-auto">
+				<span class="fs-1">→</span>
+			</div>
+			<div class="col-auto">
+				<form-group>
+					<label asp-for="IntoGameId" class="form-control-label"></label>
+					<input asp-for="IntoGameId" class="form-control" />
+				</form-group>
+			</div>
+			</row>
+		</div>
+	</row>
+	<button type="submit" class="btn btn-secondary"><i class="fa fa-eye"></i> Preview</button>
+</form>
+<div condition="Model.ValidIds" class="mt-3">
+	@{
+		var gameNameDifference = Model.FromGame!.Game!.Title != Model.IntoGame!.Game!.Title;
+	}
+	<card class="mb-2">
+		<cardheader>
+			<row>
+				<div class="col-6">
+					<h3>From Game</h3>
+					<h4><game-link id="@Model.FromGame.Game.Id">@Model.FromGame!.Game!.Title</game-link></h4>
+				</div>
+				<div class="col-6">
+					<h3>Into Game</h3>
+					<h4><game-link id="@Model.IntoGame.Game.Id">@Model.IntoGame!.Game!.Title</game-link></h4>
+				</div>
+			</row>
+		</cardheader>
+		<cardbody>
+			<row>
+				<div class="col-6">
+					<h4>Publications</h4>
+					<ul>
+						@foreach (var pub in Model.FromGame.Publications!)
+						{
+							<li>
+								<pub-link id="@pub.Id">@pub.Title</pub-link><span condition="@string.IsNullOrEmpty(pub.RomName) && gameNameDifference" class="text-danger"> Title will change!</span>
+							</li>
+						}
+					</ul>
+				</div>
+				<div class="col-6">
+					<h4>Publications</h4>
+					<ul>
+						@foreach (var pub in Model.IntoGame.Publications!)
+						{
+							<li>
+								<pub-link id="@pub.Id">@pub.Title</pub-link>
+							</li>
+						}
+					</ul>
+				</div>
+			</row>
+			<row>
+				<column></column>
+				<div class="col-6">
+					<h4>Submissions</h4>
+					<ul>
+						@foreach (var sub in Model.FromGame.Submissions!)
+						{
+							<li>
+								<sub-link id="@sub.Id">@sub.Title</sub-link><span condition="@string.IsNullOrEmpty(sub.RomName) && gameNameDifference" class="text-danger"> Title will change!</span>
+							</li>
+						}
+					</ul>
+				</div>
+				<div class="col-6">
+					<h4>Submissions</h4>
+					<ul>
+						@foreach (var sub in Model.IntoGame.Submissions!)
+						{
+							<li>
+								<sub-link id="@sub.Id">@sub.Title</sub-link>
+							</li>
+						}
+					</ul>
+				</div>
+			</row>
+			<row>
+				<column></column>
+				<div class="col-6">
+					<h4>
+						<a condition="Model.FromGame.Roms!.Any()" asp-page="/Games/Roms/List" asp-route-gameId="@Model.FromGameId">Roms</a>
+						<span condition="!Model.FromGame.Roms!.Any()">Roms</span>
+					</h4>
+					<ul>
+						@foreach (var rom in Model.FromGame.Roms!)
+						{
+							<li>@rom.Title</li>
+						}
+					</ul>
+				</div>
+				<div class="col-6">
+					<h4>
+						<a condition="Model.IntoGame.Roms!.Any()" asp-page="/Games/Roms/List" asp-route-gameId="@Model.IntoGameId">Roms</a>
+						<span condition="!Model.IntoGame.Roms!.Any()">Roms</span>
+					</h4>
+					<ul>
+						@foreach (var rom in Model.IntoGame.Roms!)
+						{
+							<li>@rom.Title</li>
+						}
+					</ul>
+				</div>
+			</row>
+			<row>
+				<column></column>
+				<div class="col-6">
+					<h4>Userfiles</h4>
+					<ul>
+						@foreach (var userfile in Model.FromGame.Userfiles!)
+						{
+							<li><a asp-page="/UserFiles/Info" asp-route-id="@userfile.Id">#@userfile.Id - @userfile.Title</a></li>
+						}
+					</ul>
+				</div>
+				<div class="col-6">
+					<h4>Userfiles</h4>
+					<ul>
+						@foreach (var userfile in Model.IntoGame.Userfiles!)
+						{
+							<li><a asp-page="/UserFiles/Info" asp-route-id="@userfile.Id">#@userfile.Id - @userfile.Title</a></li>
+						}
+					</ul>
+				</div>
+			</row>
+			<row>
+				<column></column>
+				<div class="col-6">
+					<h4>
+						<a condition="Model.FromGame.RamAddresses!.Any()" asp-page="/RamAddresses/Index" asp-route-id="@Model.FromGameId">Ram Addresses</a>
+						<span condition="!Model.FromGame.RamAddresses!.Any()">Ram Addresses</span>
+					</h4>
+					<ul>
+						@foreach (var address in Model.FromGame.RamAddresses!)
+						{
+							<li>@address.Title</li>
+						}
+					</ul>
+				</div>
+				<div class="col-6">
+					<h4>
+						<a condition="Model.IntoGame.RamAddresses!.Any()" asp-page="/RamAddresses/Index" asp-route-id="@Model.IntoGameId">Ram Addresses</a>
+						<span condition="!Model.IntoGame.RamAddresses!.Any()">Ram Addresses</span>
+					</h4>
+					<ul>
+						@foreach (var address in Model.IntoGame.RamAddresses!)
+						{
+							<li>@address.Title</li>
+						}
+					</ul>
+				</div>
+			</row>
+		</cardbody>
+	</card>
+	<form method="post">
+		<input type="hidden" asp-for="FromGameId" />
+		<input type="hidden" asp-for="IntoGameId" />
+		<div class="text-center">
+			<button type="submit" class="btn btn-primary"><i class="fa fa fa-wrench"></i> Rewire</button>
+		</div>
+	</form>
+</div>

--- a/TASVideos/Pages/Games/Rewire.cshtml.cs
+++ b/TASVideos/Pages/Games/Rewire.cshtml.cs
@@ -1,0 +1,140 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using TASVideos.Data;
+using TASVideos.Data.Entity;
+
+namespace TASVideos.Pages.Games;
+
+[RequirePermission(PermissionTo.RewireGames)]
+public class RewireModel : BasePageModel
+{
+	private readonly ApplicationDbContext _db;
+
+	public RewireModel(
+		ApplicationDbContext db)
+	{
+		_db = db;
+	}
+
+	[FromQuery]
+	[Display(Name = "From Game Id")]
+	public int? FromGameId { get; set; }
+
+	[FromQuery]
+	[Display(Name = "Into Game Id")]
+	public int? IntoGameId { get; set; }
+
+	public bool ValidIds { get; set; } = false;
+
+	public RewireEntry? FromGame { get; set; }
+	public RewireEntry? IntoGame { get; set; }
+
+	public class RewireEntry
+	{
+		public Entry? Game;
+		public ICollection<EntryWithRom>? Publications;
+		public ICollection<EntryWithRom>? Submissions;
+		public ICollection<Entry>? Roms;
+		public ICollection<EntryLong>? Userfiles;
+		public ICollection<Entry>? RamAddresses;
+	}
+
+	public record Entry(int Id, string Title);
+	public record EntryWithRom(int Id, string Title, string? RomName);
+	public record EntryLong(long Id, string Title);
+
+	public async Task OnGet()
+	{
+		ValidIds = await _db.Games
+			.Where(g => g.Id == FromGameId || g.Id == IntoGameId)
+			.CountAsync() == 2;
+		if (ValidIds)
+		{
+			FromGame = await _db.Games
+				.Where(g => g.Id == FromGameId)
+				.Select(g => new RewireEntry
+				{
+					Game = new Entry(g.Id, g.DisplayName),
+					Publications = g.Publications.Select(p => new EntryWithRom(p.Id, p.Title, p.Rom == null ? null : p.Rom.TitleOverride)).ToList(),
+					Submissions = g.Submissions.Select(s => new EntryWithRom(s.Id, s.Title, s.Rom == null ? null : s.Rom.TitleOverride)).ToList(),
+					Roms = g.Roms.Select(r => new Entry(r.Id, r.Name)).ToList(),
+					Userfiles = g.UserFiles.Select(u => new EntryLong(u.Id, u.Title)).ToList(),
+				})
+				.FirstOrDefaultAsync();
+			FromGame!.RamAddresses = await _db.GameRamAddresses
+				.Where(a => a.GameId == FromGameId)
+				.Select(a => new Entry(a.Id, a.Address.ToString()))
+				.ToListAsync();
+
+			IntoGame = await _db.Games
+				.Where(g => g.Id == IntoGameId)
+				.Select(g => new RewireEntry
+				{
+					Game = new Entry(g.Id, g.DisplayName),
+					Publications = g.Publications.Select(p => new EntryWithRom(p.Id, p.Title, p.Rom == null ? null : p.Rom.TitleOverride)).ToList(),
+					Submissions = g.Submissions.Select(s => new EntryWithRom(s.Id, s.Title, s.Rom == null ? null : s.Rom.TitleOverride)).ToList(),
+					Roms = g.Roms.Select(r => new Entry(r.Id, r.Name)).ToList(),
+					Userfiles = g.UserFiles.Select(u => new EntryLong(u.Id, u.Title)).ToList(),
+				})
+				.FirstOrDefaultAsync();
+			IntoGame!.RamAddresses = await _db.GameRamAddresses
+				.Where(a => a.GameId == IntoGameId)
+				.Select(a => new Entry(a.Id, a.Address.ToString()))
+				.ToListAsync();
+		}
+	}
+
+	public async Task<IActionResult> OnPost()
+	{
+		if (FromGameId is not null && IntoGameId is not null)
+		{
+			ValidIds = await _db.Games
+				.Where(g => g.Id == FromGameId || g.Id == IntoGameId)
+				.CountAsync() == 2;
+			if (ValidIds)
+			{
+				int intoGameId = (int)IntoGameId;
+				var rewireGames = await _db.Games
+					.Include(g => g.Publications)
+					.Include(g => g.Submissions)
+					.Include(g => g.Roms)
+					.Include(g => g.UserFiles)
+					.Where(g => g.Id == FromGameId)
+					.FirstOrDefaultAsync();
+				foreach (var pub in rewireGames!.Publications)
+				{
+					pub.GameId = intoGameId;
+				}
+
+				foreach (var sub in rewireGames!.Submissions)
+				{
+					sub.GameId = intoGameId;
+				}
+
+				foreach (var rom in rewireGames!.Roms)
+				{
+					rom.GameId = intoGameId;
+				}
+
+				foreach (var userfile in rewireGames!.UserFiles)
+				{
+					userfile.GameId = intoGameId;
+				}
+
+				var rewireRamAddresses = await _db.GameRamAddresses
+				.Where(a => a.GameId == FromGameId)
+				.ToListAsync();
+
+				foreach (var address in rewireRamAddresses)
+				{
+					address.GameId = intoGameId;
+				}
+
+				await ConcurrentSave(_db, $"Rewired Game {FromGameId} into Game {IntoGameId}", $"Unable to rewire Game {FromGameId} into Game {IntoGameId}");
+			}
+		}
+
+		return RedirectToPage("Rewire", new { FromGameId, IntoGameId });
+	}
+}

--- a/TASVideos/Pages/Games/Rewire.cshtml.cs
+++ b/TASVideos/Pages/Games/Rewire.cshtml.cs
@@ -61,7 +61,7 @@ public class RewireModel : BasePageModel
 					Roms = g.Roms.Select(r => new Entry(r.Id, r.Name)).ToList(),
 					Userfiles = g.UserFiles.Select(u => new EntryLong(u.Id, u.Title)).ToList(),
 				})
-				.FirstOrDefaultAsync();
+				.SingleAsync();
 			FromGame!.RamAddresses = await _db.GameRamAddresses
 				.Where(a => a.GameId == FromGameId)
 				.Select(a => new Entry(a.Id, a.Address.ToString()))
@@ -77,7 +77,7 @@ public class RewireModel : BasePageModel
 					Roms = g.Roms.Select(r => new Entry(r.Id, r.Name)).ToList(),
 					Userfiles = g.UserFiles.Select(u => new EntryLong(u.Id, u.Title)).ToList(),
 				})
-				.FirstOrDefaultAsync();
+				.SingleAsync();
 			IntoGame!.RamAddresses = await _db.GameRamAddresses
 				.Where(a => a.GameId == IntoGameId)
 				.Select(a => new Entry(a.Id, a.Address.ToString()))
@@ -101,7 +101,7 @@ public class RewireModel : BasePageModel
 					.Include(g => g.Roms)
 					.Include(g => g.UserFiles)
 					.Where(g => g.Id == FromGameId)
-					.FirstOrDefaultAsync();
+					.SingleAsync();
 				foreach (var pub in rewireGames!.Publications)
 				{
 					pub.GameId = intoGameId;

--- a/TASVideos/Pages/Games/Rewire.cshtml.cs
+++ b/TASVideos/Pages/Games/Rewire.cshtml.cs
@@ -25,7 +25,7 @@ public class RewireModel : BasePageModel
 	[Display(Name = "Into Game Id")]
 	public int? IntoGameId { get; set; }
 
-	public bool ValidIds { get; set; } = false;
+	public bool ValidIds { get; set; }
 
 	public RewireEntry? FromGame { get; set; }
 	public RewireEntry? IntoGame { get; set; }
@@ -102,22 +102,22 @@ public class RewireModel : BasePageModel
 					.Include(g => g.UserFiles)
 					.Where(g => g.Id == FromGameId)
 					.SingleAsync();
-				foreach (var pub in rewireGames!.Publications)
+				foreach (var pub in rewireGames.Publications)
 				{
 					pub.GameId = intoGameId;
 				}
 
-				foreach (var sub in rewireGames!.Submissions)
+				foreach (var sub in rewireGames.Submissions)
 				{
 					sub.GameId = intoGameId;
 				}
 
-				foreach (var rom in rewireGames!.Roms)
+				foreach (var rom in rewireGames.Roms)
 				{
 					rom.GameId = intoGameId;
 				}
 
-				foreach (var userfile in rewireGames!.UserFiles)
+				foreach (var userfile in rewireGames.UserFiles)
 				{
 					userfile.GameId = intoGameId;
 				}


### PR DESCRIPTION
This adds a page to easily rewire all occurrences of one Game ID into a different Game ID.
This includes Publications, Submissions, Roms, Userfiles, and Ram Addresses.
This is a somewhat dangerous operation since this merging can't easily be undone. It can be undone manually though.
It also displays all Publications and Submissions that will change their title if merged. Ideally this is prevented beforehand and the rewiring is only applied if no title change occurs.