### PR TITLE
Change Primary Movie Replacement log to be consistent with all the other logs

### DIFF
--- a/TASVideos/Pages/Publications/PrimaryMovie.cshtml.cs
+++ b/TASVideos/Pages/Publications/PrimaryMovie.cshtml.cs
@@ -77,15 +77,15 @@ public class PrimaryMoviesModel : BasePageModel
 			return Page();
 		}
 
-		string log = $"Replaced Primary movie file from {publication.MovieFileName} to {PrimaryMovieFile!.FileName} for reason: {Reason}";
-		publication.MovieFileName = PrimaryMovieFile.FileName;
+		string log = $"Primary movie file replaced, Reason: {Reason}";
+		publication.MovieFileName = PrimaryMovieFile!.FileName;
 		publication.MovieFile = await PrimaryMovieFile.ToBytes();
 		await _publicationMaintenanceLogger.Log(Id, User.GetUserId(), log);
 		var result = await ConcurrentSave(_db, log, "Unable to add file");
 		if (result)
 		{
 			await _publisher.SendPublicationEdit(
-				$"{Id}M publication primary movie file changed by {User.Name()}",
+				$"{Id}M edited by {User.Name()}",
 				$"{log} | {PublicationTitle}",
 				$"{Id}M");
 		}


### PR DESCRIPTION
Changes it from:
> 4126M publication primary movie file changed by feos (Replaced Primary movie file from warhippy,mittenz,the8bitbeast,g0gotbc-genpeitoumaden.bk2 to warhippy,mittenz,the8bitbeast,g0gotbc-genpeitoumaden.zip for reason: username change | PCE Genpei Touma Den by WarHippy, Mittenz, The8bitbeast, g0goTBC in 07:54.06) https://tasvideos.org/4126M

to:
> 4126M edited by feos (Primary movie file replaced, Reason: username change | PCE Genpei Touma Den by WarHippy, Mittenz, The8bitbeast, g0goTBC in 07:54.06) https://tasvideos.org/4126M

<hr>

Examples of other current messages to show the consistency:
> 949M edited by CloakTheLurker (Description updated | GB Metroid II: Return of Samus by Cardboard in 45:08.42) https://tasvideos.org/949M

> 1927M Catalog edited by CloakTheLurker (Game Version changed from Unknown Rom to RLV904_Invasion_of_the_Zombie_Monsters.rom | MSX Invasion of the Zombie Monsters by scrimpeh in 04:15.31) https://tasvideos.org/1927M