### PR TITLE
Display publisher and judge stats as rows (+tiny tweaks)

### DIFF
--- a/TASVideos/Pages/Activity/Judges.cshtml
+++ b/TASVideos/Pages/Activity/Judges.cshtml
@@ -20,9 +20,9 @@
 <p>Submissions judged by <profile-link username="@Model.UserName"></profile-link></p>
 <hr />
 <label>Total: @total</label><br />
-Accepted: @acceptedTotal (@acceptedTotal.ToPercent(total)%)
-Rejected: @rejectedTotal (@rejectedTotal.ToPercent(total)%)
-Cancelled: @cancelledTotal (@cancelledTotal.ToPercent(total)%)
+<div>Accepted: @acceptedTotal (@acceptedTotal.ToPercent(total)%)</div>
+<div>Rejected: @rejectedTotal (@rejectedTotal.ToPercent(total)%)</div>
+<div>Cancelled: @cancelledTotal (@cancelledTotal.ToPercent(total)%)</div>
 <hr />
 <div class="table-container">
 	<table class="table table-striped">

--- a/TASVideos/Pages/Activity/Publishers.cshtml
+++ b/TASVideos/Pages/Activity/Publishers.cshtml
@@ -2,8 +2,30 @@
 @{ ViewData["Title"] = $"Publisher Activity for {Model.UserName}"; }
 @model PublishersModel
 
+@{
+	var counts = new Dictionary<string, int>();
+	var total = Model.Publications.Count();
+	var classes = Model.Publications
+		.Select(p => p.Class)
+		.Distinct();
+	foreach (var c in classes)
+	{
+		counts.Add(c, Model.Publications
+			.Select(p => p)
+			.Where(p => p.Class == c)
+			.Count());
+	}
+}
+
 <p>Movies published by <profile-link username="@Model.UserName"></profile-link></p>
 <hr />
+<label>Total: @total</label>
+@foreach (var c in counts)
+{
+	<div>@c.Key: @c.Value</div>
+}
+<hr />
+
 <div class="table-container">
 	<table class="table table-striped">
 		<tr>

--- a/TASVideos/Pages/Activity/Publishers.cshtml
+++ b/TASVideos/Pages/Activity/Publishers.cshtml
@@ -3,24 +3,17 @@
 @model PublishersModel
 
 @{
-	var counts = new Dictionary<string, int>();
 	var total = Model.Publications.Count();
-	var classes = Model.Publications
-		.Select(p => p.Class)
-		.Distinct();
-	foreach (var c in classes)
-	{
-		counts.Add(c, Model.Publications
-			.Select(p => p)
-			.Where(p => p.Class == c)
-			.Count());
-	}
+
+	var classCounts = Model.Publications
+		.GroupBy(p => p.Class)
+		.ToDictionary(tkey => tkey.Key, tvalue => tvalue.Count());
 }
 
 <p>Movies published by <profile-link username="@Model.UserName"></profile-link></p>
 <hr />
 <label>Total: @total</label>
-@foreach (var c in counts)
+@foreach (var c in classCounts)
 {
 	<div>@c.Key: @c.Value</div>
 }

--- a/TASVideos/Pages/Shared/_Profile.cshtml
+++ b/TASVideos/Pages/Shared/_Profile.cshtml
@@ -4,24 +4,32 @@
 }
 <row>
 	<div class="col-md-6">
-		<card>
+		<card class="mb-2">
 			<cardheader>
-				<h4>
-					<a condition="User.IsLoggedIn() && User.Name() != Model.UserName"
-					   asp-page="/Messages/Create"
-					   asp-route-defaultToUser="@Model.UserName"
-					   class="btn btn-secondary btn-sm">
-						<i class="fa fa-envelope"></i> PM
-					</a>
-					<a permission="EditUsers"
-					   asp-page="/Users/Edit"
-					   asp-route-returnUrl="@Context.CurrentPathToReturnUrl()"
-					   asp-route-id="@Model.Id"
-					   class="btn btn-primary btn-sm border border-warning">
-						<i class="fa fa-pencil"></i> Edit
-					</a>
-					@Model.UserName
-				</h4>
+				<row>
+					<div class="col">
+						<h4>
+							@Model.UserName
+						</h4>
+					</div>
+					<div class="col">
+						<div class="float-end">
+							<a condition="User.IsLoggedIn() && User.Name() != Model.UserName"
+							asp-page="/Messages/Create"
+							asp-route-defaultToUser="@Model.UserName"
+							class="btn btn-secondary btn-sm">
+								<i class="fa fa-envelope"></i> PM
+							</a>
+							<a permission="EditUsers"
+							asp-page="/Users/Edit"
+							asp-route-returnUrl="@Context.CurrentPathToReturnUrl()"
+							asp-route-id="@Model.Id"
+							class="btn btn-primary btn-sm border border-warning">
+								<i class="fa fa-pencil"></i> Edit
+							</a>
+						</div>
+					</div>
+				</row>
 			</cardheader>
 			<cardbody>
 				<img condition="@(!string.IsNullOrWhiteSpace(Model.Avatar))" src="@Model.Avatar" class="float-end" />
@@ -99,7 +107,7 @@
 				<forum-markup markup=@Model.Signature enable-html=false enable-bb-code=true></forum-markup>
 			</div>
 		</card>
-		<card>
+		<card class="mb-2">
 			<cardheader><h4>Roles</h4></cardheader>
 			<cardbody>
 				@if (Model.Roles.Any())
@@ -116,19 +124,19 @@
 				}
 			</cardbody>
 		</card>
-		<card>
+		<card class="mb-2">
 			<cardheader condition="Model.Judgments.TotalJudgments > 0"><h4>Judgments</h4></cardheader>
 			<cardbody>
 				<p>Total movies judged: <a asp-page="/Activity/Judges" asp-route-username="@Model.UserName">@Model.Judgments.TotalJudgments</a></p>
 			</cardbody>
 		</card>
-		<card>
+		<card class="mb-2">
 			<cardheader condition="Model.Publishing.TotalPublished > 0"><h4>Publishing</h4></cardheader>
 			<cardbody>
 				<p>Total movies published: <a asp-page="/Activity/Publishers" asp-route-username="@Model.UserName">@Model.Publishing.TotalPublished</a></p>
 			</cardbody>
 		</card>
-		<card condition="Model.WikiEdits.TotalEdits > 0">
+		<card class="mb-2" condition="Model.WikiEdits.TotalEdits > 0">
 			<cardheader><h4>Wiki</h4></cardheader>
 			<cardbody>
 				<div>
@@ -146,7 +154,7 @@
 		</card>
 	</div>
 	<div class="col-md-6">
-		<card class="text-start text-md-end">
+		<card class="text-start text-md-end mb-2">
 			<cardheader><h4>Publications</h4></cardheader>
 			<cardbody>
 				<div condition="!Model.AnyPublications" class="card-text">
@@ -167,7 +175,7 @@
 				</div>
 			</cardbody>
 		</card>
-		<card class="text-start text-md-end">
+		<card class="text-start text-md-end mb-2">
 			<cardheader><h4>Submissions</h4></cardheader>
 			<cardbody>
 				<div condition="Model.SubmissionCount == 0" class="card-text">
@@ -197,7 +205,7 @@
 				</div>
 			</cardbody>
 		</card>
-		<card class="text-start text-md-end">
+		<card class="text-start text-md-end mb-2">
 			<cardheader><h4>Ratings</h4></cardheader>
 			<cardbody>
 				<a class="btn btn-warning btn-sm" a asp-page="/Users/Ratings" asp-route-userName="@Model.UserName">See Ratings</a>
@@ -215,7 +223,7 @@
 				</div>
 			</cardbody>
 		</card>
-		<card class="text-start text-md-end" condition="Model.UserFiles.Total > 0">
+		<card class="text-start text-md-end mb-2" condition="Model.UserFiles.Total > 0">
 			<cardheader>
 				<h4>User Files</h4>
 			</cardheader>

--- a/TASVideos/ViewComponents/WikiLink.cs
+++ b/TASVideos/ViewComponents/WikiLink.cs
@@ -46,7 +46,7 @@ public class WikiLink : ViewComponent
 			var title = await GetPublicationTitle(id.Value);
 			if (!string.IsNullOrWhiteSpace(title))
 			{
-				model.DisplayText = $"[{id.Value}]" + title;
+				model.DisplayText = $"[{id.Value}] " + title;
 			}
 		}
 


### PR DESCRIPTION
- move profile cards 2px away from each other vertically
- move profile buttons to the right
- add space to replacement text of pub links

![изображение](https://user-images.githubusercontent.com/7092625/181362227-a55259fd-1dd7-4d11-a4e1-1465eb8ecdb0.png)

Outdated pic, those buttons are in the reversed order on it, fixed since then:

![изображение](https://user-images.githubusercontent.com/7092625/181362154-089ae379-7c66-4109-aa03-1e7afbc8ea04.png)
