### PR TITLE
Enable logging for AntiForgeryToken errors

### DIFF
--- a/TASVideos/appsettings.Production.json
+++ b/TASVideos/appsettings.Production.json
@@ -12,7 +12,8 @@
     "MinimumLevel": {
       "Default": "Warning",
       "Override": {
-        "Microsoft.AspNetCore.Identity":  "Error"
+        "Microsoft.AspNetCore.Identity": "Error",
+        "Microsoft.AspNetCore.Mvc.ViewFeatures.Filters.AutoValidateAntiforgeryTokenAuthorizationFilter": "Information"
       }
 		},
     "WriteTo": [


### PR DESCRIPTION
People keep running into this problem where they want to submit data and they get a 400 Bad Request error page.
So let's enable logging!

With this we can assure that *at least one* of these six situations is occurring:
1. The cookie token is not present.
2. The request token is not present.
3. The cookie token can't be decrypted.
4. The request token can't be decrypted.
5. The cookie token and request token do not match.
6. _It's not the AntiForgeryToken at all._