### PR TITLE
Use Game Id on Game Page for the wiki page

### DIFF
--- a/TASVideos/Pages/Games/Index.cshtml
+++ b/TASVideos/Pages/Games/Index.cshtml
@@ -2,7 +2,7 @@
 @model IndexModel
 @{
 	ViewData["Title"] = $"{Model.Game.DisplayName}";
-	string wiki = LinkConstants.GameWikiPage + Model.Id;
+	string wiki = LinkConstants.GameWikiPage + Model.Game.Id;
 	bool canEdit = WikiHelper.UserCanEditWikiPage(wiki, User.Name(), ViewData.UserPermissions());
 }
 


### PR DESCRIPTION
Resolves #1453 .
The Model.Id might be the game abbreviation, so we have to use Model.Game.Id