### PR TITLE
Userfiles

### DIFF
--- a/TASVideos/Pages/Shared/_UserFileInfo.cshtml
+++ b/TASVideos/Pages/Shared/_UserFileInfo.cshtml
@@ -17,14 +17,14 @@
 	var canEdit = Model.Author == User.Name() || User.Has(PermissionTo.EditUserFiles);
 }
 
-<div class="card mb-3">
-	<div class="card-header">
-		<h4>
+<div class="card border-primary border mb-2">
+	<cardheader>
+		<h4 class="mt-2">
 			#@Model.Id <span condition="Model.Hidden"><i>(unlisted)</i> </span>- @Model.Title
 			<span condition="canEdit" class="float-end">
 				<a asp-page="/UserFiles/Edit" asp-route-id="@Model.Id" asp-route-returnUrl="@Context.CurrentPathToReturnUrl()" class="btn btn-primary btn-sm border border-warning"><i class="fa fa-pencil"></i> Edit</a>
 				<delete-button
-					class="btn-sm",
+					class="btn-sm border border-warning",
 					warning-message="Are you sure you want to delete this file?"
 					asp-href="/UserFiles?handler=Delete&fileId=@Model.Id&returnUrl=@Context.CurrentPathToReturnUrl()"
 				>
@@ -32,99 +32,118 @@
 				</delete-button>
 			</span>
 		</h4>
-		
-	</div>
+	</cardheader>
+	<cardbody class="px-2 py-0">
+		<row class="gx-3">
+			<div class="col px-3 py-3" style="background-color: var(--bs-gray-200)">
+				@Model.FileName
 
-	<div class="card-body">
-		<div class="card-text">
-			<p>@Model.FileName</p>
-			<p>Uploaded <timezone-convert asp-for="@Model.UploadTimestamp" /> by <profile-link username="@Model.Author"></profile-link> (<a href="/UserFiles/ForUser/@Model.Author">@Model.AuthorUserFilesCount</a> files)</p>
+				<div condition="@(Model.IsMovie)">
+					In @FormatTime(Model.Time) (@Model.Frames frames), @Model.Rerecords rerecords
+				</div>
 
-			@if (Model.GameId.HasValue)
-			{
-				<p>
-					For
-					<a href="/Games/@Model.GameId">@Model.GameName</a>
-
-					<span condition="Model.GameSystem is not null">
-						(@(Model.GameSystem ?? Model.System))
+				<div condition="@(Model.GameId.HasValue)">
+					Game: <a href="/Games/@Model.GameId">@Model.GameName</a>
+					<span condition="!string.IsNullOrWhiteSpace(Model.GameSystem)">
+						(@(Model.GameSystem))
 					</span>
-				</p>
-			}
-			else if (Model.System is not null)
-			{
-				<text>For @Model.System</text>
-			}
+				</div>
 
-			@if (Model.IsMovie)
-			{
-				<p>In @FormatTime(Model.Time) (@Model.Frames frames), @Model.Rerecords rerecords</p>
-			}
+				<div condition="@(!Model.GameId.HasValue && !string.IsNullOrWhiteSpace(Model.System))">
+					System: @Model.System
+				</div>
 
-			<p>
-				@Model.Views view@(Model.Views == 1 ? "" : "s"),
-				@Model.Downloads download@(Model.Downloads == 1 ? "" : "s")
-			</p>
-		</div>
+				<div class="text-muted">
+					<div>
+						<span condition="@(Model.Comments.Any())">
+							@Model.Comments.Count() comment@(Model.Comments.Count() == 1 ? "" : "s"),
+						</span>
+						@Model.Views view@(Model.Views == 1 ? "" : "s"),
+						@Model.Downloads download@(Model.Downloads == 1 ? "" : "s")
+					</div>
+					<div>
+						Uploaded <timezone-convert asp-for="@Model.UploadTimestamp" /> by <profile-link username="@Model.Author"></profile-link> (<a href="/UserFiles/ForUser/@Model.Author">@Model.AuthorUserFilesCount</a> files)
+					</div>
+				</div>
 
-		@if (!string.IsNullOrEmpty(Model.Description))
-		{
-			<hr />
-			<div class="card-text">
-				<wiki-markup markup=@Model.Description></wiki-markup>
+				<div class="mt-2">
+					<a asp-page="/UserFiles/Info" asp-page-handler="Download" asp-route-id="@Model.Id" class="btn btn-secondary">
+						<i class="fa fa-download"></i> Download (@Model.FileSizeUncompressed.ToSizeString())
+					</a>
+					<a asp-page="/UserFiles/Info" asp-route-id="@Model.Id" class="btn btn-secondary">
+						<i class="fa fa-info-circle"></i> Information
+					</a>
+				</div>
 			</div>
-		}
+		</row>
 
-		<hr />
-		@if (Model.Comments.Any())
-		{
+		<div class="col d-flex flex-column py-2 px-2" condition="@(!string.IsNullOrEmpty(Model.Description))">
+				<wiki-markup markup=@Model.Description></wiki-markup>
+		</div>
+	</cardbody>
+</div>
 
-			<collapsablecontent-header body-id="collapse-content-userfile-@Model.Id">
-				<strong>Comments</strong>
-			</collapsablecontent-header>
-			<collapsablecontent-body id="collapse-content-userfile-@Model.Id" start-shown="@true">
-				@foreach (var comment in Model.Comments.OrderBy(c => c.CreationTimeStamp))
-				{
-					<profile-link username="@comment.UserName"></profile-link><span> </span><timezone-convert asp-for="@comment.CreationTimeStamp" in-line="true" />
-					<wiki-markup markup="@comment.Text" id="view-comment-@comment.Id"></wiki-markup>
-					<div condition="User.Has(PermissionTo.EditForumPosts) || User.GetUserId() == comment.UserId">
-						<div class="d-none" id="edit-comment-@comment.Id">
-							<form method="POST" asp-page="/UserFiles/Index" asp-route-handler="EditComment" asp-route-returnUrl="@Context.CurrentPathToReturnUrl()">
-								<input type="hidden" name="commentId" value="@comment.Id" />
-								<textarea name="comment" class="form-control">@comment.Text</textarea>
-								<button type="submit" class="btn btn-primary btn-sm mt-1"><i class="fa fa-save"></i> Save</button>
-							</form>
-						</div>
-						
-						<button type="button" class="btn btn-primary btn-sm mb-2" onclick="this.classList.add('d-none'); document.getElementById('edit-comment-@comment.Id').classList.remove('d-none'); document.getElementById('view-comment-@comment.Id').classList.add('d-none');"><i class="fa fa-pencil"></i> Edit</button>
+@foreach (var comment in Model.Comments.OrderBy(c => c.CreationTimeStamp))
+{
+	<div class="card border-primary border mb-2" condition="@(Model.Comments.Any())">
+		<cardheader>
+			<row>
+				<div class="col">
+					<h6>
+						<profile-link username="@comment.UserName"></profile-link>
+					</h6>
+					<div class="text-muted">
+						<timezone-convert asp-for="@comment.CreationTimeStamp" in-line="true" />
+					</div>
+				</div>
+				<div class="col" condition="User.Has(PermissionTo.EditForumPosts) || User.GetUserId() == comment.UserId">
+					<div class="float-end mb-1 mt-1">
+						<button type="button" class="btn btn-primary btn-sm border border-warning" id="edit-button-@comment.Id" onclick="
+							this.classList.add('d-none');
+							document.getElementById('edit-comment-@comment.Id').classList.remove('d-none');
+							document.getElementById('view-comment-@comment.Id').classList.add('d-none');
+							"><i class="fa fa-pencil"></i> Edit
+						</button>
 						<delete-button
-							class="btn-sm mb-2"
+							class="btn-sm border border-warning"
 							asp-href="/UserFiles/Index?handler=DeleteComment&commentId=@comment.Id&returnUrl=@Context.CurrentPathToReturnUrl()"
 							warning-message="Are you sure you want to delete this comment?"
 							condition="User.Has(PermissionTo.EditForumPosts) || User.GetUserId() == comment.UserId">
 							<i class="fa fa-remove"></i>
 						</delete-button>
 					</div>
-				}
-			</collapsablecontent-body>
-			<hr />
-		}
-		
-		<div permission="CreateForumPosts">
-			<form method="POST" asp-page="/UserFiles/Index" asp-route-handler="Comment" asp-route-returnUrl="@Context.CurrentPathToReturnUrl()">
-				<input type="hidden" name="fileId" value="@Model.Id "/>
-				<label class="form-control-label">Comment:</label>
-				<textarea class="form-control" name="comment"></textarea>
-				<button type="submit" class="btn btn-primary mt-1"><i class="fa fa-plus"></i> Post</button>
-			</form>
-			<hr />
-		</div>
-		<a asp-page="/UserFiles/Info" asp-page-handler="Download" asp-route-id="@Model.Id" class="card-link">
-			<i class="fa fa-download"></i> Download (@Model.FileSizeUncompressed.ToSizeString())
-		</a>
-
-		<a asp-page="/UserFiles/Info" asp-route-id="@Model.Id" class="card-link">
-			<i class="fa fa-info-circle"></i> Info
-		</a>
+				</div>
+			</row>
+		</cardheader>
+		<cardbody>
+			<wiki-markup markup="@comment.Text" id="view-comment-@comment.Id"></wiki-markup>
+			<div class="d-none" id="edit-comment-@comment.Id">
+				<form method="POST" asp-page="/UserFiles/Index" asp-route-handler="EditComment" asp-route-returnUrl="@Context.CurrentPathToReturnUrl()">
+					<input type="hidden" name="commentId" value="@comment.Id" />
+					<textarea name="comment" class="form-control">@comment.Text</textarea>
+					<button type="submit" class="btn btn-primary btn-sm mt-2"><i class="fa fa-save"></i> Save</button>
+					<button type="button" class="btn btn-secondary btn-sm mt-2" onclick="
+						document.getElementById('edit-comment-@comment.Id').classList.add('d-none');
+						document.getElementById('view-comment-@comment.Id').classList.remove('d-none');
+						document.getElementById('edit-button-@comment.Id').classList.remove('d-none');
+						"><i class="fa fa-times"></i> Cancel
+					</button>
+				</form>
+			</div>
+		</cardbody>
 	</div>
+}
+
+<div class="card border-primary border mb-2" permission="CreateForumPosts">
+	<cardheader style="background-color: var(--bs-gray-200)">
+		<h4>Comment:</h4>
+	</cardheader>
+	<cardbody>
+		<form method="POST" asp-page="/UserFiles/Index" asp-route-handler="Comment" asp-route-returnUrl="@Context.CurrentPathToReturnUrl()">
+			<input type="hidden" name="fileId" value="@Model.Id "/>
+			<label class="form-control-label"></label>
+			<textarea class="form-control" name="comment"></textarea>
+			<button type="submit" class="btn btn-primary mt-3 mb-3"><i class="fa fa-plus"></i> Post</button>
+		</form>
+	</cardbody>
 </div>

--- a/TASVideos/TagHelpers/CollapsableTagHelper.cs
+++ b/TASVideos/TagHelpers/CollapsableTagHelper.cs
@@ -23,14 +23,6 @@ public class CollapsableHeaderTagHelper : TagHelper
 				<a class='collapsed' data-bs-toggle='collapse' {Attr("href", "#" + BodyId)} aria-expanded='false' aria-controls='collapse1' role='button'>
 					{content}
 				</a>
-				<a
-					data-bs-toggle='collapse'
-					class='collapsed btn btn-default btn-xs text-end'
-					{Attr("href", "#" + BodyId)}
-					{Attr("aria-label", $"Expand/Collapse {BodyId}")}
-					aria-expanded='false'
-					role='button'
-				>
 					<i class='fa' aria-hidden='true'></i>
 					<span class='sr-only'>Expand/Collapse {Text(BodyId)}</span>
 				</a>


### PR DESCRIPTION
before

![2](https://user-images.githubusercontent.com/7092625/178557770-3cf451d3-9e43-4119-a7dd-b521e5653cee.png)

after 

![1](https://user-images.githubusercontent.com/7092625/178557660-d6e231a6-f337-40d0-952d-b672b8369ce5.png)

I don't know how to stop showing comments if the userfile is viewed among other userfiles (per game or per user). But when it's viewed on its own, it doesn't make sense to collapse/uncollapse them.