### PR TITLE
add gamegroup module

### DIFF
--- a/TASVideos.Core/Services/ForumWriterHelper.cs
+++ b/TASVideos.Core/Services/ForumWriterHelper.cs
@@ -22,4 +22,6 @@ public class ForumWriterHelper : IWriterHelper
 	public async Task<string?> GetSubmissionTitle(int id) => (await _db.Submissions.FirstOrDefaultAsync(s => s.Id == id))?.Title;
 
 	public async Task<string?> GetGameTitle(int id) => (await _db.Games.FirstOrDefaultAsync(s => s.Id == id))?.DisplayName;
+
+	public async Task<string?> GetGameGroupTitle(int id) => (await _db.GameGroups.FirstOrDefaultAsync(s => s.Id == id))?.Name;
 }

--- a/TASVideos.ForumEngine/BbParser.cs
+++ b/TASVideos.ForumEngine/BbParser.cs
@@ -156,6 +156,7 @@ public class BbParser
 		{ "thread", new() { Children = TagInfo.ChildrenAllowed.IfParam } }, // like url, but the link is a number
 		{ "post", new() { Children = TagInfo.ChildrenAllowed.IfParam } }, // like thread
 		{ "game", new() { Children = TagInfo.ChildrenAllowed.IfParam } }, // like thread
+		{ "gamegroup", new() { Children = TagInfo.ChildrenAllowed.IfParam } }, // like thread
 		{ "movie", new() { Children = TagInfo.ChildrenAllowed.IfParam } }, // like thread
 		{ "submission", new() { Children = TagInfo.ChildrenAllowed.IfParam } }, // like thread
 		{ "userfile", new() { Children = TagInfo.ChildrenAllowed.IfParam } }, // like thread

--- a/TASVideos.ForumEngine/Node.cs
+++ b/TASVideos.ForumEngine/Node.cs
@@ -16,6 +16,12 @@ public interface IWriterHelper
 	Task<string?> GetGameTitle(int id);
 
 	/// <summary>
+	/// Get the title (name) of a game gruop.
+	/// </summary>
+	/// <returns>`null` if not found</returns>
+	Task<string?> GetGameGroupTitle(int id);
+
+	/// <summary>
 	/// Get the title of a movie.
 	/// </summary>
 	/// <returns>`null` if not found</returns>
@@ -31,6 +37,7 @@ public interface IWriterHelper
 public class NullWriterHelper : IWriterHelper
 {
 	public Task<string?> GetGameTitle(int id) => Task.FromResult<string?>(null);
+	public Task<string?> GetGameGroupTitle(int id) => Task.FromResult<string?>(null);
 	public Task<string?> GetMovieTitle(int id) => Task.FromResult<string?>(null);
 	public Task<string?> GetSubmissionTitle(int id) => Task.FromResult<string?>(null);
 
@@ -307,6 +314,13 @@ public class Element : INode
 					h,
 					s => "/" + s + "G",
 					async s => (int.TryParse(s, out var id) ? await h.GetGameTitle(id) : null) ?? "Game #" + s);
+				break;
+			case "gamegroup":
+				await WriteHref(
+					w,
+					h,
+					s => "/GameGroups/" + s,
+					async s => (int.TryParse(s, out var id) ? await h.GetGameGroupTitle(id) : null) ?? "Game group #" + s);
 				break;
 			case "movie":
 				await WriteHref(

--- a/TASVideos/Pages/Forum/_CreatePostHelper.cshtml
+++ b/TASVideos/Pages/Forum/_CreatePostHelper.cshtml
@@ -45,6 +45,7 @@
 	<button type="button" class="btn btn-success btn-sm flex-grow-0 border-dark" tabindex="-1" data-fmt="[thread],[/thread]">thread</button>
 	<button type="button" class="btn btn-success btn-sm flex-grow-0 border-dark" tabindex="-1" data-fmt="[post],[/post]">post</button>
 	<button type="button" class="btn btn-success btn-sm flex-grow-0 border-dark" tabindex="-1" data-fmt="[game],[/game]">game</button>
+	<button type="button" class="btn btn-success btn-sm flex-grow-0 border-dark" tabindex="-1" data-fmt="[gamegroup],[/gamegroup]">gamegroup</button>
 	<button type="button" class="btn btn-success btn-sm flex-grow-0 border-dark" tabindex="-1" data-fmt="[movie],[/movie]">movie</button>
 	<button type="button" class="btn btn-success btn-sm flex-grow-0 border-dark" tabindex="-1" data-fmt="[submission],[/submission]">submission</button>
 	<button type="button" class="btn btn-success btn-sm flex-grow-0 border-dark" tabindex="-1" data-fmt="[wiki],[/wiki]">wiki</button>


### PR DESCRIPTION
Similar to what we currently have for movies ([movie][/movie]) and games ([game][/game]), this PR aims to add a module for game group entries so that [gamegroup]26[/gamegroup] would create a link to https://tasvideos.org/GameGroups/26 while displaying the Name of the gamegroup entry (Contra in this case).
![image](https://user-images.githubusercontent.com/19356108/189446872-2915a368-9fd2-4a0f-94df-e18a684017af.png)
It's "Game Group #26" instead of the actual name in the testing screenshot because of sample data generation issue.