### PR TITLE
forum: show tooltip for our custom URL tags if there's replacement text

### DIFF
--- a/TASVideos.ForumEngine/Node.cs
+++ b/TASVideos.ForumEngine/Node.cs
@@ -136,6 +136,7 @@ public class Element : INode
 		w.Attribute("href", href);
 		if (Options != "")
 		{
+			w.Attribute("title", await transformUrlText(Options));
 			await WriteChildren(w, h);
 		}
 		else

--- a/TASVideos/ViewComponents/WikiLink.cs
+++ b/TASVideos/ViewComponents/WikiLink.cs
@@ -46,7 +46,7 @@ public class WikiLink : ViewComponent
 			var title = await GetPublicationTitle(id.Value);
 			if (!string.IsNullOrWhiteSpace(title))
 			{
-				model.DisplayText = $"[{id.Value}]" + title;
+				model.DisplayText = $"[{id.Value}] " + title;
 			}
 		}
 


### PR DESCRIPTION
example:

`[movie=4689]pub[/movie]` is rendered as `pub` linking to that movie and showing `[4689] GB Gunman Clive by ViGadeomes in 00:47.17` on hover

also added space between [id] and pub title in wiki link