### PR TITLE
Fix bk2/fm2/dsm parsing when the input log file is >1GB large

### DIFF
--- a/TASVideos.Parsers/IMovieParser.cs
+++ b/TASVideos.Parsers/IMovieParser.cs
@@ -58,7 +58,7 @@ public sealed class MovieParser : IMovieParser
 		catch (Exception)
 		{
 			// TODO: do we want to log here? or catch at a higher layer?
-			return Error("An general error occured while processing the movie file.");
+			return Error("A general error occured while processing the movie file.");
 		}
 	}
 
@@ -76,7 +76,7 @@ public sealed class MovieParser : IMovieParser
 		catch (Exception)
 		{
 			// TODO: do we want to log here? or catch at a higher layer?
-			return Error("An general error occured while processing the movie file.");
+			return Error("A general error occured while processing the movie file.");
 		}
 	}
 

--- a/TASVideos.Parsers/Parsers/Bk2.cs
+++ b/TASVideos.Parsers/Parsers/Bk2.cs
@@ -15,6 +15,12 @@ internal class Bk2 : ParserBase, IParser
 	private const double NtscSnesFramerate = 60.0988138974405;
 	private const double PalSnesFramerate = 50.0069789081886;
 
+	// This could be implemented with (await reader.ReadToEndAsync()).LineSplit().PipeCount();
+	// However, this ends up reading the entire (uncompressed!) Input Log.txt file into a string
+	// If the Input Log.txt is >1GB big, it will end being "too big", as .NET disallows a single
+	// object being larger than 2GB (also, note .NET strings are UTF16 rather than UTF8)
+	// This method is used instead to figure out the frame count without loading the entire input log
+	// into memory. Might be faster too (although speed is probably not significant in most cases anyway)
 	private static int GetFrameCount(StreamReader reader)
 	{
 		var frames = 0;

--- a/TASVideos.Parsers/Parsers/Dsm.cs
+++ b/TASVideos.Parsers/Parsers/Dsm.cs
@@ -10,7 +10,6 @@ internal class Dsm : IParser
 
 	public async Task<IParseResult> Parse(Stream file, long length)
 	{
-		using var reader = new StreamReader(file);
 		var result = new ParseResult
 		{
 			Region = RegionType.Ntsc,
@@ -18,12 +17,7 @@ internal class Dsm : IParser
 			SystemCode = SystemCodes.Ds
 		};
 
-		var lines = (await reader.ReadToEndAsync()).LineSplit();
-		var header = lines
-			.WithoutPipes()
-			.ToArray();
-
-		result.Frames = lines.PipeCount();
+		(var header, result.Frames) = await file.PipeBasedMovieHeaderAndFrameCount();
 
 		int? rerecordVal = header.GetValueFor(Keys.RerecordCount).ToPositiveInt();
 		if (rerecordVal.HasValue)

--- a/TASVideos.Parsers/Parsers/Fm2.cs
+++ b/TASVideos.Parsers/Parsers/Fm2.cs
@@ -10,7 +10,6 @@ internal class Fm2 : IParser
 
 	public async Task<IParseResult> Parse(Stream file, long length)
 	{
-		using var reader = new StreamReader(file);
 		var result = new ParseResult
 		{
 			Region = RegionType.Ntsc,
@@ -18,10 +17,7 @@ internal class Fm2 : IParser
 			SystemCode = SystemCodes.Nes
 		};
 
-		var lines = (await reader.ReadToEndAsync()).LineSplit();
-		var header = lines
-			.WithoutPipes()
-			.ToArray();
+		(var header, result.Frames) = await file.PipeBasedMovieHeaderAndFrameCount();
 
 		if (header.GetValueFor(Keys.Fds).ToBool())
 		{
@@ -47,8 +43,6 @@ internal class Fm2 : IParser
 		{
 			result.StartType = MovieStartType.Savestate;
 		}
-
-		result.Frames = lines.PipeCount();
 
 		return result;
 	}


### PR DESCRIPTION
This is currently blocking me from submitting max score Desert Bus :)