### PR TITLE
make the submission count on gamegroup pages link to a list

### DIFF
--- a/TASVideos/Pages/GameGroups/Index.cshtml
+++ b/TASVideos/Pages/GameGroups/Index.cshtml
@@ -42,7 +42,9 @@
 				</a>
 			</td>
 			<td>
-				@game.SubmissionsCount
+				<a href="/Subs-List?GameId=@(game.Id)">
+					@game.SubmissionsCount
+				</a>
 			</td>
 			<td>
 				<a href="/@game.GameResourcesPage">


### PR DESCRIPTION
Currently the Publications numbers on game group pages link to the corresponding list (example: https://tasvideos.org/Movies-175G) while the Submissions numbers don't have hyperlinks. This commit makes the Submissions numbers link the corresponding list (example: https://tasvideos.org/Subs-List?GameId=175) as well.