### PR TITLE
Make titles bigger on certain pages

### DIFF
--- a/TASVideos/wwwroot/css/partials/_bootstrap-overrides.scss
+++ b/TASVideos/wwwroot/css/partials/_bootstrap-overrides.scss
@@ -38,6 +38,10 @@ h1 {
 	.card & {
 		font-size: 1em;
 	}
+
+	&.card {
+		font-size: 1.75em;
+	}
 }
 
 h2 {


### PR DESCRIPTION
Fixes #1087

Title is now larger than Status on Submission Page
![image](https://user-images.githubusercontent.com/26491971/196580500-98538ad6-4147-4418-bb1d-84bbcae8d410.png)

This fix addresses other pages that use header cards as well.
