### PR TITLE
Add Rollback button on PageHistory page

### DIFF
--- a/TASVideos.Data/Entity/WikiPage.cs
+++ b/TASVideos.Data/Entity/WikiPage.cs
@@ -40,6 +40,11 @@ public static class WikiQueryableExtensions
 		return list.Where(wp => wp.ChildId == null);
 	}
 
+	public static IQueryable<WikiPage> ThatAreNotCurrent(this IQueryable<WikiPage> list)
+	{
+		return list.Where(wp => wp.ChildId != null);
+	}
+
 	public static IQueryable<WikiPage> ForPage(this IQueryable<WikiPage> list, string pageName)
 	{
 		return list.Where(w => w.PageName == pageName);

--- a/TASVideos/Pages/Wiki/Edit.cshtml
+++ b/TASVideos/Pages/Wiki/Edit.cshtml
@@ -1,4 +1,4 @@
-@page
+@page "{handler?}"
 @model EditModel
 @{
 	ViewData["Title"] = $"Editing {Model.Path}";

--- a/TASVideos/Pages/Wiki/Edit.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Edit.cshtml.cs
@@ -125,10 +125,7 @@ public class EditModel : BasePageModel
 
 		if (page.Revision == 1 || !PageToEdit.MinorEdit)
 		{
-			await _publisher.SendGeneralWiki(
-				$"Page {Path} {(page.Revision > 1 ? "edited" : "created")} by {User.Name()}",
-				$"{PageToEdit.RevisionMessage}",
-				Path);
+			await Announce(page);
 		}
 
 		return BaseRedirect("/" + page.PageName);
@@ -168,8 +165,7 @@ public class EditModel : BasePageModel
 		};
 
 		await _wikiPages.Add(rollBackRevision);
-
-		// TOOD: announce
+		await Announce(rollBackRevision);
 
 		return BasePageRedirect("PageHistory", new { Path, Latest = true });
 	}
@@ -178,5 +174,13 @@ public class EditModel : BasePageModel
 	{
 		var userName = WikiHelper.ToUserName(path);
 		return await _db.Users.Exists(userName);
+	}
+
+	private async Task Announce(WikiPage page)
+	{
+		await _publisher.SendGeneralWiki(
+			$"Page {Path} {(page.Revision > 1 ? "edited" : "created")} by {User.Name()}",
+			$"{PageToEdit.RevisionMessage}",
+			Path!);
 	}
 }

--- a/TASVideos/Pages/Wiki/Edit.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Edit.cshtml.cs
@@ -180,7 +180,7 @@ public class EditModel : BasePageModel
 	{
 		await _publisher.SendGeneralWiki(
 			$"Page {Path} {(page.Revision > 1 ? "edited" : "created")} by {User.Name()}",
-			$"{PageToEdit.RevisionMessage}",
+			$"{page.RevisionMessage}",
 			Path!);
 	}
 }

--- a/TASVideos/Pages/Wiki/PageHistory.cshtml
+++ b/TASVideos/Pages/Wiki/PageHistory.cshtml
@@ -99,9 +99,11 @@
 								onClick="diffBtnClicked(null, @revision.Revision)">
 								To
 							</button>
+							
 						</div>
 					</td>
 					<td>
+						
 						<delete-button
 							permission="DeleteWikiPages"
 							asp-href="/Wiki/DeletedPages/DeleteRevision?path=@(Model.History.PageName)&revision=@revision.Revision"
@@ -109,6 +111,11 @@
 							class="btn-sm">
 							<i class="fa fa-remove"></i>
 						</delete-button>
+						<form asp-page-handler="RollbackLatest">
+							<input type="hidden" asp-for="Path" />
+							<input type="hidden" name="previousRevision" value="@(164)" />
+							<button condition="i == 0 && revision.Revision > 1" type="submit" class="btn btn-sm btn-warning" title="Rollback this revision"><i class="fa fa-undo"></i></button>
+						</form>
 					</td>
 				</tr>
 			}

--- a/TASVideos/Pages/Wiki/PageHistory.cshtml
+++ b/TASVideos/Pages/Wiki/PageHistory.cshtml
@@ -6,6 +6,7 @@
 @{
 	ViewData["Title"] = "Page History For " + Model.History.PageName;
 	bool hasDiff = Model.FromRevision.HasValue && Model.ToRevision.HasValue;
+	var canEdit = WikiHelper.UserCanEditWikiPage(Model.Path, User.Name(), User.Permissions());
 }
 
 @functions{
@@ -111,7 +112,7 @@
 							class="btn-sm">
 							<i class="fa fa-remove"></i>
 						</delete-button>
-						<form asp-page-handler="RollbackLatest">
+						<form asp-page-handler="RollbackLatest" condition="canEdit">
 							<input type="hidden" asp-for="Path" />
 							<input type="hidden" name="previousRevision" value="@(164)" />
 							<button condition="i == 0 && revision.Revision > 1" type="submit" class="btn btn-sm btn-warning" title="Rollback this revision"><i class="fa fa-undo"></i></button>

--- a/TASVideos/Pages/Wiki/PageHistory.cshtml
+++ b/TASVideos/Pages/Wiki/PageHistory.cshtml
@@ -112,8 +112,7 @@
 							class="btn-sm">
 							<i class="fa fa-remove"></i>
 						</delete-button>
-						<form asp-page-handler="RollbackLatest" condition="canEdit">
-							<input type="hidden" asp-for="Path" />
+						<form asp-page="/Wiki/Edit" asp-page-handler="RollbackLatest" asp-route-path="@Model.Path" condition="canEdit">
 							<input type="hidden" name="previousRevision" value="@(164)" />
 							<button condition="i == 0 && revision.Revision > 1" type="submit" class="btn btn-sm btn-warning" title="Rollback this revision"><i class="fa fa-undo"></i></button>
 						</form>

--- a/TASVideos/Pages/Wiki/PageHistory.cshtml.cs
+++ b/TASVideos/Pages/Wiki/PageHistory.cshtml.cs
@@ -71,6 +71,52 @@ public class PageHistoryModel : BasePageModel
 		}
 	}
 
+	public async Task<IActionResult> OnPostRollbackLatest(string path)
+	{
+		// TODO: it is more complex than this
+		if (!User.Has(PermissionTo.EditWikiPages))
+		{
+			return AccessDenied();
+		}
+
+		var latestRevision = await _wikiPages.Page(path);
+		if (latestRevision is null)
+		{
+			return NotFound();
+		}
+
+		if (latestRevision.Revision == 1)
+		{
+			return BadRequest("Cannot rollback the first revision of a page, just delete instead.");
+		}
+
+		var previousRevision = await _wikiPages.Query
+			.Where(wp => wp.PageName == path)
+			.ThatAreNotCurrent()
+			.OrderByDescending(wp => wp.Revision)
+			.FirstOrDefaultAsync();
+
+		if (previousRevision is null)
+		{
+			return NotFound();
+		}
+
+		var rollBackRevision = new WikiPage
+		{
+			PageName = path,
+			RevisionMessage = $"Rolling back Revision {latestRevision.Revision} \"{latestRevision.RevisionMessage}\"",
+			Markup = previousRevision.Markup,
+			AuthorId = User.GetUserId(),
+			MinorEdit = false
+		};
+
+		await _wikiPages.Add(rollBackRevision);
+
+		// TOOD: announce
+
+		return BasePageRedirect("PageHistory", new { Path = path, Latest = true });
+	}
+
 	private async Task<WikiDiffModel?> GetPageDiff(string pageName, int fromRevision, int toRevision)
 	{
 		var revisions = await _wikiPages.Query


### PR DESCRIPTION
Implements #558 
If permission to edit, the page history will show a rollback button on the latest revision.  If clicked, it will create a new commit that is an undo of the previous commit.

Pictures are helpful!

Objectionable revision created and shown on history:
![Rollback-start](https://user-images.githubusercontent.com/1679846/171254780-4b398029-72a1-487e-beb5-d76cb077beec.png)

When rollback is clicked:
![Rollback-rollback](https://user-images.githubusercontent.com/1679846/171254550-d7bbdb69-9d17-4d50-ab99-5f569716fe62.png)

External media publish message:
![Rollback-media-message](https://user-images.githubusercontent.com/1679846/171254521-47b7b0b8-6226-4114-9b45-6d6a517843e9.png)
