### PR TITLE
Use arrows (→) for breadcrumbs when in forum

### DIFF
--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -16,6 +16,10 @@
 		  integrity="sha512-SfTiTlX6kk+qitfevl/7LibUOeJWlt9rbyDn92a1DqWOw9vWG2MFoays0sgObmWazO5BQPiFucnnEAjpAB+/Sw=="
 		  crossorigin="anonymous"
 		  referrerpolicy="no-referrer" />
+	@if (this.Model.HttpContext.Request.Path.ToString().TrimStart('/').StartsWith("Forum/"))
+	{
+		<link rel="stylesheet" href="/css/forum.css" />
+	}
 
 	<script src="~/js/site-head.js"></script>
 

--- a/TASVideos/Startup.cs
+++ b/TASVideos/Startup.cs
@@ -51,6 +51,7 @@ public class Startup
 			pipeline.AddScssBundle("/css/site.css", "/css/site.scss");
 			pipeline.AddScssBundle("/css/darkmode.css", "/css/darkmode.scss");
 			pipeline.AddScssBundle("/css/darkmode-initial.css", "/css/darkmode-initial.scss");
+			pipeline.AddScssBundle("/css/forum.css", "/css/forum.scss");
 		});
 	}
 

--- a/TASVideos/wwwroot/css/forum.scss
+++ b/TASVideos/wwwroot/css/forum.scss
@@ -1,0 +1,3 @@
+﻿:root {
+    --bs-breadcrumb-divider: '→';
+}


### PR DESCRIPTION
Resolves #1086 .

This accentuates that
![image](https://user-images.githubusercontent.com/22375320/189421625-5f8613c3-1dd6-485d-aa38-11ae24f3d7d3.png)
can be accessed at Movies/GruefoodDelight, but
![image](https://user-images.githubusercontent.com/22375320/189421721-17bcf725-19a3-4942-82c6-a8105ac188ff.png)
*can't* be accessed at Forum/Site/GruefoodDelight (because it's Forum/Topics/14102).