### PR TITLE
Make forum activity icons clickable

### DIFF
--- a/TASVideos.Common/Constants.cs
+++ b/TASVideos.Common/Constants.cs
@@ -90,7 +90,7 @@ public static class ForumConstants
 	public const int WorkBenchForumId = 7;
 	public const int NewsTopicId = 8694;
 
-	public const int DaysTopicsCountAsActive = 14;
+	public const int DaysPostsCountAsActive = 14;
 }
 
 public static class PostGroups

--- a/TASVideos.Core/Dtos/ForumDtos.cs
+++ b/TASVideos.Core/Dtos/ForumDtos.cs
@@ -21,6 +21,8 @@ public class ForumCategoryDisplayDto
 		public string? Description { get; init; }
 		public LatestPost? LastPost { get; set; }
 		public string ActivityTopics { get; set; } = "";
+		public string ActivityPostsCreated { get; set; } = "";
+		public string ActivityPostsEdited { get; set; } = "";
 	}
 }
 

--- a/TASVideos.Core/Dtos/ForumDtos.cs
+++ b/TASVideos.Core/Dtos/ForumDtos.cs
@@ -20,7 +20,6 @@ public class ForumCategoryDisplayDto
 		public string Name { get; init; } = "";
 		public string? Description { get; init; }
 		public LatestPost? LastPost { get; set; }
-		public string ActivityTopics { get; set; } = "";
 		public string ActivityPostsCreated { get; set; } = "";
 		public string ActivityPostsEdited { get; set; } = "";
 	}

--- a/TASVideos.Core/Services/ForumService.cs
+++ b/TASVideos.Core/Services/ForumService.cs
@@ -118,7 +118,7 @@ internal class ForumService : IForumService
 			forumActivity.TryGetValue(forumId, out Dictionary<int, (string, string)>? subforumActivity);
 			subforumActivity ??= new Dictionary<int, (string, string)>();
 			subforumActivity.TryGetValue(topicId, out (string, string) postActivity);
-			var createPostActivity = JsonSerializer.Deserialize<Dictionary<int, long>>(postActivity.Item1) ?? new Dictionary<int, long>();
+			var createPostActivity = postActivity.Item1 == null ? new Dictionary<int, long>() : JsonSerializer.Deserialize<Dictionary<int, long>>(postActivity.Item1)!;
 			createPostActivity[postId] = createTimestamp.UnixTimestamp();
 			subforumActivity[topicId] = (JsonSerializer.Serialize(createPostActivity), postActivity.Item2);
 			forumActivity[forumId] = subforumActivity;
@@ -127,7 +127,7 @@ internal class ForumService : IForumService
 		if (_cacheService.TryGetValue(PostActivityOfSubforumsCacheKey, out Dictionary<int, (string, string)> fullSubforumActivity))
 		{
 			fullSubforumActivity.TryGetValue(forumId, out (string, string) postActivity);
-			var createPostActivity = JsonSerializer.Deserialize<Dictionary<int, long>>(postActivity.Item1) ?? new Dictionary<int, long>();
+			var createPostActivity = postActivity.Item1 == null ? new Dictionary<int, long>() : JsonSerializer.Deserialize<Dictionary<int, long>>(postActivity.Item1)!;
 			createPostActivity[postId] = createTimestamp.UnixTimestamp();
 			fullSubforumActivity[forumId] = (JsonSerializer.Serialize(createPostActivity), postActivity.Item2);
 			_cacheService.Set(PostActivityOfSubforumsCacheKey, fullSubforumActivity, Durations.OneDayInSeconds);
@@ -141,7 +141,7 @@ internal class ForumService : IForumService
 			forumActivity.TryGetValue(forumId, out Dictionary<int, (string, string)>? subforumActivity);
 			subforumActivity ??= new Dictionary<int, (string, string)>();
 			subforumActivity.TryGetValue(topicId, out (string, string) postActivity);
-			var editPostActivity = JsonSerializer.Deserialize<Dictionary<int, long>>(postActivity.Item1) ?? new Dictionary<int, long>();
+			var editPostActivity = postActivity.Item2 == null ? new Dictionary<int, long>() : JsonSerializer.Deserialize<Dictionary<int, long>>(postActivity.Item2)!;
 			editPostActivity[postId] = editTimestamp.UnixTimestamp();
 			subforumActivity[topicId] = (postActivity.Item1, JsonSerializer.Serialize(editPostActivity));
 			forumActivity[forumId] = subforumActivity;
@@ -150,7 +150,7 @@ internal class ForumService : IForumService
 		if (_cacheService.TryGetValue(PostActivityOfSubforumsCacheKey, out Dictionary<int, (string, string)> fullSubforumActivity))
 		{
 			fullSubforumActivity.TryGetValue(forumId, out (string, string) postActivity);
-			var editPostActivity = JsonSerializer.Deserialize<Dictionary<int, long>>(postActivity.Item1) ?? new Dictionary<int, long>();
+			var editPostActivity = postActivity.Item2 == null ? new Dictionary<int, long>() : JsonSerializer.Deserialize<Dictionary<int, long>>(postActivity.Item2)!;
 			editPostActivity[postId] = editTimestamp.UnixTimestamp();
 			fullSubforumActivity[forumId] = (postActivity.Item1, JsonSerializer.Serialize(editPostActivity));
 			_cacheService.Set(PostActivityOfSubforumsCacheKey, fullSubforumActivity, Durations.OneDayInSeconds);

--- a/TASVideos.Core/Services/ForumService.cs
+++ b/TASVideos.Core/Services/ForumService.cs
@@ -265,7 +265,7 @@ internal class ForumService : IForumService
 			return forumActivity;
 		}
 
-		DateTime minimumDate = DateTime.UtcNow.AddDays(-ForumConstants.DaysTopicsCountAsActive);
+		DateTime minimumDate = DateTime.UtcNow.AddDays(-ForumConstants.DaysPostsCountAsActive);
 
 		var fullrow = await _db.ForumPosts
 			.Where(fp => fp.CreateTimestamp > minimumDate || fp.PostEditedTimestamp > minimumDate)
@@ -317,7 +317,7 @@ internal class ForumService : IForumService
 			return subforumActivity;
 		}
 
-		DateTime minimumDate = DateTime.UtcNow.AddDays(-ForumConstants.DaysTopicsCountAsActive);
+		DateTime minimumDate = DateTime.UtcNow.AddDays(-ForumConstants.DaysPostsCountAsActive);
 
 		var fullrow = await _db.ForumPosts
 			.Where(fp => fp.CreateTimestamp > minimumDate || fp.PostEditedTimestamp > minimumDate)

--- a/TASVideos.Core/Services/TASVideoAgent.cs
+++ b/TASVideos.Core/Services/TASVideoAgent.cs
@@ -82,6 +82,7 @@ internal class TASVideoAgent : ITASVideoAgent
 			topic.Id,
 			new LatestPost(post.Id, post.CreateTimestamp, SiteGlobalConstants.TASVideoAgent));
 		_forumService.CacheNewPostActivity(post.ForumId, topic.Id, post.CreateTimestamp);
+		_forumService.CacheNewPostActivity2(post.ForumId, topic.Id, post.Id, post.CreateTimestamp);
 
 		return topic.Id;
 	}

--- a/TASVideos.Core/Services/TASVideoAgent.cs
+++ b/TASVideos.Core/Services/TASVideoAgent.cs
@@ -81,7 +81,6 @@ internal class TASVideoAgent : ITASVideoAgent
 			ForumConstants.WorkBenchForumId,
 			topic.Id,
 			new LatestPost(post.Id, post.CreateTimestamp, SiteGlobalConstants.TASVideoAgent));
-		_forumService.CacheNewPostActivity(post.ForumId, topic.Id, post.CreateTimestamp);
 		_forumService.CacheNewPostActivity2(post.ForumId, topic.Id, post.Id, post.CreateTimestamp);
 
 		return topic.Id;

--- a/TASVideos.Core/Services/TASVideoAgent.cs
+++ b/TASVideos.Core/Services/TASVideoAgent.cs
@@ -118,6 +118,9 @@ internal class TASVideoAgent : ITASVideoAgent
 				PosterMood = ForumPostMood.Happy
 			});
 			await _db.SaveChangesAsync();
+
+			_forumService.ClearLatestPostCache();
+			_forumService.ClearTopicActivityCache();
 		}
 	}
 
@@ -153,6 +156,9 @@ internal class TASVideoAgent : ITASVideoAgent
 				PosterMood = ForumPostMood.Puzzled
 			});
 			await _db.SaveChangesAsync();
+
+			_forumService.ClearLatestPostCache();
+			_forumService.ClearTopicActivityCache();
 		}
 	}
 

--- a/TASVideos.Core/Services/TASVideoAgent.cs
+++ b/TASVideos.Core/Services/TASVideoAgent.cs
@@ -81,7 +81,7 @@ internal class TASVideoAgent : ITASVideoAgent
 			ForumConstants.WorkBenchForumId,
 			topic.Id,
 			new LatestPost(post.Id, post.CreateTimestamp, SiteGlobalConstants.TASVideoAgent));
-		_forumService.CacheNewPostActivity2(post.ForumId, topic.Id, post.Id, post.CreateTimestamp);
+		_forumService.CacheNewPostActivity(post.ForumId, topic.Id, post.Id, post.CreateTimestamp);
 
 		return topic.Id;
 	}

--- a/TASVideos/Pages/Forum/Index.cshtml
+++ b/TASVideos/Pages/Forum/Index.cshtml
@@ -72,6 +72,21 @@
 					activitySubforum.parentElement.setAttribute('href', '/Forum/Posts/' + firstPostId);
 				}
 			}
+
+			// clean up localStorage
+			let allActivityPostIds = new Set();
+			for (let activitySubforum of activitySubforums) {
+				let activityPostsCreated = JSON.parse(activitySubforum.dataset.activityPostsCreated);
+				for (let postId in activityPostsCreated) {
+					allActivityPostIds.add(postId);
+				}
+				let activityPostsEdited = JSON.parse(activitySubforum.dataset.activityPostsEdited);
+				for (let postId in activityPostsEdited) {
+					allActivityPostIds.add(postId);
+				}
+			}
+			Object.keys(visitedPosts).filter(postId => !allActivityPostIds.has(postId)).forEach(postId => delete visitedPosts[postId]);
+			localStorage.setItem('VisitedPosts', JSON.stringify(visitedPosts));
 		}
 		function markAllPostsRead() {
 			let visitedPosts = localStorage.getItem('VisitedPosts');

--- a/TASVideos/Pages/Forum/Index.cshtml
+++ b/TASVideos/Pages/Forum/Index.cshtml
@@ -36,38 +36,58 @@
 	<script>
 		let currentTime = Number(document.getElementById('serverUnixTime').textContent);
 		{
-			let visitedTopics = localStorage.getItem('VisitedTopics');
-			if (visitedTopics) {
-				visitedTopics = JSON.parse(visitedTopics);
-			} else {
-				visitedTopics = {};
-			}
+			let visitedPosts = localStorage.getItem('VisitedPosts');
+			visitedPosts = JSON.parse(visitedPosts) ?? {};
 			let activitySubforums = document.getElementsByClassName('activity-subforum');
-			for (let activityTopic of activitySubforums){
-				let activityJson = JSON.parse(activityTopic.dataset.activityJson);
-				let display = false;
-				for (let topicId in activityJson){
-					let lastVisit = visitedTopics[topicId];
-					if (!lastVisit || lastVisit < activityJson[topicId]){
-						display = true;
-						break;
+			for (let activitySubforum of activitySubforums) {
+				let displayClass;
+				let firstPostId, firstPostDate;
+				let activityPostsCreated = JSON.parse(activitySubforum.dataset.activityPostsCreated);
+				for (let postId in activityPostsCreated) {
+					let lastVisit = visitedPosts[postId];
+					if (!lastVisit || lastVisit < activityPostsCreated[postId]) {
+						displayClass = 'text-warning';
+						if (!firstPostId || activityPostsCreated[postId] < firstPostDate) {
+							firstPostId = postId;
+							firstPostDate = activityPostsCreated[postId];
+						}
 					}
 				}
-				if (display){
-					activityTopic.classList.remove('d-none');
+				if (!displayClass) {
+					let activityPostsEdited = JSON.parse(activitySubforum.dataset.activityPostsEdited);
+					for (let postId in activityPostsEdited) {
+						let lastVisit = visitedPosts[postId];
+						if (!lastVisit || lastVisit < activityPostsEdited[postId]) {
+							displayClass = 'text-info';
+							if (!firstPostId || activityPostsEdited[postId] < firstPostDate) {
+								firstPostId = postId;
+								firstPostDate = activityPostsEdited[postId];
+							}
+						}
+					}
+				}
+				if (displayClass) {
+					activitySubforum.classList.add(displayClass);
+					activitySubforum.classList.remove('d-none');
+					activitySubforum.parentElement.setAttribute('href', '/Forum/Posts/' + firstPostId);
 				}
 			}
 		}
-		function markAllPostsRead(){
-			let visitedTopics = {};
+		function markAllPostsRead() {
+			let visitedPosts = localStorage.getItem('VisitedPosts');
+			visitedPosts = JSON.parse(visitedPosts) ?? {};
 			let activitySubforums = document.getElementsByClassName('activity-subforum');
-			for (let activityTopic of activitySubforums){
-				let activityJson = JSON.parse(activityTopic.dataset.activityJson);
-				for (let topicId in activityJson){
-					visitedTopics[topicId] = currentTime;
+			for (let activitySubforum of activitySubforums) {
+				let activityPostsCreated = JSON.parse(activitySubforum.dataset.activityPostsCreated);
+				for (let postId in activityPostsCreated) {
+					visitedPosts[postId] = currentTime;
+				}
+				let activityPostsEdited = JSON.parse(activitySubforum.dataset.activityPostsEdited);
+				for (let postId in activityPostsEdited) {
+					visitedPosts[postId] = currentTime;
 				}
 			}
-			localStorage.setItem('VisitedTopics', JSON.stringify(visitedTopics));
+			localStorage.setItem('VisitedPosts', JSON.stringify(visitedPosts));
 			location.reload();
 		}
 	</script>

--- a/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
@@ -164,15 +164,18 @@ public class EditModel : BaseForumModel
 		forumPost.PostEditedTimestamp = DateTime.UtcNow;
 
 		var result = await ConcurrentSave(_db, $"Post {Id} edited", "Unable to edit post");
-		if (result && !MinorEdit)
+		if (result)
 		{
 			_forumService.CacheEditedPostActivity(forumPost.ForumId, forumPost.Topic!.Id, forumPost.Id, (DateTime)forumPost.PostEditedTimestamp);
 
-			await _publisher.SendForum(
-				forumPost.Topic!.Forum!.Restricted,
-				$"Post edited by {User.Name()}",
-				$"{forumPost.Topic.Forum.ShortName}: {forumPost.Topic.Title}",
-				$"Forum/Posts/{Id}");
+			if (!MinorEdit)
+			{
+				await _publisher.SendForum(
+					forumPost.Topic!.Forum!.Restricted,
+					$"Post edited by {User.Name()}",
+					$"{forumPost.Topic.Forum.ShortName}: {forumPost.Topic.Title}",
+					$"Forum/Posts/{Id}");
+			}
 		}
 
 		return BaseRedirect($"/Forum/Posts/{Id}");

--- a/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
@@ -166,6 +166,8 @@ public class EditModel : BaseForumModel
 		var result = await ConcurrentSave(_db, $"Post {Id} edited", "Unable to edit post");
 		if (result && !MinorEdit)
 		{
+			_forumService.CacheEditedPostActivity2(forumPost.ForumId, forumPost.Topic!.Id, forumPost.Id, (DateTime)forumPost.PostEditedTimestamp);
+
 			await _publisher.SendForum(
 				forumPost.Topic!.Forum!.Restricted,
 				$"Post edited by {User.Name()}",

--- a/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
@@ -166,7 +166,7 @@ public class EditModel : BaseForumModel
 		var result = await ConcurrentSave(_db, $"Post {Id} edited", "Unable to edit post");
 		if (result && !MinorEdit)
 		{
-			_forumService.CacheEditedPostActivity2(forumPost.ForumId, forumPost.Topic!.Id, forumPost.Id, (DateTime)forumPost.PostEditedTimestamp);
+			_forumService.CacheEditedPostActivity(forumPost.ForumId, forumPost.Topic!.Id, forumPost.Id, (DateTime)forumPost.PostEditedTimestamp);
 
 			await _publisher.SendForum(
 				forumPost.Topic!.Forum!.Restricted,

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml
@@ -35,7 +35,12 @@
 					<span condition="@(topic.Type == ForumTopicType.Announcement)" class="fw-bold text-warning"><i class="fa fa-bullhorn"></i> Announcement: </span>
 					<span condition="@(topic.Type == ForumTopicType.Sticky)" class="fw-bold text-info"><i class="fa fa-sticky-note"></i> Sticky: </span>
 					<span condition="@topic.IsLocked" class="text-danger"><i class="fa fa-lock"></i></span>
-					<span condition="@(Model.ActivityTopics.ContainsKey(topic.Id))"><i class="fa fa-file text-warning activity-topic d-none" data-topic-id="@topic.Id" data-activity-unix="@(Model.ActivityTopics[topic.Id].UnixTimestamp())"></i></span>
+					<a condition="@(Model.ActivityTopics.ContainsKey(topic.Id))" class="text-decoration-none">
+						<i class="fa fa-file activity-topic d-none"
+						data-topic-id="@topic.Id"
+						data-activity-posts-created="@Model.ActivityTopics[topic.Id].Item1"
+					    data-activity-posts-edited="@Model.ActivityTopics[topic.Id].Item2"></i>
+					</a>
 					<a asp-page="/Forum/Topics/Index" asp-route-id="@topic.Id" class="fw-bold">@topic.Title</a>
 					<div class="ms-2">
 						@{
@@ -44,20 +49,20 @@
 							{
 								for (int pageNumber = 1; pageNumber <= totalPages; pageNumber++)
 								{
-									<text>
-										<a asp-page="/Forum/Topics/Index"
+										<text>
+											<a asp-page="/Forum/Topics/Index"
 										   asp-route-id="@topic.Id"
 										   asp-route-CurrentPage="@pageNumber"
 										   asp-route-PageSize="@ForumConstants.PostsPerPage"
 										   asp-route-Sort="CreateTimestamp"
 										   class="btn btn-outline-primary btn-sm mt-1">
-											@pageNumber
-										</a>
-									</text>
+												@pageNumber
+											</a>
+										</text>
 									if (totalPages > 5 && pageNumber == 2)
 									{
 										pageNumber = totalPages - 2;
-										<text><span>…</span></text>
+											<text><span>…</span></text>
 									}
 								}
 							}
@@ -85,32 +90,58 @@
 	<script>
 		let currentTime = Number(document.getElementById('serverUnixTime').textContent);
 		{
-			let visitedTopics = localStorage.getItem('VisitedTopics');
-			if (visitedTopics !== null){
-				visitedTopics = JSON.parse(visitedTopics);
-			}else{
-				visitedTopics = {};
-			}
+			let visitedPosts = localStorage.getItem('VisitedPosts');
+			visitedPosts = JSON.parse(visitedPosts) ?? {};
 			let activityTopics = document.getElementsByClassName('activity-topic');
-			for (let activityTopic of activityTopics){
-				let lastVisit = visitedTopics[activityTopic.dataset.topicId];
-				if (lastVisit === undefined || lastVisit < activityTopic.dataset.activityUnix){
+			for (let activityTopic of activityTopics) {
+				let displayClass;
+				let firstPostId, firstPostDate;
+				let activityPostsCreated = JSON.parse(activityTopic.dataset.activityPostsCreated);
+				for (let postId in activityPostsCreated) {
+					let lastVisit = visitedPosts[postId];
+					if (!lastVisit || lastVisit < activityPostsCreated[postId]) {
+						displayClass = 'text-warning';
+						if (!firstPostId || activityPostsCreated[postId] < firstPostDate) {
+							firstPostId = postId;
+							firstPostDate = activityPostsCreated[postId];
+						}
+					}
+				}
+				if (!displayClass) {
+					let activityPostsEdited = JSON.parse(activityTopic.dataset.activityPostsEdited);
+					for (let postId in activityPostsEdited) {
+						let lastVisit = visitedPosts[postId];
+						if (!lastVisit || lastVisit < activityPostsEdited[postId]) {
+							displayClass = 'text-info';
+							if (!firstPostId || activityPostsEdited[postId] < firstPostDate) {
+								firstPostId = postId;
+								firstPostDate = activityPostsEdited[postId];
+							}
+						}
+					}
+				}
+				if (displayClass) {
+					activityTopic.classList.add(displayClass);
 					activityTopic.classList.remove('d-none');
+					activityTopic.parentElement.setAttribute('href', '/Forum/Posts/' + firstPostId);
 				}
 			}
 		}
 		function markSubforumPostsRead(){
-			let visitedTopics = localStorage.getItem('VisitedTopics');
-			if (visitedTopics !== null){
-				visitedTopics = JSON.parse(visitedTopics);
-			}else{
-				visitedTopics = {};
-			}
+			let visitedPosts = localStorage.getItem('VisitedPosts');
+			visitedPosts = JSON.parse(visitedPosts) ?? {};
 			let activityTopics = document.getElementsByClassName('activity-topic');
-			for (let activityTopic of activityTopics){
-				visitedTopics[activityTopic.dataset.topicId] = currentTime;
+			for (let activityTopic of activityTopics) {
+				let activityPostsCreated = JSON.parse(activityTopic.dataset.activityPostsCreated);
+				for (let postId in activityPostsCreated) {
+					visitedPosts[postId] = currentTime;
+				}
+				let activityPostsEdited = JSON.parse(activityTopic.dataset.activityPostsEdited);
+				for (let postId in activityPostsEdited) {
+					visitedPosts[postId] = currentTime;
+				}
 			}
-			localStorage.setItem('VisitedTopics', JSON.stringify(visitedTopics));
+			localStorage.setItem('VisitedPosts', JSON.stringify(visitedPosts));
 			location.reload();
 		}
 	</script>

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
@@ -68,7 +68,7 @@ public class IndexModel : BasePageModel
 			.ThenByDescending(ft => ft.LastPost != null ? ft.LastPost.Id : 0)
 			.PageOf(Search);
 
-		ActivityTopics = await _forumService.Get2PostActivityOfTopics2(Id);
+		ActivityTopics = await _forumService.GetPostActivityOfSubforum(Id);
 
 		return Page();
 	}

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
@@ -30,7 +30,7 @@ public class IndexModel : BasePageModel
 	public int Id { get; set; }
 
 	public ForumDisplayModel Forum { get; set; } = new();
-	public Dictionary<int, DateTime> ActivityTopics { get; set; } = new();
+	public Dictionary<int, (string, string)> ActivityTopics { get; set; } = new();
 
 	public async Task<IActionResult> OnGet()
 	{
@@ -68,7 +68,7 @@ public class IndexModel : BasePageModel
 			.ThenByDescending(ft => ft.LastPost != null ? ft.LastPost.Id : 0)
 			.PageOf(Search);
 
-		ActivityTopics = await _forumService.GetTopicsWithActivity(Id) ?? new Dictionary<int, DateTime>();
+		ActivityTopics = await _forumService.Get2PostActivityOfTopics(Id);
 
 		return Page();
 	}

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
@@ -68,7 +68,7 @@ public class IndexModel : BasePageModel
 			.ThenByDescending(ft => ft.LastPost != null ? ft.LastPost.Id : 0)
 			.PageOf(Search);
 
-		ActivityTopics = await _forumService.Get2PostActivityOfTopics(Id);
+		ActivityTopics = await _forumService.Get2PostActivityOfTopics2(Id);
 
 		return Page();
 	}

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml
@@ -166,9 +166,9 @@
 			visitedPosts = JSON.parse(visitedPosts) ?? {};
 			for (let i = 0; i < activityPosts.length; i++) {
 				let lastVisit = visitedPosts[activityPosts[i].dataset.postId];
-				if (lastVisit === undefined || lastVisit < activityPosts[i].dataset.unixCreated) {
+				if (activityPosts[i].dataset.unixCreated && (lastVisit === undefined || lastVisit < activityPosts[i].dataset.unixCreated)) {
 					activityPosts[i].classList.add('text-warning');
-				} else if (activityPosts[i].dataset.unixEdited && lastVisit < activityPosts[i].dataset.unixEdited) {
+				} else if (activityPosts[i].dataset.unixEdited && (lastVisit === undefined || lastVisit < activityPosts[i].dataset.unixEdited)) {
 					activityPosts[i].classList.add('text-info');
 				}
 				visitedPosts[activityPosts[i].dataset.postId] = currentTime;

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml
@@ -175,19 +175,5 @@
 			}
 			localStorage.setItem('VisitedPosts', JSON.stringify(visitedPosts));
 		}
-		/*
-		{
-			let topicId = '@Model.Id';
-			let currentTime = Number(document.getElementById('serverUnixTime').textContent);
-			let visitedTopics = localStorage.getItem('VisitedTopics');
-			if (visitedTopics !== null) {
-				visitedTopics = JSON.parse(visitedTopics);
-				visitedTopics[topicId] = currentTime;
-			} else {
-				visitedTopics = { [topicId]: currentTime };
-			}
-			localStorage.setItem('VisitedTopics', JSON.stringify(visitedTopics));
-		}
-		*/
 	</script>
 }

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml
@@ -160,6 +160,23 @@
 @section Scripts {
 	<script condition="@(Model.SaveActivity)">
 		{
+			let currentTime = Number(document.getElementById('serverUnixTime').textContent);
+			let activityPosts = document.getElementsByClassName('activity-post');
+			let visitedPosts = localStorage.getItem('VisitedPosts');
+			visitedPosts = JSON.parse(visitedPosts) ?? {};
+			for (let i = 0; i < activityPosts.length; i++) {
+				let lastVisit = visitedPosts[activityPosts[i].dataset.postId];
+				if (lastVisit === undefined || lastVisit < activityPosts[i].dataset.unixCreated) {
+					activityPosts[i].classList.add('text-warning');
+				} else if (activityPosts[i].dataset.unixEdited && lastVisit < activityPosts[i].dataset.unixEdited) {
+					activityPosts[i].classList.add('text-info');
+				}
+				visitedPosts[activityPosts[i].dataset.postId] = currentTime;
+			}
+			localStorage.setItem('VisitedPosts', JSON.stringify(visitedPosts));
+		}
+		/*
+		{
 			let topicId = '@Model.Id';
 			let currentTime = Number(document.getElementById('serverUnixTime').textContent);
 			let visitedTopics = localStorage.getItem('VisitedTopics');
@@ -171,5 +188,6 @@
 			}
 			localStorage.setItem('VisitedTopics', JSON.stringify(visitedTopics));
 		}
+		*/
 	</script>
 }

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
@@ -190,7 +190,7 @@ public class IndexModel : BaseForumModel
 			await _topicWatcher.MarkSeen(Id, userId.Value);
 		}
 
-		SaveActivity = (await _forumService.Get2PostActivityOfTopics2(Topic.ForumId)).ContainsKey(Id);
+		SaveActivity = (await _forumService.GetPostActivityOfSubforum(Topic.ForumId)).ContainsKey(Id);
 
 		return Page();
 	}

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
@@ -190,7 +190,7 @@ public class IndexModel : BaseForumModel
 			await _topicWatcher.MarkSeen(Id, userId.Value);
 		}
 
-		SaveActivity = (await _forumService.Get2PostActivityOfTopics(Topic.ForumId)).ContainsKey(Id);
+		SaveActivity = (await _forumService.Get2PostActivityOfTopics2(Topic.ForumId)).ContainsKey(Id);
 
 		return Page();
 	}

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
@@ -190,9 +190,7 @@ public class IndexModel : BaseForumModel
 			await _topicWatcher.MarkSeen(Id, userId.Value);
 		}
 
-		var hasActivity = (await _forumService.GetTopicsWithActivity(Topic.ForumId))?.ContainsKey(Id) ?? false;
-		var onLastPage = Topic.Posts.CurrentPage == Topic.Posts.LastPage();
-		SaveActivity = hasActivity && onLastPage;
+		SaveActivity = (await _forumService.Get2PostActivityOfTopics(Topic.ForumId)).ContainsKey(Id);
 
 		return Page();
 	}

--- a/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
@@ -7,7 +7,7 @@
 					<a href="/Forum/Posts/@(Model.Id)"
 					   title="Link to this post"
 					   class="float-start text-decoration-none text-dark">
-						<i class="fa fa-bookmark-o"></i>
+						<i class="fa fa-bookmark @(Model.CreateTimestamp > DateTime.UtcNow.AddDays(-ForumConstants.DaysTopicsCountAsActive) || Model.PostEditedTimestamp > DateTime.UtcNow.AddDays(-ForumConstants.DaysTopicsCountAsActive) ? "activity-post" : "")" data-post-id="@Model.Id" data-unix-created="@Model.CreateTimestamp.UnixTimestamp()" data-unix-edited="@Model.PostEditedTimestamp?.UnixTimestamp()"></i>
 						Posted: <timezone-convert asp-for="@Model.CreateTimestamp" />
 						<span condition="@(Model.PostEditedTimestamp != null)">@{var postEditedTimestamp = (DateTime)Model.PostEditedTimestamp!;}<br />(Edited: <timezone-convert asp-for="@postEditedTimestamp" />)</span>
 					</a>

--- a/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
@@ -1,6 +1,6 @@
 ﻿@model TASVideos.Pages.Forum.Models.IForumPostEntry
 @{
-	DateTime minimumDate = DateTime.UtcNow.AddDays(-ForumConstants.DaysTopicsCountAsActive);
+	DateTime minimumDate = DateTime.UtcNow.AddDays(-ForumConstants.DaysPostsCountAsActive);
 	bool isCreateActivity = Model.CreateTimestamp > minimumDate;
 	bool isEditActivity = Model.PostEditedTimestamp > minimumDate;
 	string addClass = (isCreateActivity || isEditActivity) ? "activity-post" : "";

--- a/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
@@ -1,4 +1,10 @@
 ﻿@model TASVideos.Pages.Forum.Models.IForumPostEntry
+@{
+	DateTime minimumDate = DateTime.UtcNow.AddDays(-ForumConstants.DaysTopicsCountAsActive);
+	bool isCreateActivity = Model.CreateTimestamp > minimumDate;
+	bool isEditActivity = Model.PostEditedTimestamp > minimumDate;
+	string addClass = (isCreateActivity || isEditActivity) ? "activity-post" : "";
+}
 <card id="@Model.Id" class="@(Model.Highlight ? "forum-post-highlight border-warning border-2" : "border-primary") border mb-2">
 	<cardheader class="px-2 py-1">
 		<row class="align-items-center">
@@ -7,7 +13,7 @@
 					<a href="/Forum/Posts/@(Model.Id)"
 					   title="Link to this post"
 					   class="float-start text-decoration-none text-dark">
-						<i class="fa fa-bookmark @(Model.CreateTimestamp > DateTime.UtcNow.AddDays(-ForumConstants.DaysTopicsCountAsActive) || Model.PostEditedTimestamp > DateTime.UtcNow.AddDays(-ForumConstants.DaysTopicsCountAsActive) ? "activity-post" : "")" data-post-id="@Model.Id" data-unix-created="@Model.CreateTimestamp.UnixTimestamp()" data-unix-edited="@Model.PostEditedTimestamp?.UnixTimestamp()"></i>
+						<i class="fa fa-bookmark @addClass" data-post-id="@Model.Id" data-unix-created="@(isCreateActivity ? Model.CreateTimestamp.UnixTimestamp() : "")" data-unix-edited="@(isEditActivity ? Model.PostEditedTimestamp?.UnixTimestamp() : "")"></i>
 						Posted: <timezone-convert asp-for="@Model.CreateTimestamp" />
 						<span condition="@(Model.PostEditedTimestamp != null)">@{var postEditedTimestamp = (DateTime)Model.PostEditedTimestamp!;}<br />(Edited: <timezone-convert asp-for="@postEditedTimestamp" />)</span>
 					</a>

--- a/TASVideos/Pages/Forum/_Category.cshtml
+++ b/TASVideos/Pages/Forum/_Category.cshtml
@@ -25,7 +25,11 @@
 		<row class="py-1 border-bottom border-card align-items-center">
 				<div class="col-8">
 					<strong>
-						<span condition="@(!string.IsNullOrEmpty(forum.ActivityTopics))"><i class="fa fa-file text-warning activity-subforum d-none" data-activity-json="@forum.ActivityTopics"></i></span>
+						<a condition="@(!string.IsNullOrEmpty(forum.ActivityPostsCreated) || !string.IsNullOrEmpty(forum.ActivityPostsEdited))" class="text-decoration-none">
+							<i class="fa fa-file activity-subforum d-none"
+							data-activity-posts-created="@forum.ActivityPostsCreated"
+						    data-activity-posts-edited="@forum.ActivityPostsEdited"></i>
+						</a>
 						<a asp-page="/Forum/Subforum/Index" asp-route-id="@forum.Id">@forum.Name</a>
 					</strong>
 				<div class="ps-3">


### PR DESCRIPTION
Resolves #1429 by upgrading the way activity icons work. Instead of locally tracking only the forum visit, we now locally track all "activity posts" the user visits.

A post is an activity post if it was created or edited in the "past few" days. The actual range is determined by the constant `ForumConstants.DaysPostsCountAsActive` and is currently 14 days. Though due to caching it *can* include posts longer ago than that.

If you click on an icon you will directly go to the activity post.
If multiple activity posts belong to the icon, you will be brought to the first one you haven't visited yet.
If you have visited all activity posts, no icon will be shown.

There are both post creations icons (orange) and post edit icons (blue).
The edit icon will only be visible if you already visited all post creations, even if an edit came before a different post.

Additionally, I added the same colors of icons on the posts themselves. Meaning no matter how you navigate there, you will see the activity post icons on the posts themselves. Of course, you will see them only once. Afterwards they're just regular white icons.

![image](https://user-images.githubusercontent.com/22375320/195952744-0f7ebd74-15df-4e53-acd1-7b2a00544f5f.png)

![image](https://user-images.githubusercontent.com/22375320/195952787-bb909e7d-b1f7-4bdd-bfb3-9daae515b72e.png)

![image](https://user-images.githubusercontent.com/22375320/195952944-b0329a56-39a3-4ebf-b394-17b09e43c7d5.png)
