### PR TITLE
Make Topic Reply Notification Email template a bit more user friendly

### DIFF
--- a/TASVideos.Core/Services/Email/EmailService.cs
+++ b/TASVideos.Core/Services/Email/EmailService.cs
@@ -89,17 +89,28 @@ internal class EmailService : IEmailService
 		}
 
 		string subject = "Topic Reply Notification - " + template.TopicTitle;
-		string message = $@"Hello,
-
-<a href=""{template.BaseUrl}/Forum/Posts/{template.PostId}"">A new post</a> has been sent to the {siteName} forum topic <a href=""{template.BaseUrl}/Forum/Topics/{template.TopicId}"">{template.TopicTitle}</a> since your last visit.
-
-Notification emails for this topic will not be sent until you visit it.
+		string message = $@"<p>
+    Hello,<br>
+    <br>
+    The {siteName} forum topic ""{template.TopicTitle}"" has received a new post since your last visit.
+</p>
+<p>
+    <a href=""{template.BaseUrl}/Forum/Posts/{template.PostId}"">{template.BaseUrl}/Forum/Posts/{template.PostId}</a>
+</p>
+<p>
+    No more notification emails for this topic will be sent until you visit it.<br>
+    If the post was moved or deleted you can find the topic <a href=""{template.BaseUrl}/Forum/Topics/{template.TopicId}"">here</a>.
+</p>
 <hr />
-<p><a href=""{template.BaseUrl}/Forum/Topics/{template.TopicId}?handler=Unwatch"">Stop this topic from notifying you</a></p>
-<p>To stop all topic notification emails, follow <a href=""{template.BaseUrl}/Profile/WatchedTopics"">this link</a> and press ""Stop Watching All"".</p>
+<p>
+    To stop this particular topic from notifying you, visit <a href=""{template.BaseUrl}/Forum/Topics/{template.TopicId}?handler=Unwatch"">this link</a>.<br>
+    To stop all topic notification emails, visit <a href=""{template.BaseUrl}/Profile/WatchedTopics"">this link</a> and press ""Stop Watching All"".
+</p>
 <hr />
-Thanks,
-TASVideos staff";
+<p>
+    Thanks,<br>
+    TASVideos staff
+</p>";
 
 		await _emailSender.SendEmail(new StandardEmail
 		{


### PR DESCRIPTION
Includes better spacing and more intuitive format (most important link is the biggest one).
It also may fix gmail accidentally grouping different topic reply notifications together due to having the same email text. Now the link text is different, so that hopefully prevents ~~the grouping~~ Edit: see comment below.

I'm fine with suggestions for spelling or expressions. The main purpose of this PR is the change in link formatting and positioning.

<hr>

Before:
![image](https://user-images.githubusercontent.com/22375320/199006757-46c618f0-4c1d-4fe8-8ddc-3a2e84683923.png)

After:
![image](https://user-images.githubusercontent.com/22375320/199006774-4bfbf430-3a72-414a-b19d-f2d9260d254a.png)
