### PR TITLE
Use only \n lineendings for <pre> blocks

### DIFF
--- a/TASVideos/Pages/Error.cshtml
+++ b/TASVideos/Pages/Error.cshtml
@@ -8,7 +8,7 @@
 <h5>@Model.StatusCodeString</h5>
 <div condition="!string.IsNullOrEmpty(Model.ExceptionMessage)">
 	<span>Exception:</span>
-	<pre>@Model.ExceptionMessage</pre>
+	<pre>@Model.ExceptionMessage.ReplaceLineEndings("\n")</pre>
 </div>
 <div condition="Model.RecoveredFormData.Count != 0">
 	<span>Submitted Form Data:</span>

--- a/TASVideos/Pages/Wiki/ViewSource.cshtml
+++ b/TASVideos/Pages/Wiki/ViewSource.cshtml
@@ -13,4 +13,4 @@
 	<a href="/@Model.WikiPage.PageName" class="btn btn-secondary"><span class="fa fa-arrow-left"></span> Back to Page</a>
 </div>
 <hr />
-<pre>@Model.WikiPage.Markup</pre>
+<pre>@Model.WikiPage.Markup.ReplaceLineEndings("\n")</pre>


### PR DESCRIPTION
This circumvents the firefox bug that doubles \r\n in &lt;pre&gt; blocks when copying.

This is the bug from 2009 https://bugzilla.mozilla.org/show_bug.cgi?id=514006