### PR TITLE
Don't split Usernames in Path Displays

### DIFF
--- a/TASVideos.Common/Extensions/StringExtensions.cs
+++ b/TASVideos.Common/Extensions/StringExtensions.cs
@@ -91,21 +91,21 @@ public static class StringExtensions
 			return "";
 		}
 
-		if (str.StartsWith("HomePages/"))
+		if (!str.StartsWith("HomePages/"))
 		{
-			var pathFragments = str.SplitWithEmpty("/");
-			for (int i = 0; i < pathFragments.Length; i++)
-			{
-				if (i != 1)
-				{
-					pathFragments[i] = SplitCamelCase(pathFragments[i]);
-				}
-			}
-
-			return string.Join(" / ", pathFragments);
+			return SplitCamelCase(str);
 		}
 
-		return SplitCamelCase(str);
+		var pathFragments = str.SplitWithEmpty("/");
+		for (int i = 0; i < pathFragments.Length; i++)
+		{
+			if (i != 1)
+			{
+				pathFragments[i] = SplitCamelCase(pathFragments[i]);
+			}
+		}
+
+		return string.Join(" / ", pathFragments);
 	}
 
 	/// <summary>

--- a/TASVideos.Common/Extensions/StringExtensions.cs
+++ b/TASVideos.Common/Extensions/StringExtensions.cs
@@ -81,6 +81,24 @@ public static class StringExtensions
 	}
 
 	/// <summary>
+	/// Uses <see cref="SplitCamelCase"/> to split the string,
+	/// but also checks for a HomePages path and undoes the split for the usernames in the path.
+	/// </summary>
+	public static string SplitPathCamelCase(this string? str)
+	{
+		string split = SplitCamelCase(str);
+
+		if (split.StartsWith("Home Pages / "))
+		{
+			string[] retSplit = split.Split(" / ");
+			retSplit[1] = retSplit[1].RemoveAllSpaces();
+			split = string.Join(" / ", retSplit);
+		}
+
+		return split;
+	}
+
+	/// <summary>
 	/// Takes a comma separated string and returns a list of values.
 	/// </summary>
 	public static IEnumerable<string> CsvToStrings(this string? param)
@@ -122,11 +140,18 @@ public static class StringExtensions
 		return str.Split(new[] { separator }, StringSplitOptions.RemoveEmptyEntries);
 	}
 
+	private static readonly Regex SplitCamelCaseRegex = new(@"(\/)|(\p{Ll})(?=[\p{Lu}\p{Nd}])|(\p{Nd})(?=[\p{Lu}])|([\p{L}\p{Nd}])(?=[^\p{L}\p{Nd}])|([^\p{L}\p{Nd}])(?=[\p{L}\p{Nd}])");
 	private static string SplitCamelCaseInternal(this string? str)
 	{
 		return !string.IsNullOrWhiteSpace(str)
-			? Regex.Replace(str, @"(\/)|(\p{Ll})(?=[\p{Lu}\p{Nd}])|(\p{Nd})(?=[\p{Lu}])|([\p{L}\p{Nd}])(?=[^\p{L}\p{Nd}])|([^\p{L}\p{Nd}])(?=[\p{L}\p{Nd}])", "$1$2$3$4$5 ")
+			? SplitCamelCaseRegex.Replace(str, "$1$2$3$4$5 ")
 			: "";
+	}
+
+	private static readonly Regex SpaceRegex = new(@" +");
+	public static string RemoveAllSpaces(this string? str)
+	{
+		return SpaceRegex.Replace(str ?? "", "");
 	}
 
 	public static string UnicodeAwareSubstring(this string s, int startIndex)

--- a/TASVideos.Common/Extensions/StringExtensions.cs
+++ b/TASVideos.Common/Extensions/StringExtensions.cs
@@ -86,16 +86,26 @@ public static class StringExtensions
 	/// </summary>
 	public static string SplitPathCamelCase(this string? str)
 	{
-		string split = SplitCamelCase(str);
-
-		if (split.StartsWith("Home Pages / "))
+		if (str is null)
 		{
-			string[] retSplit = split.Split(" / ");
-			retSplit[1] = retSplit[1].RemoveAllSpaces();
-			split = string.Join(" / ", retSplit);
+			return "";
 		}
 
-		return split;
+		if (str.StartsWith("HomePages/"))
+		{
+			var pathFragments = str.SplitWithEmpty("/");
+			for (int i = 0; i < pathFragments.Length; i++)
+			{
+				if (i != 1)
+				{
+					pathFragments[i] = SplitCamelCase(pathFragments[i]);
+				}
+			}
+
+			return string.Join(" / ", pathFragments);
+		}
+
+		return SplitCamelCase(str);
 	}
 
 	/// <summary>

--- a/TASVideos/Pages/Shared/Components/ListSubPages/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/ListSubPages/Default.cshtml
@@ -2,8 +2,8 @@
 @{
 	var pageId = ViewData.UniqueId();
 
-	var parent = ViewData["Parent"]?.ToString();
-	var pageGrouping = Model.GroupBy(tkey => tkey.ReplaceFirst(parent + "/", "").Split('/').FirstOrDefault());
+	var parent = ViewData["Parent"]?.ToString().SplitPathCamelCase();
+	var pageGrouping = Model.Select(page => page.SplitPathCamelCase()).GroupBy(tkey => tkey.ReplaceFirst(parent + " / ", "").Split(" / ").FirstOrDefault()).OrderBy(g => g.Key);
 
 	var show = (bool)(ViewData["show"] ?? false);
 }
@@ -11,20 +11,20 @@
 <div condition="@Model.Any()" class="card">
 	<div class="card-header">
 		<collapsablecontent-header body-id="collapse-content-@pageId">
-			<i class="fa fa-chevron-circle-down"></i> <strong>Subpages for @ViewData["Parent"]?.ToString().SplitCamelCase()</strong>
+			<i class="fa fa-chevron-circle-down"></i> <strong>Subpages for @parent</strong>
 		</collapsablecontent-header>
 	</div>
 	<collapsablecontent-body id="collapse-content-@pageId" start-shown="@show">
 		<div class="card-body">
 			<ul>
-				@foreach (var pageGroup in pageGrouping.OrderBy(g => g.Key))
+				@foreach (var pageGroup in pageGrouping)
 				{
 					<li>
-						<a href="/@($"{parent}/{pageGroup.Key}")">@pageGroup.Key?.Replace($"{parent}/", "").SplitCamelCase()</a>
+						<a href="/@($"{parent.RemoveAllSpaces()}/{pageGroup.Key.RemoveAllSpaces()}")">@pageGroup.Key?.Replace($"{parent} / ", "")</a>
 						<ul condition="pageGroup.Count() > 1">
-							@foreach (var subpage in pageGroup.Where(pg => pg != $"{parent}/{pageGroup.Key}").OrderBy(pg => pg))
+							@foreach (var subpage in pageGroup.Where(pg => pg != $"{parent} / {pageGroup.Key}").OrderBy(pg => pg))
 							{
-								<li><a href="/@subpage">@subpage.Replace($"{parent}/{pageGroup.Key}/", "").SplitCamelCase()</a></li>
+								<li><a href="/@subpage.RemoveAllSpaces()">@subpage.Replace($"{parent} / {pageGroup.Key} / ", "")</a></li>
 							}
 						</ul>
 					</li>

--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -100,7 +100,7 @@
 		var title = ViewData["Title"]?.ToString();
 		if (ViewData["WikiPage"] != null)
 		{
-			title = title.SplitCamelCase();
+			title = title.SplitPathCamelCase();
 		}
 	}
 	@if (IsSectionDefined("PageTitle"))

--- a/TASVideos/Pages/Shared/_WikiLayout.cshtml
+++ b/TASVideos/Pages/Shared/_WikiLayout.cshtml
@@ -29,14 +29,12 @@
 		<nav aria-label="breadcrumb" class="card card-header">
 			<ol class="breadcrumb m-0">
 				@{
-					var allPages = pageData.PageName.Split('/');
-					var runningPath = "";
-					foreach (var item in allPages.Take(allPages.Length - 1))
+					var allPages = pageData.PageName.SplitPathCamelCase().Split(" / ");
+					for (int i = 0; i < allPages.Length - 1; i++)
 					{
-						runningPath += $"/{item}";
-						<li class="breadcrumb-item"><a href="@runningPath">@item.SplitCamelCase()</a></li>
+						<li class="breadcrumb-item"><a href="@('/' + string.Join('/', (allPages.Take(i+1))).RemoveAllSpaces())">@allPages[i]</a></li>
 					}
-					<li class="breadcrumb-item active" aria-current="page"><h1>@allPages.Last().SplitCamelCase()</h1></li>
+					<li class="breadcrumb-item active" aria-current="page"><h1>@allPages.Last()</h1></li>
 				}
 			</ol>
 		</nav>

--- a/tests/TASVideos.Common.Tests/Extensions/StringExtensionTests.cs
+++ b/tests/TASVideos.Common.Tests/Extensions/StringExtensionTests.cs
@@ -54,6 +54,10 @@ public class StringExtensionTests
 	}
 
 	[TestMethod]
+	[DataRow(null, "")]
+	[DataRow("", "")]
+	[DataRow("\r \n \t", "\r \n \t")]
+	[DataRow(" ", " ")]
 	[DataRow("GameResources/NES/SuperMarioBros", "Game Resources / NES / Super Mario Bros")]
 	[DataRow("HomePages/adelikat", "Home Pages / adelikat")]
 	[DataRow("HomePages/Adelikat", "Home Pages / Adelikat")]
@@ -61,8 +65,8 @@ public class StringExtensionTests
 	[DataRow("HomePages/UserNameWithCamelCase", "Home Pages / UserNameWithCamelCase")]
 	[DataRow("HomePages/UserNameWithCamelCase/Subpage", "Home Pages / UserNameWithCamelCase / Subpage")]
 	[DataRow("HomePages/UserNameWithCamelCase/SubPage", "Home Pages / UserNameWithCamelCase / Sub Page")]
-	[DataRow("HomePages/Sonic 2", "HomePages / Sonic 2")]
-	[DataRow("HomePages/Sonic 2/SubPage", "HomePages / Sonic 2 / Sub Page")]
+	[DataRow("HomePages/Sonic 2", "Home Pages / Sonic 2")]
+	[DataRow("HomePages/Sonic 2/SubPage", "Home Pages / Sonic 2 / Sub Page")]
 	public void SplitPathCamelCase_Tests(string str, string expected)
 	{
 		var actual = str.SplitPathCamelCase();

--- a/tests/TASVideos.Common.Tests/Extensions/StringExtensionTests.cs
+++ b/tests/TASVideos.Common.Tests/Extensions/StringExtensionTests.cs
@@ -61,6 +61,8 @@ public class StringExtensionTests
 	[DataRow("HomePages/UserNameWithCamelCase", "Home Pages / UserNameWithCamelCase")]
 	[DataRow("HomePages/UserNameWithCamelCase/Subpage", "Home Pages / UserNameWithCamelCase / Subpage")]
 	[DataRow("HomePages/UserNameWithCamelCase/SubPage", "Home Pages / UserNameWithCamelCase / Sub Page")]
+	[DataRow("HomePages/Sonic 2", "HomePages / Sonic 2")]
+	[DataRow("HomePages/Sonic 2/SubPage", "HomePages / Sonic 2 / Sub Page")]
 	public void SplitPathCamelCase_Tests(string str, string expected)
 	{
 		var actual = str.SplitPathCamelCase();

--- a/tests/TASVideos.Common.Tests/Extensions/StringExtensionTests.cs
+++ b/tests/TASVideos.Common.Tests/Extensions/StringExtensionTests.cs
@@ -47,13 +47,23 @@ public class StringExtensionTests
 	[DataRow("TASVideos", "TASVideos")]
 	[DataRow("NumbersGet1Space", "Numbers Get 1 Space")]
 	[DataRow("Special.Characters.Get.Spaces", "Special . Characters . Get . Spaces")]
+	public void SplitCamelCase_Tests(string str, string expected)
+	{
+		var actual = str.SplitCamelCase();
+		Assert.AreEqual(expected, actual);
+	}
+
+	[TestMethod]
 	[DataRow("GameResources/NES/SuperMarioBros", "Game Resources / NES / Super Mario Bros")]
 	[DataRow("HomePages/adelikat", "Home Pages / adelikat")]
 	[DataRow("HomePages/Adelikat", "Home Pages / Adelikat")]
 	[DataRow("HomePages/[^_^]", "Home Pages / [^_^]")]
-	public void SplitCamelCase_Tests(string str, string expected)
+	[DataRow("HomePages/UserNameWithCamelCase", "Home Pages / UserNameWithCamelCase")]
+	[DataRow("HomePages/UserNameWithCamelCase/Subpage", "Home Pages / UserNameWithCamelCase / Subpage")]
+	[DataRow("HomePages/UserNameWithCamelCase/SubPage", "Home Pages / UserNameWithCamelCase / Sub Page")]
+	public void SplitPathCamelCase_Tests(string str, string expected)
 	{
-		var actual = str.SplitCamelCase();
+		var actual = str.SplitPathCamelCase();
 		Assert.AreEqual(expected, actual);
 	}
 


### PR DESCRIPTION
Resolves #1118 .
This PR solves the same issue as PR #1448 , but instead of keeping a isHomePage flag throughout the code, this code changes the frontend to be independent of the path it has to display.
Instead of splitting the path and CamelCasing every element, it first CamelCases the whole path and afterward splits and displays every element. The advantage is that you have the whole path information available for the CamelCase operation, so you can conditionally skip converting certain elements.

If we want to be super convenient, we'd make an entire helper class to do all this for us. The code of this PR would be easy to change into that, if we ever decide that's what we want.

### Before | After
![image](https://user-images.githubusercontent.com/22375320/197195418-9807724e-49b5-4f05-95c2-6a6f3758ff21.png)

![image](https://user-images.githubusercontent.com/22375320/197195726-e3c188e4-a5f1-461b-96a7-66ee9856246f.png)

![image](https://user-images.githubusercontent.com/22375320/197195987-1e2058fb-1828-4620-9b16-d1ece7d62430.png)
