### PR TITLE
Fix space not available error

### DIFF
--- a/TASVideos.Core/Services/IUserFiles.cs
+++ b/TASVideos.Core/Services/IUserFiles.cs
@@ -27,7 +27,6 @@ public interface IUserFiles
 	/// <summary>
 	/// Uploads a file for the user to user files
 	/// </summary>
-	/// <exception cref="InvalidOperationException">Thrown if space is not available <seealso cref="SpaceAvailable"/></exception>
 	/// <returns>The id of the saved file and an <seealso cref="IParseResult"/> if the file is a movie type</returns>
 	Task<(long id, IParseResult? parseResult)> Upload(int userId, UserFileUpload file);
 }
@@ -76,11 +75,6 @@ internal class UserFiles : IUserFiles
 
 	public async Task<(long, IParseResult?)> Upload(int userId, UserFileUpload file)
 	{
-		if (!await SpaceAvailable(userId, file.FileData.Length))
-		{
-			throw new InvalidOperationException($"Not enough space available to upload file {file.FileName}");
-		}
-
 		var fileExt = Path.GetExtension(file.FileName);
 		var userFile = new UserFile
 		{

--- a/tests/TASVideos.Core.Tests/Services/UserFilesTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/UserFilesTests.cs
@@ -174,23 +174,6 @@ public class UserFilesTests
 	}
 
 	[TestMethod]
-	[ExpectedException(typeof(InvalidOperationException))]
-	public async Task Upload_Throws_IfSpaceNotAvailable()
-	{
-		const int userId = 1;
-		_db.UserFiles.Add(new UserFile
-		{
-			Id = 1,
-			AuthorId = userId,
-			Content = new byte[SiteGlobalConstants.UserFileStorageLimit],
-			CompressionType = Compression.None
-		});
-		await _db.SaveChangesAsync();
-
-		await _userFiles.Upload(userId, new("title", "desc", null, null, new byte[] { 0xFF }, "script.lua", true));
-	}
-
-	[TestMethod]
 	public async Task Upload_SupplementalFile_Success()
 	{
 		const int userId = 1;


### PR DESCRIPTION
The filesize passed here is the uncompressed file size rather than the compressed file size. We already check the compressed file size earlier here, no need to try to do the check again.