### PR TITLE
Back up textarea in localstorage on Post, Topic, and Submission creation

### DIFF
--- a/TASVideos/Pages/Forum/Posts/Create.cshtml
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml
@@ -45,7 +45,7 @@
 		<span asp-validation-for="Post.Text" class="text-danger"></span>
 	</form-group>
 	<fullrow id="backup-restore" class="d-none">
-		<button id="backup-restore-button" type="button" class="btn btn-secondary" onclick="restoreContent()">Restore Text</button>
+		<button id="backup-restore-button" type="button" class="btn btn-secondary">Restore Text</button>
 		<label class="text-muted">from <span id="backup-time"></span></label>
 	</fullrow>
 	<fullrow class="mt-3">

--- a/TASVideos/Pages/Forum/Posts/Create.cshtml
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml
@@ -16,6 +16,7 @@
 	}
 </show-more>
 <br />
+<span id="backup-submission-determinator" class="d-none">@Model.BackupSubmissionDeterminator</span>
 <form method="POST" class="backup-form">
 	<input type="hidden" asp-for="Post.TopicTitle" />
 	<row>

--- a/TASVideos/Pages/Forum/Posts/Create.cshtml
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml
@@ -16,7 +16,7 @@
 	}
 </show-more>
 <br />
-<form method="POST">
+<form method="POST" class="backup-form">
 	<input type="hidden" asp-for="Post.TopicTitle" />
 	<row>
 		<column md="6">
@@ -40,9 +40,13 @@
 		<partial name="_CreatePostHelper" model="@("Post_Text")" />
 	</fullrow>
 	<form-group>
-		<textarea asp-for="Post.Text" class="form-control" rows="20"></textarea>
+		<textarea asp-for="Post.Text" class="form-control backup-content" rows="20" data-backup-key="backup-post-@Model.TopicId"></textarea>
 		<span asp-validation-for="Post.Text" class="text-danger"></span>
 	</form-group>
+	<fullrow id="backup-restore" class="d-none">
+		<button id="backup-restore-button" type="button" class="btn btn-secondary" onclick="restoreContent()">Restore Text</button>
+		<label class="text-muted">from <span id="backup-time"></span></label>
+	</fullrow>
 	<fullrow class="mt-3">
 		<input asp-for="WatchTopic" />
 		<label asp-for="WatchTopic"></label>
@@ -58,4 +62,5 @@
 
 @section Scripts {
 	<partial name="_ValidationScriptsPartial" />
+	<script src="~/js/backup-text.js"></script>
 }

--- a/TASVideos/Pages/Forum/Posts/Create.cshtml
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml
@@ -17,7 +17,7 @@
 </show-more>
 <br />
 <span id="backup-submission-determinator" class="d-none">@Model.BackupSubmissionDeterminator</span>
-<form method="POST" class="backup-form">
+<form method="POST">
 	<input type="hidden" asp-for="Post.TopicTitle" />
 	<row>
 		<column md="6">

--- a/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
@@ -53,6 +53,8 @@ public class CreateModel : BaseForumModel
 
 	public AvatarUrls UserAvatars { get; set; } = new(null, null);
 
+	public string BackupSubmissionDeterminator { get; set; } = "";
+
 	public async Task<IActionResult> OnGet()
 	{
 		var seeRestricted = User.Has(PermissionTo.SeeRestrictedForums);
@@ -116,6 +118,12 @@ public class CreateModel : BaseForumModel
 			.ToListAsync();
 
 		UserAvatars = await _forumService.UserAvatars(User.GetUserId());
+
+		BackupSubmissionDeterminator = (await _db.ForumPosts
+			.ForTopic(TopicId)
+			.Where(fp => fp.PosterId == user.Id)
+			.CountAsync())
+			.ToString();
 
 		return Page();
 	}

--- a/TASVideos/Pages/Forum/Topics/Create.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Create.cshtml
@@ -67,7 +67,7 @@
 		<span asp-validation-for="Topic.Post" class="text-danger"></span>
 	</form-group>
 	<fullrow id="backup-restore" class="d-none">
-		<button id="backup-restore-button" type="button" class="btn btn-secondary" onclick="restoreContent()">Restore Text</button>
+		<button id="backup-restore-button" type="button" class="btn btn-secondary">Restore Text</button>
 		<label class="text-muted">from <span id="backup-time"></span></label>
 	</fullrow>
 	<fullrow class="mt-3">

--- a/TASVideos/Pages/Forum/Topics/Create.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Create.cshtml
@@ -6,7 +6,7 @@
 <partial Name="_ForumHeader" />
 <h4>Creating topic for: <a asp-page="/Forum/Subforum/Index" asp-route-id="@Model.ForumId">@Model.Topic.ForumName</a></h4>
 <div asp-validation-summary="All" class="text-danger"></div>
-<form method="post">
+<form method="post" class="backup-form">
 	<div permission="CreateForumPolls">
 		<button id="add-poll-btn" type="button" class="btn btn-primary btn-sm">Add Poll</button>
 		<div id="poll-container" class="alert alert-dark d-none">
@@ -62,9 +62,13 @@
 		<partial name="_CreatePostHelper" model="@("Topic_Post")" />
 	</fullrow>
 	<form-group>
-		<textarea asp-for="Topic.Post" class="form-control" rows="20"></textarea>
+		<textarea asp-for="Topic.Post" class="form-control backup-content" rows="20" data-backup-key="backup-topic-@Model.ForumId"></textarea>
 		<span asp-validation-for="Topic.Post" class="text-danger"></span>
 	</form-group>
+	<fullrow id="backup-restore" class="d-none">
+		<button id="backup-restore-button" type="button" class="btn btn-secondary" onclick="restoreContent()">Restore Text</button>
+		<label class="text-muted">from <span id="backup-time"></span></label>
+	</fullrow>
 	<fullrow class="mt-3">
 		<input asp-for="WatchTopic" />
 		<label asp-for="WatchTopic"></label>
@@ -80,4 +84,5 @@
 
 @section Scripts {
 	<partial name="_ValidationScriptsPartial" />
+	<script src="~/js/backup-text.js"></script>
 }

--- a/TASVideos/Pages/Forum/Topics/Create.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Create.cshtml
@@ -7,7 +7,7 @@
 <h4>Creating topic for: <a asp-page="/Forum/Subforum/Index" asp-route-id="@Model.ForumId">@Model.Topic.ForumName</a></h4>
 <div asp-validation-summary="All" class="text-danger"></div>
 <span id="backup-submission-determinator" class="d-none">@Model.BackupSubmissionDeterminator</span>
-<form method="post" class="backup-form">
+<form method="post">
 	<div permission="CreateForumPolls">
 		<button id="add-poll-btn" type="button" class="btn btn-primary btn-sm">Add Poll</button>
 		<div id="poll-container" class="alert alert-dark d-none">

--- a/TASVideos/Pages/Forum/Topics/Create.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Create.cshtml
@@ -6,6 +6,7 @@
 <partial Name="_ForumHeader" />
 <h4>Creating topic for: <a asp-page="/Forum/Subforum/Index" asp-route-id="@Model.ForumId">@Model.Topic.ForumName</a></h4>
 <div asp-validation-summary="All" class="text-danger"></div>
+<span id="backup-submission-determinator" class="d-none">@Model.BackupSubmissionDeterminator</span>
 <form method="post" class="backup-form">
 	<div permission="CreateForumPolls">
 		<button id="add-poll-btn" type="button" class="btn btn-primary btn-sm">Add Poll</button>

--- a/TASVideos/Pages/Forum/Topics/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Create.cshtml.cs
@@ -42,6 +42,8 @@ public class CreateModel : BaseForumModel
 
 	public AvatarUrls UserAvatars { get; set; } = new(null, null);
 
+	public string BackupSubmissionDeterminator { get; set; } = "";
+
 	public async Task<IActionResult> OnGet()
 	{
 		var seeRestricted = User.Has(PermissionTo.SeeRestrictedForums);
@@ -67,6 +69,12 @@ public class CreateModel : BaseForumModel
 		{
 			WatchTopic = user.AutoWatchTopic == UserPreference.Always;
 		}
+
+		BackupSubmissionDeterminator = (await _db.ForumTopics
+			.ForForum(ForumId)
+			.Where(f => f.PosterId == User.GetUserId())
+			.CountAsync())
+			.ToString();
 
 		return Page();
 	}

--- a/TASVideos/Pages/Submissions/Submit.cshtml
+++ b/TASVideos/Pages/Submissions/Submit.cshtml
@@ -17,7 +17,7 @@
 <danger-alert dismissible="true" condition="parseErrors">
 	@await Component.RenderWiki("System/SubmissionZipFailure")
 </danger-alert>
-<form method="post" enctype="multipart/form-data">
+<form method="post" enctype="multipart/form-data" class="backup-form">
 	<row>
 		<column lg="6">
 			<form-group>
@@ -84,8 +84,12 @@
 				@await Component.RenderWiki("System/SubmissionImportant")
 			</span>
 			<partial name="_WikiEditHelper" model="@("Create_Markup")" />
-			<textarea asp-for="Create.Markup" rows="12" class="form-control wiki-edit"></textarea>
+			<textarea asp-for="Create.Markup" rows="12" class="form-control wiki-edit backup-content" data-backup-key="backup-submission"></textarea>
 			<span asp-validation-for="Create.Markup" class="text-danger"></span>
+			<fullrow id="backup-restore" class="d-none mt-2">
+				<button id="backup-restore-button" type="button" class="btn btn-secondary" onclick="restoreContent()">Restore Text</button>
+				<label class="text-muted">from <span id="backup-time"></span></label>
+			</fullrow>
 			<div>
 				<button id="prefill-btn" type="button" class="btn btn-secondary mt-2">Prefill comments</button>
 			</div>
@@ -128,4 +132,5 @@
 			document.getElementById('submit-blurb').classList.remove('d-none');
 		});
 	</script>
+	<script src="~/js/backup-text.js"></script>
 }

--- a/TASVideos/Pages/Submissions/Submit.cshtml
+++ b/TASVideos/Pages/Submissions/Submit.cshtml
@@ -17,6 +17,7 @@
 <danger-alert dismissible="true" condition="parseErrors">
 	@await Component.RenderWiki("System/SubmissionZipFailure")
 </danger-alert>
+<span id="backup-submission-determinator" class="d-none">@Model.BackupSubmissionDeterminator</span>
 <form method="post" enctype="multipart/form-data" class="backup-form">
 	<row>
 		<column lg="6">

--- a/TASVideos/Pages/Submissions/Submit.cshtml
+++ b/TASVideos/Pages/Submissions/Submit.cshtml
@@ -18,7 +18,7 @@
 	@await Component.RenderWiki("System/SubmissionZipFailure")
 </danger-alert>
 <span id="backup-submission-determinator" class="d-none">@Model.BackupSubmissionDeterminator</span>
-<form method="post" enctype="multipart/form-data" class="backup-form">
+<form method="post" enctype="multipart/form-data">
 	<row>
 		<column lg="6">
 			<form-group>

--- a/TASVideos/Pages/Submissions/Submit.cshtml
+++ b/TASVideos/Pages/Submissions/Submit.cshtml
@@ -88,7 +88,7 @@
 			<textarea asp-for="Create.Markup" rows="12" class="form-control wiki-edit backup-content" data-backup-key="backup-submission"></textarea>
 			<span asp-validation-for="Create.Markup" class="text-danger"></span>
 			<fullrow id="backup-restore" class="d-none mt-2">
-				<button id="backup-restore-button" type="button" class="btn btn-secondary" onclick="restoreContent()">Restore Text</button>
+				<button id="backup-restore-button" type="button" class="btn btn-secondary">Restore Text</button>
 				<label class="text-muted">from <span id="backup-time"></span></label>
 			</fullrow>
 			<div>

--- a/TASVideos/Pages/Submissions/Submit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Submit.cshtml.cs
@@ -6,6 +6,7 @@ using TASVideos.Core.Services.Wiki;
 using TASVideos.Core.Services.Youtube;
 using TASVideos.Data;
 using TASVideos.Data.Entity;
+using TASVideos.Extensions;
 using TASVideos.MovieParsers;
 using TASVideos.Pages.Submissions.Models;
 
@@ -50,12 +51,19 @@ public class SubmitModel : BasePageModel
 	[BindProperty]
 	public SubmissionCreateModel Create { get; set; } = new();
 
-	public void OnGet()
+	public string BackupSubmissionDeterminator { get; set; } = "";
+
+	public async Task OnGet()
 	{
 		Create = new SubmissionCreateModel
 		{
 			Authors = new List<string> { User.Name() }
 		};
+
+		BackupSubmissionDeterminator = (await _db.Submissions
+			.Where(s => s.SubmitterId == User.GetUserId())
+			.CountAsync())
+			.ToString();
 	}
 
 	public async Task<IActionResult> OnPost()

--- a/TASVideos/Pages/Submissions/Submit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Submit.cshtml.cs
@@ -6,7 +6,6 @@ using TASVideos.Core.Services.Wiki;
 using TASVideos.Core.Services.Youtube;
 using TASVideos.Data;
 using TASVideos.Data.Entity;
-using TASVideos.Extensions;
 using TASVideos.MovieParsers;
 using TASVideos.Pages.Submissions.Models;
 

--- a/TASVideos/wwwroot/js/backup-text.js
+++ b/TASVideos/wwwroot/js/backup-text.js
@@ -5,33 +5,33 @@
 // id: "backup-restore-button" | button to restore data
 
 function convertSecondsToRelativeTime(seconds) {
-    const minutes = Math.floor(seconds / 60);
-    const hours = Math.floor(seconds / (60 * 60));
-    const days = Math.floor(seconds / (60 * 60 * 24));
-    if (seconds < 5) {
-        return "a few seconds ago";
-    }
-    else if (seconds < 60) {
-        return `${seconds} seconds ago`;
-    }
-    else if (minutes < 2) {
-        return "1 minute ago";
-    }
-    else if (minutes < 60) {
-        return `${minutes} minutes ago`;
-    }
-    else if (hours < 2) {
-        return "1 hour ago";
-    }
-    else if (hours < 24) {
-        return `${hours} hours ago`;
-    }
-    else if (days < 2) {
-        return "1 day ago";
-    }
-    else {
-        return `${days} days ago`;
-    }
+	const minutes = Math.floor(seconds / 60);
+	const hours = Math.floor(seconds / (60 * 60));
+	const days = Math.floor(seconds / (60 * 60 * 24));
+	if (seconds < 5) {
+		return "a few seconds ago";
+	}
+	else if (seconds < 60) {
+		return `${seconds} seconds ago`;
+	}
+	else if (minutes < 2) {
+		return "1 minute ago";
+	}
+	else if (minutes < 60) {
+		return `${minutes} minutes ago`;
+	}
+	else if (hours < 2) {
+		return "1 hour ago";
+	}
+	else if (hours < 24) {
+		return `${hours} hours ago`;
+	}
+	else if (days < 2) {
+		return "1 day ago";
+	}
+	else {
+		return `${days} days ago`;
+	}
 }
 
 const textarea = document.querySelector('textarea.backup-content');
@@ -40,33 +40,33 @@ localStorage.removeItem(backupKey + '-restore');
 
 let backupData = localStorage.getItem(backupKey);
 if (backupData) {
-    let backupObject = JSON.parse(backupData);
-    document.getElementById('backup-time').innerText = convertSecondsToRelativeTime(Math.floor(Date.now() / 1000) - backupObject.date);
-    localStorage.setItem(backupKey + '-restore', backupData);
-    document.getElementById('backup-restore').classList.remove('d-none');
+	let backupObject = JSON.parse(backupData);
+	document.getElementById('backup-time').innerText = convertSecondsToRelativeTime(Math.floor(Date.now() / 1000) - backupObject.date);
+	localStorage.setItem(backupKey + '-restore', backupData);
+	document.getElementById('backup-restore').classList.remove('d-none');
 }
 
 function backupContent() {
-    if (textarea.value) {
-        let backupObject = JSON.stringify({ content: textarea.value, date: Math.floor(Date.now() / 1000) });
-        localStorage.setItem(backupKey, backupObject)
-    }
+	if (textarea.value) {
+		let backupObject = JSON.stringify({ content: textarea.value, date: Math.floor(Date.now() / 1000) });
+		localStorage.setItem(backupKey, backupObject)
+	}
 }
 setInterval(backupContent, 5000);
 
 const restoreButton = document.getElementById('backup-restore-button');
 function restoreContent() {
-    let backupObject = JSON.parse(localStorage.getItem(backupKey + '-restore'));
-    if (backupObject && !textarea.value) {
-        textarea.value = backupObject.content;
-        backupContent();
-    }
+	let backupObject = JSON.parse(localStorage.getItem(backupKey + '-restore'));
+	if (backupObject && !textarea.value) {
+		textarea.value = backupObject.content;
+		backupContent();
+	}
 }
 restoreButton.onclick = restoreContent;
 
 const form = document.querySelector('form.backup-form');
 function deleteBackup() {
-    localStorage.removeItem(backupKey);
-    localStorage.removeItem(backupKey + '-restore');
+	localStorage.removeItem(backupKey);
+	localStorage.removeItem(backupKey + '-restore');
 }
 form.onsubmit = deleteBackup;

--- a/TASVideos/wwwroot/js/backup-text.js
+++ b/TASVideos/wwwroot/js/backup-text.js
@@ -1,0 +1,72 @@
+﻿// class: "backup-form"        | surrounding form
+// class: "backup-content"     | textarea to save text from, needs a data-backup-key attribute
+// id: "backup-time"           | where the time will be put
+// id: "backup-restore"        | surrounding element hidden by default to display when backup exists
+// id: "backup-restore-button" | button to restore data
+
+function convertSecondsToRelativeTime(seconds) {
+    const minutes = Math.ceil(seconds / 60);
+    const hours = Math.ceil(seconds / (60 * 60));
+    const days = Math.ceil(seconds / (60 * 60 * 24));
+    if (seconds < 5) {
+        return "a few seconds ago";
+    }
+    else if (seconds < 60) {
+        return `${seconds} seconds ago`;
+    }
+    else if (minutes < 2) {
+        return "1 minute ago";
+    }
+    else if (minutes < 60) {
+        return `${minutes} minutes ago`;
+    }
+    else if (hours < 2) {
+        return "1 hour ago";
+    }
+    else if (hours < 24) {
+        return `${hours} hours ago`;
+    }
+    else if (days < 2) {
+        return "1 day ago";
+    }
+    else {
+        return `${days} days ago`;
+    }
+}
+
+const textarea = document.querySelector('textarea.backup-content');
+const backupKey = textarea.dataset.backupKey;
+localStorage.removeItem(backupKey + '-restore');
+
+let backupData = localStorage.getItem(backupKey);
+if (backupData) {
+    let backupObject = JSON.parse(backupData);
+    document.getElementById('backup-time').innerText = convertSecondsToRelativeTime(Math.floor(Date.now() / 1000) - backupObject.date);
+    localStorage.setItem(backupKey + '-restore', backupData);
+    document.getElementById('backup-restore').classList.remove('d-none');
+}
+
+function backupContent() {
+    if (textarea.value) {
+        let backupObject = JSON.stringify({ content: textarea.value, date: Math.floor(Date.now() / 1000) });
+        localStorage.setItem(backupKey, backupObject)
+    }
+}
+setInterval(backupContent, 5000);
+
+const restoreButton = document.getElementById('backup-restore-button');
+function restoreContent() {
+    let backupObject = JSON.parse(localStorage.getItem(backupKey + '-restore'));
+    if (backupObject && !textarea.value) {
+        textarea.value = backupObject.content;
+        backupContent();
+    }
+}
+restoreButton.onclick = restoreContent;
+
+const form = document.querySelector('form.backup-form');
+function deleteBackup() {
+    localStorage.removeItem(backupKey);
+    localStorage.removeItem(backupKey + '-restore');
+}
+form.onsubmit = deleteBackup;

--- a/TASVideos/wwwroot/js/backup-text.js
+++ b/TASVideos/wwwroot/js/backup-text.js
@@ -43,6 +43,12 @@ const textarea = document.querySelector('textarea.backup-content');
 const submissionDeterminator = document.getElementById('backup-submission-determinator').innerHTML;
 const backupKey = textarea.dataset.backupKey;
 localStorage.removeItem(backupKey + '-restore');
+const restoreButton = document.getElementById('backup-restore-button');
+
+function updateRestoreButtonDisabledState() {
+	restoreButton.disabled = !!textarea.value;
+}
+textarea.oninput = updateRestoreButtonDisabledState;
 
 let backupData = localStorage.getItem(backupKey);
 if (backupData) {
@@ -50,6 +56,7 @@ if (backupData) {
 	if (submissionDeterminator === backupObject.submissionDeterminator) {
 		document.getElementById('backup-time').innerText = convertSecondsToRelativeTime(Math.floor(Date.now() / 1000) - backupObject.date);
 		localStorage.setItem(backupKey + '-restore', backupData);
+		updateRestoreButtonDisabledState();
 		document.getElementById('backup-restore').classList.remove('d-none');
 	} else {
 		localStorage.removeItem(backupKey);
@@ -72,12 +79,11 @@ document.onvisibilitychange = () => {
 	}
 };
 
-const restoreButton = document.getElementById('backup-restore-button');
 function restoreContent() {
 	let backupObject = JSON.parse(localStorage.getItem(backupKey + '-restore'));
 	if (backupObject && !textarea.value) {
 		textarea.value = backupObject.content;
-		backupContent();
+		updateRestoreButtonDisabledState();
 	}
 }
 restoreButton.onclick = restoreContent;

--- a/TASVideos/wwwroot/js/backup-text.js
+++ b/TASVideos/wwwroot/js/backup-text.js
@@ -4,86 +4,88 @@
 // id: "backup-restore"                 | surrounding element hidden by default to display when backup exists
 // id: "backup-restore-button"          | button to restore data
 // id: "backup-submission-determinator" | span whose value only changes when a form submission went through (e.g. post count), it's used to determine whether a previous saved backup is deleted or not
-function convertSecondsToRelativeTime(seconds) {
-	const minutes = Math.floor(seconds / 60);
-	const hours = Math.floor(seconds / (60 * 60));
-	const days = Math.floor(seconds / (60 * 60 * 24));
-	if (seconds < 5) {
-		return "a few seconds ago";
+{
+	function convertSecondsToRelativeTime(seconds) {
+		const minutes = Math.floor(seconds / 60);
+		const hours = Math.floor(seconds / (60 * 60));
+		const days = Math.floor(seconds / (60 * 60 * 24));
+		if (seconds < 5) {
+			return "a few seconds ago";
+		}
+
+		if (seconds < 60) {
+			return `${seconds} seconds ago`;
+		}
+
+		if (minutes < 2) {
+			return "1 minute ago";
+		}
+
+		if (minutes < 60) {
+			return `${minutes} minutes ago`;
+		}
+
+		if (hours < 2) {
+			return "1 hour ago";
+		}
+
+		if (hours < 24) {
+			return `${hours} hours ago`;
+		}
+
+		if (days < 2) {
+			return "1 day ago";
+		}
+
+		return `${days} days ago`;
 	}
 
-	if (seconds < 60) {
-		return `${seconds} seconds ago`;
+	const textarea = document.querySelector('textarea.backup-content');
+	const submissionDeterminator = document.getElementById('backup-submission-determinator').innerHTML;
+	const backupKey = textarea.dataset.backupKey;
+	localStorage.removeItem(backupKey + '-restore');
+	const restoreButton = document.getElementById('backup-restore-button');
+
+	function updateRestoreButtonDisabledState() {
+		restoreButton.disabled = !!textarea.value;
+	}
+	textarea.oninput = updateRestoreButtonDisabledState;
+
+	let backupData = localStorage.getItem(backupKey);
+	if (backupData) {
+		let backupObject = JSON.parse(backupData);
+		if (submissionDeterminator === backupObject.submissionDeterminator) {
+			document.getElementById('backup-time').innerText = convertSecondsToRelativeTime(Math.floor(Date.now() / 1000) - backupObject.date);
+			localStorage.setItem(backupKey + '-restore', backupData);
+			updateRestoreButtonDisabledState();
+			document.getElementById('backup-restore').classList.remove('d-none');
+		} else {
+			localStorage.removeItem(backupKey);
+		}
 	}
 
-	if (minutes < 2) {
-		return "1 minute ago";
+	function backupContent() {
+		if (textarea.value) {
+			let backupObject = JSON.stringify({
+				content: textarea.value,
+				date: Math.floor(Date.now() / 1000),
+				submissionDeterminator: submissionDeterminator
+			});
+			localStorage.setItem(backupKey, backupObject)
+		}
 	}
+	document.onvisibilitychange = () => {
+		if (document.visibilityState === 'hidden') {
+			backupContent();
+		}
+	};
 
-	if (minutes < 60) {
-		return `${minutes} minutes ago`;
+	function restoreContent() {
+		let backupObject = JSON.parse(localStorage.getItem(backupKey + '-restore'));
+		if (backupObject && !textarea.value) {
+			textarea.value = backupObject.content;
+			updateRestoreButtonDisabledState();
+		}
 	}
-
-	if (hours < 2) {
-		return "1 hour ago";
-	}
-
-	if (hours < 24) {
-		return `${hours} hours ago`;
-	}
-
-	if (days < 2) {
-		return "1 day ago";
-	}
-
-	return `${days} days ago`;
+	restoreButton.onclick = restoreContent;
 }
-
-const textarea = document.querySelector('textarea.backup-content');
-const submissionDeterminator = document.getElementById('backup-submission-determinator').innerHTML;
-const backupKey = textarea.dataset.backupKey;
-localStorage.removeItem(backupKey + '-restore');
-const restoreButton = document.getElementById('backup-restore-button');
-
-function updateRestoreButtonDisabledState() {
-	restoreButton.disabled = !!textarea.value;
-}
-textarea.oninput = updateRestoreButtonDisabledState;
-
-let backupData = localStorage.getItem(backupKey);
-if (backupData) {
-	let backupObject = JSON.parse(backupData);
-	if (submissionDeterminator === backupObject.submissionDeterminator) {
-		document.getElementById('backup-time').innerText = convertSecondsToRelativeTime(Math.floor(Date.now() / 1000) - backupObject.date);
-		localStorage.setItem(backupKey + '-restore', backupData);
-		updateRestoreButtonDisabledState();
-		document.getElementById('backup-restore').classList.remove('d-none');
-	} else {
-		localStorage.removeItem(backupKey);
-	}
-}
-
-function backupContent() {
-	if (textarea.value) {
-		let backupObject = JSON.stringify({
-			content: textarea.value,
-			date: Math.floor(Date.now() / 1000),
-			submissionDeterminator: submissionDeterminator
-		});
-		localStorage.setItem(backupKey, backupObject)
-	}
-}
-document.onvisibilitychange = () => {
-	if (document.visibilityState === 'hidden') {
-		backupContent();
-	}
-};
-
-function restoreContent() {
-	let backupObject = JSON.parse(localStorage.getItem(backupKey + '-restore'));
-	if (backupObject && !textarea.value) {
-		textarea.value = backupObject.content;
-		updateRestoreButtonDisabledState();
-	}
-}
-restoreButton.onclick = restoreContent;

--- a/TASVideos/wwwroot/js/backup-text.js
+++ b/TASVideos/wwwroot/js/backup-text.js
@@ -1,8 +1,8 @@
 ﻿// class: "backup-form"                 | surrounding form
 // class: "backup-content"              | textarea to save text from, needs a data-backup-key attribute
 // id: "backup-time"                    | where the time will be put
-// id: "backup-restore"				    | surrounding element hidden by default to display when backup exists
-// id: "backup-restore-button"	        | button to restore data
+// id: "backup-restore"                 | surrounding element hidden by default to display when backup exists
+// id: "backup-restore-button"          | button to restore data
 // id: "backup-submission-determinator" | span whose value only changes when a form submission went through (e.g. post count), it's used to determine whether a previous saved backup is deleted or not
 function convertSecondsToRelativeTime(seconds) {
 	const minutes = Math.floor(seconds / 60);
@@ -53,7 +53,7 @@ if (backupData) {
 		document.getElementById('backup-restore').classList.remove('d-none');
 	} else {
 		localStorage.removeItem(backupKey);
-    }
+	}
 }
 
 function backupContent() {

--- a/TASVideos/wwwroot/js/backup-text.js
+++ b/TASVideos/wwwroot/js/backup-text.js
@@ -5,9 +5,9 @@
 // id: "backup-restore-button" | button to restore data
 
 function convertSecondsToRelativeTime(seconds) {
-    const minutes = Math.ceil(seconds / 60);
-    const hours = Math.ceil(seconds / (60 * 60));
-    const days = Math.ceil(seconds / (60 * 60 * 24));
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(seconds / (60 * 60));
+    const days = Math.floor(seconds / (60 * 60 * 24));
     if (seconds < 5) {
         return "a few seconds ago";
     }

--- a/TASVideos/wwwroot/js/backup-text.js
+++ b/TASVideos/wwwroot/js/backup-text.js
@@ -3,7 +3,6 @@
 // id: "backup-time"           | where the time will be put
 // id: "backup-restore"        | surrounding element hidden by default to display when backup exists
 // id: "backup-restore-button" | button to restore data
-
 function convertSecondsToRelativeTime(seconds) {
 	const minutes = Math.floor(seconds / 60);
 	const hours = Math.floor(seconds / (60 * 60));
@@ -11,27 +10,32 @@ function convertSecondsToRelativeTime(seconds) {
 	if (seconds < 5) {
 		return "a few seconds ago";
 	}
-	else if (seconds < 60) {
+
+	if (seconds < 60) {
 		return `${seconds} seconds ago`;
 	}
-	else if (minutes < 2) {
+
+	if (minutes < 2) {
 		return "1 minute ago";
 	}
-	else if (minutes < 60) {
+
+	if (minutes < 60) {
 		return `${minutes} minutes ago`;
 	}
-	else if (hours < 2) {
+
+	if (hours < 2) {
 		return "1 hour ago";
 	}
-	else if (hours < 24) {
+
+	if (hours < 24) {
 		return `${hours} hours ago`;
 	}
-	else if (days < 2) {
+
+	if (days < 2) {
 		return "1 day ago";
 	}
-	else {
-		return `${days} days ago`;
-	}
+
+	return `${days} days ago`;
 }
 
 const textarea = document.querySelector('textarea.backup-content');

--- a/TASVideos/wwwroot/js/backup-text.js
+++ b/TASVideos/wwwroot/js/backup-text.js
@@ -66,7 +66,11 @@ function backupContent() {
 		localStorage.setItem(backupKey, backupObject)
 	}
 }
-setInterval(backupContent, 5000);
+document.onvisibilitychange = () => {
+	if (document.visibilityState === 'hidden') {
+		backupContent();
+	}
+};
 
 const restoreButton = document.getElementById('backup-restore-button');
 function restoreContent() {

--- a/TASVideos/wwwroot/js/backup-text.js
+++ b/TASVideos/wwwroot/js/backup-text.js
@@ -1,5 +1,4 @@
-﻿// class: "backup-form"                 | surrounding form
-// class: "backup-content"              | textarea to save text from, needs a data-backup-key attribute
+﻿// class: "backup-content"              | textarea to save text from, needs a data-backup-key attribute
 // id: "backup-time"                    | where the time will be put
 // id: "backup-restore"                 | surrounding element hidden by default to display when backup exists
 // id: "backup-restore-button"          | button to restore data


### PR DESCRIPTION
Attempts to resolve #212 .
Previous unmerged PR with relevant discussion #977 .

Implements a backup for:
- Post creation
- Topic creation
- Submission creation

Not for *editing*, only for *creating*.

<hr>

It saves the written text into the browser localStorage ~~every 5 seconds~~ whenever the visibily changes to hidden (navigated away, closed tab, closed window, changes tab, changing app, and others).
Upon page load, if it finds a backup, it will show a button the user can click to restore the saved text.
![image](https://user-images.githubusercontent.com/22375320/189497878-5eae383c-2c8a-4c2d-938d-b654f04c9ff6.png)

~~Once you submit the form, this backup is deleted.~~
The backup is deleted once you open the form again and the **determinator** is different.
This determinator is a value that only changes once the form submission was successful. So here I use: the count of your posts / count of your topics / count of your submissions.