### PR TITLE
Only check for Game Abbreviation collision if a non-null value is provided

### DIFF
--- a/TASVideos/Pages/Games/Edit.cshtml.cs
+++ b/TASVideos/Pages/Games/Edit.cshtml.cs
@@ -89,7 +89,7 @@ public class EditModel : BasePageModel
 			}
 		}
 
-		if (await _db.Games.AnyAsync(g => g.Id != Id && g.Abbreviation == Game.Abbreviation))
+		if (Game.Abbreviation != null && await _db.Games.AnyAsync(g => g.Id != Id && g.Abbreviation == Game.Abbreviation))
 		{
 			ModelState.AddModelError($"{nameof(Game)}.{nameof(Game.Abbreviation)}", $"Abbreviation {Game.Abbreviation} already exists");
 		}


### PR DESCRIPTION
I'm intentionally not using a `string.IsNullOrEmpty` because this way the line exactly matches how the database does the unique check: allowing either null or unique values. An empty string should not be allowed to short-circuit the if statement, because it doesn't in the database.