### PR TITLE
Wiki: Turn TOC into a card telling it's a TOC

### DIFF
--- a/TASVideos.WikiEngine/MakeToc.cs
+++ b/TASVideos.WikiEngine/MakeToc.cs
@@ -18,11 +18,11 @@ public static partial class Builtins
 			.Cast<Element>()
 			.ToList();
 
-		var ret = new Element(charStart, "div") { Attributes = { ["class"] = "card" } };
-		var header = new Element(charStart, "div") { Attributes = { ["class"] = "card-header" } };
 		var strong = new Element(charStart, "strong");
 		strong.Children.Add(new Text(charStart, "Table of contents"));
+		var header = new Element(charStart, "div") { Attributes = { ["class"] = "card-header" } };
 		header.Children.Add(strong);
+		var ret = new Element(charStart, "div") { Attributes = { ["class"] = "card" } };
 		ret.Children.Add(header);
 		
 		var stack = new Stack<Element>();

--- a/TASVideos.WikiEngine/MakeToc.cs
+++ b/TASVideos.WikiEngine/MakeToc.cs
@@ -27,8 +27,6 @@ public static partial class Builtins
 		var body = new Element(charStart, "div") { Attributes = { ["class"] = "card-body" } };
 		ret.Children.Add(body);
 		var stack = new Stack<Element>();
-		stack.Push(ret);
-		stack.Push(header);
 		stack.Push(body);
 
 		var pos = (headings.Min(h => (int?)(h.Tag[1] - '0')) ?? 2) - 1; // if the biggest heading is h3 or h4, make that the top level

--- a/TASVideos.WikiEngine/MakeToc.cs
+++ b/TASVideos.WikiEngine/MakeToc.cs
@@ -22,7 +22,7 @@ public static partial class Builtins
 		strong.Children.Add(new Text(charStart, "Table of contents"));
 		var header = new Element(charStart, "div") { Attributes = { ["class"] = "card-header" } };
 		header.Children.Add(strong);
-		var ret = new Element(charStart, "div") { Attributes = { ["class"] = "card" } };
+		var ret = new Element(charStart, "div") { Attributes = { ["class"] = "card mb-2" } };
 		ret.Children.Add(header);
 		
 		var stack = new Stack<Element>();

--- a/TASVideos.WikiEngine/MakeToc.cs
+++ b/TASVideos.WikiEngine/MakeToc.cs
@@ -18,10 +18,18 @@ public static partial class Builtins
 			.Cast<Element>()
 			.ToList();
 
-		var ret = new Element(charStart, "div") { Attributes = { ["class"] = "toc" } };
+		var ret = new Element(charStart, "div") { Attributes = { ["class"] = "card" } };
+		var header = new Element(charStart, "div") { Attributes = { ["class"] = "card-header" } };
+		var strong = new Element(charStart, "strong");
+		strong.Children.Add(new Text(charStart, "Table of contents"));
+		header.Children.Add(strong);
+		ret.Children.Add(header);
+		var body = new Element(charStart, "div") { Attributes = { ["class"] = "card-body" } };
+		ret.Children.Add(body);
 		var stack = new Stack<Element>();
 		stack.Push(ret);
-		stack.Push(new Element(charStart, "div") { Attributes = { ["class"] = "card-header" } });
+		stack.Push(header);
+		stack.Push(body);
 
 		var pos = (headings.Min(h => (int?)(h.Tag[1] - '0')) ?? 2) - 1; // if the biggest heading is h3 or h4, make that the top level
 

--- a/TASVideos.WikiEngine/MakeToc.cs
+++ b/TASVideos.WikiEngine/MakeToc.cs
@@ -24,9 +24,10 @@ public static partial class Builtins
 		strong.Children.Add(new Text(charStart, "Table of contents"));
 		header.Children.Add(strong);
 		ret.Children.Add(header);
+		
+		var stack = new Stack<Element>();
 		var body = new Element(charStart, "div") { Attributes = { ["class"] = "card-body" } };
 		ret.Children.Add(body);
-		var stack = new Stack<Element>();
 		stack.Push(body);
 
 		var pos = (headings.Min(h => (int?)(h.Tag[1] - '0')) ?? 2) - 1; // if the biggest heading is h3 or h4, make that the top level

--- a/TASVideos.WikiEngine/MakeToc.cs
+++ b/TASVideos.WikiEngine/MakeToc.cs
@@ -21,6 +21,7 @@ public static partial class Builtins
 		var ret = new Element(charStart, "div") { Attributes = { ["class"] = "toc" } };
 		var stack = new Stack<Element>();
 		stack.Push(ret);
+		stack.Push(new Element(charStart, "div") { Attributes = { ["class"] = "card-header" } });
 
 		var pos = (headings.Min(h => (int?)(h.Tag[1] - '0')) ?? 2) - 1; // if the biggest heading is h3 or h4, make that the top level
 

--- a/TASVideos.WikiEngine/MakeToc.cs
+++ b/TASVideos.WikiEngine/MakeToc.cs
@@ -24,7 +24,7 @@ public static partial class Builtins
 		header.Children.Add(strong);
 		var ret = new Element(charStart, "div") { Attributes = { ["class"] = "card mb-2" } };
 		ret.Children.Add(header);
-		
+
 		var stack = new Stack<Element>();
 		var body = new Element(charStart, "div") { Attributes = { ["class"] = "card-body" } };
 		ret.Children.Add(body);


### PR DESCRIPTION
If TOC is used non-trivially, it can get incredibly confusing.

https://tasvideos.org/Reviews

![изображение](https://user-images.githubusercontent.com/7092625/180049772-5c0d896a-2d0b-44cb-b174-e06c91753a08.png)

After my change it's now

![изображение](https://user-images.githubusercontent.com/7092625/180049844-41c12347-de72-43ba-b87c-5a096a45ca39.png)

I don't know how to add an empty line after the card, should I just append a linebreak? Also I dunno if the empty line after the last marker can be removed. Finally, I had no idea what I was doing in terms of html baking, but at least the intent should be obvious.