### PR TITLE
Add timestamp for editing posts, showing when the post was edited

### DIFF
--- a/TASVideos.Data/Entity/Forum/ForumPost.cs
+++ b/TASVideos.Data/Entity/Forum/ForumPost.cs
@@ -27,6 +27,8 @@ public class ForumPost : BaseEntity
 	[Required]
 	public string Text { get; set; } = "";
 
+	public DateTime? PostEditedTimestamp { get; set; }
+
 	public bool EnableHtml { get; set; }
 	public bool EnableBbCode { get; set; }
 

--- a/TASVideos.Data/Migrations/20220901210310_AddPostEditedTimestamp.Designer.cs
+++ b/TASVideos.Data/Migrations/20220901210310_AddPostEditedTimestamp.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,10 @@ using TASVideos.Data;
 namespace TASVideos.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220901210310_AddPostEditedTimestamp")]
+    partial class AddPostEditedTimestamp
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TASVideos.Data/Migrations/20220901210310_AddPostEditedTimestamp.cs
+++ b/TASVideos.Data/Migrations/20220901210310_AddPostEditedTimestamp.cs
@@ -3,24 +3,23 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace TASVideos.Data.Migrations
-{
-    public partial class AddPostEditedTimestamp : Migration
-    {
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AddColumn<DateTime>(
-                name: "post_edited_timestamp",
-                table: "forum_posts",
-                type: "timestamp without time zone",
-                nullable: true);
-        }
+namespace TASVideos.Data.Migrations;
 
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropColumn(
-                name: "post_edited_timestamp",
-                table: "forum_posts");
-        }
-    }
+public partial class AddPostEditedTimestamp : Migration
+{
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.AddColumn<DateTime>(
+			name: "post_edited_timestamp",
+			table: "forum_posts",
+			type: "timestamp without time zone",
+			nullable: true);
+	}
+
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropColumn(
+			name: "post_edited_timestamp",
+			table: "forum_posts");
+	}
 }

--- a/TASVideos.Data/Migrations/20220901210310_AddPostEditedTimestamp.cs
+++ b/TASVideos.Data/Migrations/20220901210310_AddPostEditedTimestamp.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TASVideos.Data.Migrations
+{
+    public partial class AddPostEditedTimestamp : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "post_edited_timestamp",
+                table: "forum_posts",
+                type: "timestamp without time zone",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "post_edited_timestamp",
+                table: "forum_posts");
+        }
+    }
+}

--- a/TASVideos/Pages/Forum/Models/IForumPostEntry.cs
+++ b/TASVideos/Pages/Forum/Models/IForumPostEntry.cs
@@ -16,6 +16,7 @@ public interface IForumPostEntry
 	public bool IsEditable { get; }
 	public bool IsDeletable { get; }
 	public string Text { get; }
+	public DateTime? PostEditedTimestamp { get; }
 	public bool EnableHtml { get; }
 	public bool EnableBbCode { get; }
 	public ForumPostMood PosterMood { get; }

--- a/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
@@ -161,6 +161,8 @@ public class EditModel : BaseForumModel
 		forumPost.Text = Post.Text;
 		forumPost.PosterMood = Post.Mood;
 
+		forumPost.PostEditedTimestamp = DateTime.UtcNow;
+
 		var result = await ConcurrentSave(_db, $"Post {Id} edited", "Unable to edit post");
 		if (result && !MinorEdit)
 		{

--- a/TASVideos/Pages/Forum/Posts/Models/ForumPostEntry.cs
+++ b/TASVideos/Pages/Forum/Posts/Models/ForumPostEntry.cs
@@ -23,6 +23,7 @@ public class ForumPostEntry : IForumPostEntry
 	public PreferredPronounTypes PosterPronouns { get; set; }
 	public IList<string> PosterRoles { get; set; } = new List<string>();
 	public string Text { get; set; } = "";
+	public DateTime? PostEditedTimestamp { get; set; }
 	public string? Subject { get; set; }
 	public string? Signature { get; set; }
 

--- a/TASVideos/Pages/Forum/Posts/Models/UserPostsModel.cs
+++ b/TASVideos/Pages/Forum/Posts/Models/UserPostsModel.cs
@@ -16,6 +16,7 @@ public class UserPagePost : IForumPostEntry
 	public bool EnableBbCode { get; set; }
 	public bool EnableHtml { get; set; }
 	public string Text { get; set; } = "";
+	public DateTime? PostEditedTimestamp { get; }
 	public string? Subject { get; set; }
 	public int TopicId { get; set; }
 	public string TopicTitle { get; set; } = "";

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
@@ -134,6 +134,7 @@ public class IndexModel : BaseForumModel
 				PosterPostCount = p.Poster.Posts.Count,
 				PosterMood = p.PosterMood,
 				Text = p.Text,
+				PostEditedTimestamp = p.PostEditedTimestamp,
 				Subject = p.Subject,
 				Signature = p.Poster.Signature,
 				IsLastPost = p.Id == Topic.LastPostId

--- a/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
@@ -9,7 +9,7 @@
 					   class="float-start text-decoration-none text-dark">
 						<i class="fa fa-bookmark-o"></i>
 						Posted: <timezone-convert asp-for="@Model.CreateTimestamp" />
-						<span condition="@(Model.CreateTimestamp != Model.LastUpdateTimestamp)"><br />(Edited: <timezone-convert asp-for="@Model.LastUpdateTimestamp" />)</span>
+						<span condition="@(Model.PostEditedTimestamp != null)">@{var postEditedTimestamp = (DateTime)Model.PostEditedTimestamp!;}<br />(Edited: <timezone-convert asp-for="@postEditedTimestamp" />)</span>
 					</a>
 				</small>
 			</div>


### PR DESCRIPTION
Resolves #1343 by adding a new db column to track edit timestamps, instead of using the Entity LastUpdateTimestamp, because that one is also affected by *moving* threads and posts.

This is one of the ways to fix the bug. A different one would be to not update the LastUpdateTimestamp entry if only certain properties are updated (ForumId and TopicId). But that felt like a hack, so here is the "proper" way. 

Because this is a new column, it won't be filled with data for all existing posts. To fill them, a custom query needs to be written to check all posts and write the LastUpdateTimestamp into the column if it doesn't match the CreateTimestamp.
```sql
UPDATE forum_posts
SET post_edited_timestamp = last_update_timestamp
WHERE last_update_timestamp != create_timestamp
```