### PR TITLE
Improve Game page logic on how the Publication tabs are named

### DIFF
--- a/TASVideos/Pages/Games/Index.cshtml
+++ b/TASVideos/Pages/Games/Index.cshtml
@@ -7,7 +7,7 @@
 }
 
 <div class="float-md-end text-center mb-2" condition="@(!string.IsNullOrWhiteSpace(Model.Game.ScreenshotUrl) || Model.Movies.Any())">
-	<img class="img-fluid" src="@(!string.IsNullOrWhiteSpace(Model.Game.ScreenshotUrl) ? Model.Game.ScreenshotUrl : $"{HttpContext.Request.ToBaseUrl()}/media/{Model.Movies.First().Screenshot.Path}")" />
+	<img class="img-fluid" src="@(!string.IsNullOrWhiteSpace(Model.Game.ScreenshotUrl) ? Model.Game.ScreenshotUrl : $"{HttpContext.Request.ToBaseUrl()}/media/{Model.Movies.First().Movie.Screenshot.Path}")" />
 </div>
 <row>
 	<div class="col-12 col-xl-6 mb-2">
@@ -80,7 +80,10 @@
 			@foreach (var movie in Model.Movies)
 			{
 				<li class="nav-item">
-					<a class="nav-link@(movie==Model.Movies.First() ? " active" : "")@(string.IsNullOrWhiteSpace(movie.Branch) ? "" : " fw-bold")" href="#tab-@(movie.Id)M" data-bs-toggle="tab">@(string.IsNullOrWhiteSpace(movie.Branch) ? "(baseline)" : $@"""{movie.Branch}""")</a>
+					<a class="nav-link@(movie==Model.Movies.First() ? " active" : "")" href="#tab-@(movie.Movie.Id)M" data-bs-toggle="tab">
+						<span condition="!string.IsNullOrEmpty(movie.TabTitleRegular)">@movie.TabTitleRegular</span>
+						<span condition="!string.IsNullOrEmpty(movie.TabTitleBold)" class="fw-bold">"@(movie.TabTitleBold)"</span>
+					</a>
 				</li>
 			}
 		</ul>
@@ -88,12 +91,12 @@
 	<div class="tab-content">
 		@foreach (var movie in Model.Movies)
 		{
-			<div id="tab-@(movie.Id)M" class="tab-pane@(movie==Model.Movies.First() ? " active" : " fade")">
-				<partial name="Components/DisplayMiniMovie/Default" model="movie" />
+			<div id="tab-@(movie.Movie.Id)M" class="tab-pane@(movie==Model.Movies.First() ? " active" : " fade")">
+				<partial name="Components/DisplayMiniMovie/Default" model="movie.Movie" />
 			</div>
 		}
 	</div>
-	<small condition="@Model.Movies.Any(m => string.IsNullOrWhiteSpace(m.Branch))" class="text-muted">The baseline tab shows the default movie beating the game as fast as possible without any special conditions.</small>
+	<small condition="@Model.Movies.Where(m => string.IsNullOrWhiteSpace(m.Movie.Branch)).Count() == 1" class="text-muted">The baseline tab shows the default movie beating the game as fast as possible without any special conditions.</small>
 </div>
 <hr />
 <row>


### PR DESCRIPTION
Resolves #1318 .

The logic here is the same as I described in [this comment](https://github.com/TASVideos/tasvideos/issues/1318#issuecomment-1235631104):
> Show only branches.
If two branches are the same, show game title with branch (or just game title if branch is empty). And the game title is of course just the game name or the override from the version.

![image](https://user-images.githubusercontent.com/22375320/194708045-677bab5a-712a-4533-b21c-c8ba75f1a62c.png)
![image](https://user-images.githubusercontent.com/22375320/194708052-b1fd5fca-7314-4f3a-99df-2cb74dc2e8f9.png)
