### PR TITLE
Add bottom pager to places where top pager exists

### DIFF
--- a/TASVideos/Pages/Forum/Posts/Unanswered.cshtml
+++ b/TASVideos/Pages/Forum/Posts/Unanswered.cshtml
@@ -30,3 +30,4 @@
 		}
 	</table>
 </div>
+<partial name="_Pager" model="Model.Posts" />

--- a/TASVideos/Pages/Shared/Components/UserMaintenanceLogs/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/UserMaintenanceLogs/Default.cshtml
@@ -4,9 +4,7 @@
 	var pagingModel = ViewData["PagingModel"] as PagingModel ?? new PagingModel();
 }
 <div condition="@Model!.Any()">
-	<fullrow class="mt-2">
-		<partial name="_Pager" model="Model" />
-	</fullrow>
+	<partial name="_Pager" model="Model" />
 	<table>
 		<sortable-table-head sorting="@pagingModel" model-type="typeof(UserMaintenanceLogEntry)" page-override="@ViewData["CurrentPage"]" />
 		@foreach(var entry in Model!)
@@ -27,4 +25,5 @@
 			</tr>
 		}
 	</table>
+	<partial name="_Pager" model="Model" />
 </div>

--- a/TASVideos/Pages/Submissions/Index.cshtml
+++ b/TASVideos/Pages/Submissions/Index.cshtml
@@ -75,6 +75,7 @@
 		}
 	</table>
 </div>
+<partial name="_Pager" model="Model.Submissions" />
 @section Scripts {
 	<script src="/js/user-search.js"></script>
 	<script>

--- a/TASVideos/Pages/UserFiles/ForUser.cshtml
+++ b/TASVideos/Pages/UserFiles/ForUser.cshtml
@@ -16,3 +16,5 @@
 {
 	<partial name="_UserFileInfo" model="file" />
 }
+
+<partial name="_Pager" model="Model.Files" />

--- a/TASVideos/Pages/Users/List.cshtml
+++ b/TASVideos/Pages/Users/List.cshtml
@@ -34,3 +34,4 @@
 		</tr>
 	}
 </table>
+<partial name="_Pager" model="Model.Users" />


### PR DESCRIPTION
If a list is long enough to have pagination, we don't want to be scrolling up **every time** we don't find the thing on the current page.

Kinda clueless about exact html formatting, especially the `fullrow` thing, which visually changes very little in places I checked, but yet it's not always used together with the pager, so I dunno.