### PR TITLE
Sort judge activity table in a custom way

### DIFF
--- a/TASVideos/Pages/Activity/Judges.cshtml
+++ b/TASVideos/Pages/Activity/Judges.cshtml
@@ -9,6 +9,12 @@
 		or SubmissionStatus.PublicationUnderway);
 	var rejectedTotal = Model.Submissions.Count(s => s.Status == SubmissionStatus.Rejected);
 	var cancelledTotal = Model.Submissions.Count(s => s.Status == SubmissionStatus.Cancelled);
+	var orders = new Dictionary<SubmissionStatus, int>
+	{
+		{ SubmissionStatus.JudgingUnderWay, 3 },
+		{ SubmissionStatus.Delayed, 2 },
+		{ SubmissionStatus.NeedsMoreInfo, 1 }
+	};
 }
 
 <p>Submissions judged by <profile-link username="@Model.UserName"></profile-link></p>
@@ -25,7 +31,9 @@ Cancelled: @cancelledTotal (@cancelledTotal.ToPercent(total)%)
 			<th>Submission</th>
 			<th>Decision</th>
 		</tr>
-		@foreach (var sub in Model.Submissions.OrderBy(s => s.Status).ThenByDescending(s => s.Id))
+		@foreach (var sub in Model.Submissions
+			.OrderByDescending(s => orders.GetValueOrDefault(s.Status, 0))
+			.ThenByDescending(s => s.Id))
 		{
 			<tr>
 				<td>


### PR DESCRIPTION
Claimed submissions currently in progress (underway, delayed, info) go first and each group gets sorted by submission id, the rest go in one pile and just get sorted by submission id, as already judged.

fixes #1132

![изображение](https://user-images.githubusercontent.com/7092625/171257945-8481a449-4fa1-4db0-bd86-a16314c88a0c.png)
