### PR TITLE
Forum:  Show tooltip on urls when appropriate

### DIFF
--- a/TASVideos.ForumEngine/Node.cs
+++ b/TASVideos.ForumEngine/Node.cs
@@ -129,20 +129,24 @@ public class Element : INode
 		}
 	}
 
-	private async Task WriteHref(HtmlWriter w, IWriterHelper h, Func<string, string> transformUrl, Func<string, Task<string>> transformUrlText)
+	private async Task WriteHref(HtmlWriter w, IWriterHelper h, Func<string, string> transformUrl, Func<string, Task<string>>? transformUrlText)
 	{
 		w.OpenTag("a");
 		var href = transformUrl(Options != "" ? Options : GetChildText());
 		w.Attribute("href", href);
 		if (Options != "")
 		{
+			if (transformUrlText != null)
+				w.Attribute("title", await transformUrlText(Options));
 			await WriteChildren(w, h);
 		}
 		else
 		{
 			// these were all parsed as ChildTagsIfParam, so we're guaranteed to have zero or one text children.
 			var text = Children.Cast<Text>().SingleOrDefault()?.Content ?? "";
-			w.Text(await transformUrlText(text));
+			if (transformUrlText != null)
+				text = await transformUrlText(text);
+			w.Text(text);
 		}
 
 		w.CloseTag("a");
@@ -280,10 +284,10 @@ public class Element : INode
 
 				break;
 			case "url":
-				await WriteHref(w, h, s => s, async s => s);
+				await WriteHref(w, h, s => s, null);
 				break;
 			case "email":
-				await WriteHref(w, h, s => "mailto:" + s, async s => s);
+				await WriteHref(w, h, s => "mailto:" + s, null);
 				break;
 			case "thread":
 				await WriteHref(w, h, s => "/Forum/Topics/" + s, async s => "Thread #" + s);


### PR DESCRIPTION
Example:

`[movie=4689]pub[/movie]` is rendered as `pub` linking to that movie and showing `[4689] GB Gunman Clive by ViGadeomes in 00:47.17` on hover.

In the implementation, we observe that `transformUrlText` should be shown somewhere so long as it's a non-trivial value.