### PR TITLE
Remove UseAuthorization Middleware which was doubled

### DIFF
--- a/TASVideos/Startup.cs
+++ b/TASVideos/Startup.cs
@@ -65,7 +65,6 @@ public class Startup
 			.UseGzipCompression(Settings)
 			.UseWebOptimizer()
 			.UseStaticFilesWithExtensionMapping()
-			.UseAuthorization()
 			.UseAuthentication()
 			.UseSwaggerUi(Environment)
 			.UseLogging()


### PR DESCRIPTION
UseAuthorization is later called inside our UseMvcWithOptions, and there in the correct place between UseRouting and UseEndpoints.
So it couldn't even have properly functioned in here.

https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.authorizationappbuilderextensions.useauthorization?view=aspnetcore-6.0
> When authorizing a resource that is routed using endpoint routing, this call must appear between the calls to app.UseRouting() and app.UseEndpoints(...) for the middleware to function correctly.