### PR TITLE
Create user setting to always/never watch topic for replies

### DIFF
--- a/TASVideos.Data/Entity/User.cs
+++ b/TASVideos.Data/Entity/User.cs
@@ -6,6 +6,11 @@ using TASVideos.Data.Entity.Forum;
 
 namespace TASVideos.Data.Entity;
 
+public enum UserPreference
+{
+	Auto = 0, Always, Never
+}
+
 [ExcludeFromHistory]
 public class User : IdentityUser<int>, ITrackable
 {
@@ -45,6 +50,8 @@ public class User : IdentityUser<int>, ITrackable
 	public PreferredPronounTypes PreferredPronouns { get; set; } = PreferredPronounTypes.Unspecified;
 
 	public bool EmailOnPrivateMessage { get; set; }
+
+	public UserPreference? AutoWatchTopic { get; set; }
 
 	public virtual ICollection<UserRole> UserRoles { get; set; } = new HashSet<UserRole>();
 	public virtual ICollection<SubmissionAuthor> Submissions { get; set; } = new HashSet<SubmissionAuthor>();

--- a/TASVideos.Data/Migrations/20220813223128_AddWatchUserPreference.Designer.cs
+++ b/TASVideos.Data/Migrations/20220813223128_AddWatchUserPreference.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,10 @@ using TASVideos.Data;
 namespace TASVideos.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220813223128_AddWatchUserPreference")]
+    partial class AddWatchUserPreference
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TASVideos.Data/Migrations/20220813223128_AddWatchUserPreference.cs
+++ b/TASVideos.Data/Migrations/20220813223128_AddWatchUserPreference.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TASVideos.Data.Migrations
+{
+    public partial class AddWatchUserPreference : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "auto_watch_topic",
+                table: "users",
+                type: "integer",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "auto_watch_topic",
+                table: "users");
+        }
+    }
+}

--- a/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
@@ -92,6 +92,13 @@ public class CreateModel : BaseForumModel
 
 		WatchTopic = await _topicWatcher.IsWatchingTopic(TopicId, User.GetUserId());
 
+		// Override default behavior if user setting demands it, even if they were already watching the topic
+		var user = await _userManager.GetUserAsync(User);
+		if (user.AutoWatchTopic != null && user.AutoWatchTopic != UserPreference.Auto)
+		{
+			WatchTopic = user.AutoWatchTopic == UserPreference.Always;
+		}
+
 		PreviousPosts = await _db.ForumPosts
 			.ForTopic(TopicId)
 			.Select(fp => new MiniPostModel

--- a/TASVideos/Pages/Forum/Topics/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Create.cshtml.cs
@@ -61,6 +61,13 @@ public class CreateModel : BaseForumModel
 
 		Topic = topic;
 		UserAvatars = await _forumService.UserAvatars(User.GetUserId());
+
+		var user = await _userManager.GetUserAsync(User);
+		if (user.AutoWatchTopic != null && user.AutoWatchTopic != UserPreference.Auto)
+		{
+			WatchTopic = user.AutoWatchTopic == UserPreference.Always;
+		}
+
 		return Page();
 	}
 

--- a/TASVideos/Pages/Profile/Models/ProfileSettingsModel.cs
+++ b/TASVideos/Pages/Profile/Models/ProfileSettingsModel.cs
@@ -37,5 +37,8 @@ public class ProfileSettingsModel
 	[Display(Name = "Email On New Private Message?")]
 	public bool EmailOnPrivateMessage { get; set; }
 
+	[Display(Name = "Automatically Watch Topics When Posting")]
+	public UserPreference AutoWatchTopic { get; set; }
+
 	public IEnumerable<RoleDto> Roles { get; set; } = new List<RoleDto>();
 }

--- a/TASVideos/Pages/Profile/Settings.cshtml
+++ b/TASVideos/Pages/Profile/Settings.cshtml
@@ -69,6 +69,10 @@
 					</label>
 				</div>
 			</form-group>
+			<form-group>
+				<label asp-for="Settings.AutoWatchTopic"></label>
+				<select asp-for="Settings.AutoWatchTopic" asp-items="@SettingsModel.AvailableUserPreferenceTypes" class="form-control"></select>
+			</form-group>
 		</column>
 		<column lg="6">
 			<form-group>

--- a/TASVideos/Pages/Profile/Settings.cshtml.cs
+++ b/TASVideos/Pages/Profile/Settings.cshtml.cs
@@ -36,6 +36,16 @@ public class SettingsModel : BasePageModel
 		})
 		.ToList();
 
+	public static readonly IEnumerable<SelectListItem> AvailableUserPreferenceTypes = Enum
+		.GetValues(typeof(UserPreference))
+		.Cast<UserPreference>()
+		.Select(m => new SelectListItem
+		{
+			Value = ((int)m).ToString(),
+			Text = m.EnumDisplayName()
+		})
+		.ToList();
+
 	[BindProperty]
 	public ProfileSettingsModel Settings { get; set; } = new();
 
@@ -55,7 +65,8 @@ public class SettingsModel : BasePageModel
 			MoodAvatar = user.MoodAvatarUrlBase,
 			PreferredPronouns = user.PreferredPronouns,
 			EmailOnPrivateMessage = user.EmailOnPrivateMessage,
-			Roles = await _userManager.UserRoles(user.Id)
+			Roles = await _userManager.UserRoles(user.Id),
+			AutoWatchTopic = user.AutoWatchTopic ?? UserPreference.Auto
 		};
 	}
 
@@ -104,6 +115,7 @@ public class SettingsModel : BasePageModel
 		user.MoodAvatarUrlBase = User.Has(PermissionTo.UseMoodAvatars) ? Settings.MoodAvatar : null;
 		user.PreferredPronouns = Settings.PreferredPronouns;
 		user.EmailOnPrivateMessage = Settings.EmailOnPrivateMessage;
+		user.AutoWatchTopic = Settings.AutoWatchTopic;
 		await _db.SaveChangesAsync();
 
 		SuccessStatusMessage("Your profile has been updated");


### PR DESCRIPTION
Resolves #929 

Adds a new user setting with Always, Never, or Auto.  Auto will fallback to default behavior (in topics, it is defaulting to true, in post create, it is only true if already watching the topic).

UI on the Profile/Settings screen
![image](https://user-images.githubusercontent.com/1679846/184516941-3df25787-0c16-4b05-ad4c-10b33dedf4dc.png)
