### PR TITLE
Disable password truncation when registering

### DIFF
--- a/TASVideos/Pages/Account/Register.cshtml
+++ b/TASVideos/Pages/Account/Register.cshtml
@@ -25,7 +25,7 @@
 			</form-group>
 			<form-group>
 				<label asp-for="Password"></label>
-				<input asp-for="Password" class="form-control" autocomplete="new-password" />
+				<input asp-for="Password" class="form-control" autocomplete="new-password" maxlength="" />
 				<span asp-validation-for="Password" class="text-danger"></span>
 			</form-group>
 			<form-group>


### PR DESCRIPTION
Resolves #1361.
The password limit is still there, but now the user will be notified of it instead of the browser truncating the password.