### PR TITLE
Mood avatar dropdown - show ids, resolves #1415

### DIFF
--- a/TASVideos/Pages/Forum/ForumBaseModel.cs
+++ b/TASVideos/Pages/Forum/ForumBaseModel.cs
@@ -22,7 +22,7 @@ public class BaseForumModel : BasePageModel
 		.Select(m => new SelectListItem
 		{
 			Value = ((int)m).ToString(),
-			Text = m.EnumDisplayName(),
+			Text = $"{(int)m}: {m.EnumDisplayName()}",
 			Group = m >= ForumPostMood.AltNormal ? AltGroup : StandardGroup
 		})
 		.ToList();


### PR DESCRIPTION
Resolves #1415 in the similar way that the old site did, by showing the ids in the dropdown when posting.  Not great, but gets the job done, probably better is some way to see it in your profile pages.

![image](https://user-images.githubusercontent.com/1679846/190928341-e11b9c62-4974-4091-b298-18f0d5cb2e99.png)
