### PR TITLE
Don't split usernames on homepages

### DIFF
--- a/TASVideos.Common/Extensions/StringExtensions.cs
+++ b/TASVideos.Common/Extensions/StringExtensions.cs
@@ -51,6 +51,18 @@ public static class StringExtensions
 			: str[..limit];
 	}
 
+	public static string SplitCamelCase(this string? str, bool isHomePage)
+	{
+		if (!isHomePage || string.IsNullOrEmpty(str))
+		{
+			return SplitCamelCase(str);
+		}
+
+		// Don't split usernames on homepages
+		// Username will be in the second slot e.g. Home Pages/CamelCaseUser/An Example
+		return string.Join("/", str.Split("/").Select((item, i) => i == 1 ? item : item.SplitCamelCase()));
+	}
+
 	/// <summary>
 	/// Takes a string and adds spaces between words,
 	/// As well as forward slashes

--- a/TASVideos/Pages/Shared/Components/ListSubPages/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/ListSubPages/Default.cshtml
@@ -1,4 +1,5 @@
-﻿@model IEnumerable<string>
+﻿@using TASVideos.Core.Services.Wiki
+@model IEnumerable<string>
 @{
 	var pageId = ViewData.UniqueId();
 
@@ -6,12 +7,15 @@
 	var pageGrouping = Model.GroupBy(tkey => tkey.ReplaceFirst(parent + "/", "").Split('/').FirstOrDefault());
 
 	var show = (bool)(ViewData["show"] ?? false);
+
+	IWikiPage pageData = ViewData["WikiPage"] as IWikiPage ?? throw new InvalidOperationException("WikiPage not set");
+	var isHomePage = WikiHelper.IsHomePage(pageData.PageName);
 }
 
 <div condition="@Model.Any()" class="card">
 	<div class="card-header">
 		<collapsablecontent-header body-id="collapse-content-@pageId">
-			<i class="fa fa-chevron-circle-down"></i> <strong>Subpages for @ViewData["Parent"]?.ToString().SplitCamelCase()</strong>
+			<i class="fa fa-chevron-circle-down"></i> <strong>Subpages for @ViewData["Parent"]?.ToString().SplitCamelCase(isHomePage)</strong>
 		</collapsablecontent-header>
 	</div>
 	<collapsablecontent-body id="collapse-content-@pageId" start-shown="@show">
@@ -20,7 +24,14 @@
 				@foreach (var pageGroup in pageGrouping.OrderBy(g => g.Key))
 				{
 					<li>
-						<a href="/@($"{parent}/{pageGroup.Key}")">@pageGroup.Key?.Replace($"{parent}/", "").SplitCamelCase()</a>
+						@{
+							// If we're showing the list of home pages, don't split the usernames
+							var parentName = @parent == "HomePages"
+								? @pageGroup.Key?.Replace($"{parent}/", "")
+								: @pageGroup.Key?.Replace($"{parent}/", "").SplitCamelCase();
+
+							<a href="/@($"{parent}/{pageGroup.Key}")">@parentName</a>
+						}
 						<ul condition="pageGroup.Count() > 1">
 							@foreach (var subpage in pageGroup.Where(pg => pg != $"{parent}/{pageGroup.Key}").OrderBy(pg => pg))
 							{

--- a/TASVideos/Pages/Shared/_WikiLayout.cshtml
+++ b/TASVideos/Pages/Shared/_WikiLayout.cshtml
@@ -33,7 +33,7 @@
 				@{
 					var allPages = pageData.PageName.Split('/');
 					var runningPath = "";
-					for(int i = 0; i < allPages.Length - 1; i++) 
+					for (int i = 0; i < allPages.Length - 1; i++) 
 					{
 						var item = allPages[i];
 						runningPath += $"/{allPages[i]}";

--- a/TASVideos/Pages/Shared/_WikiLayout.cshtml
+++ b/TASVideos/Pages/Shared/_WikiLayout.cshtml
@@ -7,6 +7,8 @@
 	ViewData["ActiveTab"] = WikiHelper.IsGameResourcesPage(pageData.PageName)
 		? "Game Resources"
 		: pageData.PageName;
+
+	bool isHomePage = WikiHelper.IsHomePage(pageData.PageName);
 }
 @section Header {
 	@{
@@ -31,12 +33,16 @@
 				@{
 					var allPages = pageData.PageName.Split('/');
 					var runningPath = "";
-					foreach (var item in allPages.Take(allPages.Length - 1))
+					for(int i = 0; i < allPages.Length - 1; i++) 
 					{
-						runningPath += $"/{item}";
-						<li class="breadcrumb-item"><a href="@runningPath">@item.SplitCamelCase()</a></li>
+						var item = allPages[i];
+						runningPath += $"/{allPages[i]}";
+						// Don't split usernames e.g. Home Pages/CamelCaseUser/An Example
+						var itemName = isHomePage && i == 1 ? item : item.SplitCamelCase();
+						<li class="breadcrumb-item"><a href="@runningPath">@itemName</a></li>
 					}
-					<li class="breadcrumb-item active" aria-current="page"><h1>@allPages.Last().SplitCamelCase()</h1></li>
+					var pageTitle = isHomePage && allPages.Length == 2 ? allPages.Last() : @allPages.Last().SplitCamelCase();
+					<li class="breadcrumb-item active" aria-current="page"><h1>@pageTitle</h1></li>
 				}
 			</ol>
 		</nav>


### PR DESCRIPTION
Fixes #1118

Cases where names aren't split anymore:

List of home pages
![image](https://user-images.githubusercontent.com/26491971/197103443-dd0e1e1a-5694-4141-94f3-99c419644148.png)

Breadcrumb on home page & its sub pages
![image](https://user-images.githubusercontent.com/26491971/197103516-7b91d8f1-21ce-4133-a523-e08e074182cc.png)

Breadcrumb for subpage list on home page
![image](https://user-images.githubusercontent.com/26491971/197103465-8e2f55ec-7d56-4832-bbfc-3066f2d6334a.png)
