### PR TITLE
Polish Page behavior when clicking on direct Login/Logout links

### DIFF
--- a/TASVideos/Pages/Account/Login.cshtml.cs
+++ b/TASVideos/Pages/Account/Login.cshtml.cs
@@ -31,9 +31,16 @@ public class LoginModel : BasePageModel
 	[Display(Name = "Remember me?")]
 	public bool RememberMe { get; set; }
 
-	public async Task OnGet()
+	public async Task<IActionResult> OnGet()
 	{
+		var user = await _signInManager.UserManager.GetUserAsync(User);
+		if (user != null)
+		{
+			return BaseReturnUrlRedirect();
+		}
+
 		await HttpContext.SignOutAsync();
+		return Page();
 	}
 
 	public async Task<IActionResult> OnPost()

--- a/TASVideos/Pages/Account/Logout.cshtml.cs
+++ b/TASVideos/Pages/Account/Logout.cshtml.cs
@@ -15,6 +15,11 @@ public class LogoutModel : BasePageModel
 		_signInManager = signInManager;
 	}
 
+	public IActionResult OnGet()
+	{
+		return Login();
+	}
+
 	public async Task<IActionResult> OnPost()
 	{
 		var user = await _signInManager.UserManager.GetUserAsync(User);


### PR DESCRIPTION
Resolves #1407 .
- If you're logged in and somehow manage to get to the Account/Login page, it will redirect to the return link (or just front page by default).
- If you somehow (e.g. with multiple tab shenanigans) reach the Account/Logout page, it will no longer display a blank page and instead redirect you properly. (And of course, it *won't* log you out. That's only done with a POST, which you can only do by clicking on the button, instead of a link.)