### PR TITLE
Replace < with ＜, and > with ＞, for YouTube titles and descriptions

### DIFF
--- a/TASVideos.Common/Extensions/StringExtensions.cs
+++ b/TASVideos.Common/Extensions/StringExtensions.cs
@@ -231,4 +231,12 @@ public static class StringExtensions
 
 		return char.ToLowerInvariant(str[0]) + str[1..];
 	}
+
+	/// <summary>
+	/// Replaces the characters &lt; and &gt; with their fullwidth versions ＜ and ＞, because YouTube doesn't allow the regular symbols in titles and descriptions.
+	/// </summary>
+	public static string FormatForYouTube(this string s)
+	{
+		return s.Replace('<', '＜').Replace('>', '＞');
+	}
 }

--- a/TASVideos.Core/Services/Youtube/YouTubeSync.cs
+++ b/TASVideos.Core/Services/Youtube/YouTubeSync.cs
@@ -90,8 +90,8 @@ internal class YouTubeSync : IYoutubeSync
 			VideoId = videoId,
 			Snippet = new()
 			{
-				Title = title,
-				Description = description,
+				Title = title.FormatForYouTube(),
+				Description = description.FormatForYouTube(),
 				CategoryId = videoDetails.CategoryId,
 				Tags = BaseTags.Concat(video.Tags).ToList()
 			}


### PR DESCRIPTION
Resolves #1222 .

The replacement function *feels* isolated enough to be a string extension, that's why I put it there. Though, technically we only use it in YouTubeSync, so it could be a private function there.

It can be easily moved if it's decided it shouldn't be an extension method.