### PR TITLE
stop passing Game.YoutubeTags to youtube

### DIFF
--- a/TASVideos.Core/Services/QueueService.cs
+++ b/TASVideos.Core/Services/QueueService.cs
@@ -376,7 +376,6 @@ internal class QueueService : IQueueService
 					queriedPub.WikiContent!,
 					queriedPub.System!.Code,
 					queriedPub.Authors.OrderBy(pa => pa.Ordinal).Select(a => a.Author!.UserName),
-					queriedPub.Game!.YoutubeTags,
 					queriedPub.ObsoletedById));
 			}
 		}
@@ -474,7 +473,6 @@ internal class QueueService : IQueueService
 				toObsolete.Authors
 					.OrderBy(pa => pa.Ordinal)
 					.Select(pa => pa.Author!.UserName),
-				toObsolete.Game!.YoutubeTags,
 				obsoletingPublicationId);
 
 			await _youtubeSync.SyncYouTubeVideo(obsoleteVideo);

--- a/TASVideos.Core/Services/Youtube/YouTubeSync.cs
+++ b/TASVideos.Core/Services/Youtube/YouTubeSync.cs
@@ -278,23 +278,11 @@ public record YoutubeVideo(
 	WikiPage WikiPage,
 	string SystemCode,
 	IEnumerable<string> Authors,
-	string? YoutubeTags,
 	int? ObsoletedBy)
 {
-	public IEnumerable<string> Tags
-	{
-		get
-		{
-			var tags = new[] { SystemCode }
-				.Concat(Authors);
-
-			if (!string.IsNullOrWhiteSpace(YoutubeTags))
-			{
-				tags = tags.Concat(YoutubeTags.SplitWithEmpty("-"));
-			}
-
-			tags = tags.Select(t => t.ToLower()).Distinct();
-			return tags;
-		}
-	}
+	public IEnumerable<string> Tags =>
+		new[] { SystemCode }
+			.Concat(Authors)
+			.Select(t => t.ToLower())
+			.Distinct();
 }

--- a/TASVideos/Pages/Publications/Edit.cshtml.cs
+++ b/TASVideos/Pages/Publications/Edit.cshtml.cs
@@ -268,7 +268,6 @@ public class EditModel : BasePageModel
 					publication.WikiContent,
 					publication.System!.Code,
 					publication.Authors.OrderBy(pa => pa.Ordinal).Select(a => a.Author!.UserName),
-					publication.Game!.YoutubeTags,
 					publication.ObsoletedById));
 			}
 		}

--- a/TASVideos/Pages/Publications/EditUrls.cshtml.cs
+++ b/TASVideos/Pages/Publications/EditUrls.cshtml.cs
@@ -99,7 +99,6 @@ public class EditUrlsModel : BasePageModel
 				SystemCode = p.System!.Code,
 				p.WikiContent,
 				Authors = p.Authors.OrderBy(pa => pa.Ordinal).Select(pa => pa.Author!.UserName),
-				p.Game!.YoutubeTags,
 				p.ObsoletedById
 			})
 			.SingleOrDefaultAsync();

--- a/TASVideos/Pages/Publications/EditUrls.cshtml.cs
+++ b/TASVideos/Pages/Publications/EditUrls.cshtml.cs
@@ -152,7 +152,6 @@ public class EditUrlsModel : BasePageModel
 					publication.WikiContent!,
 					publication.SystemCode,
 					publication.Authors,
-					publication.YoutubeTags,
 					publication.ObsoletedById);
 				await _youtubeSync.SyncYouTubeVideo(video);
 			}

--- a/TASVideos/Pages/Submissions/Publish.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Publish.cshtml.cs
@@ -177,7 +177,6 @@ public class PublishModel : BasePageModel
 				wikiPage,
 				submission.System.Code,
 				publication.Authors.OrderBy(pa => pa.Ordinal).Select(pa => pa.Author!.UserName),
-				submission.Game.YoutubeTags,
 				null);
 			await _youtubeSync.SyncYouTubeVideo(video);
 		}

--- a/tests/TASVideos.Core.Tests/Services/QueueServiceTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/QueueServiceTests.cs
@@ -575,7 +575,7 @@ public class QueueServiceTests
 
 		var wikiEntry = _db.WikiPages.Add(new WikiPage { Markup = "Test" });
 		var systemEntry = _db.GameSystems.Add(new GameSystem { Code = "Test" });
-		var gameEntry = _db.Games.Add(new Game { YoutubeTags = "Test" });
+		var gameEntry = _db.Games.Add(new Game());
 		var authorEntry = _db.Users.Add(new User { UserName = "Author" });
 
 		const int publicationId = 1;


### PR DESCRIPTION
See https://tasvideos.org/Forum/Posts/514909 for details as to why.  A possible plan is to eventually rename this field and use it for search, so we do not want to delete the column, just remove usages, for now.