### PR TITLE
Clean up RSS structure

### DIFF
--- a/TASVideos/Pages/RssFeeds/_RssPublication.cshtml
+++ b/TASVideos/Pages/RssFeeds/_RssPublication.cshtml
@@ -30,7 +30,7 @@
 		<media:community>
 			<media:starRating average="@Model.RatingAverage" count="@Model.RatingCount" min="@Model.RatingMin" max="@Model.RatingMax" />
 		</media:community>
-		<guid>@movieUrl</guid>
-		<pubDate>@Model.CreateTimestamp.ToString("u", CultureInfo.InvariantCulture)</pubDate>
 	</media:group>
+	<guid>@movieUrl</guid>
+	<pubDate>@Model.CreateTimestamp.ToString("u", CultureInfo.InvariantCulture)</pubDate>
 </item>


### PR DESCRIPTION
In the publications RSS feed, the `<guid>` and `<pubdate>` elements are currently members of the `<media:group>` element, but according to the RSS specification, they should be members of the `<item>` element directly. Contrast with [submissions.rss](https://github.com/TASVideos/tasvideos/blob/main/TASVideos/Pages/RssFeeds/_RssSubmission.cshtml), for example, which is structured correctly.

This PR just moves `<guid>` and `<pubdate>` out of `<media:group>` and directly inside `<item>`.

(It looks like these elements have always been out of place, but recently my feed reader of choice has started being more strict about how it determines whether an entry is new or not. Now it's treating every entry in publications.rss as if it was brand new every time, because it doesn't see the guid for them. This results in pages and pages of "new" duplicates!)

Here are some related references:

- [validation results for publications.rss](https://www.rssboard.org/rss-validator/check.cgi?url=https%3A%2F%2Ftasvideos.org%2FPublications.rss)
- [RSS specification](https://www.rssboard.org/rss-specification)
- [Media:group sub-specification](https://www.rssboard.org/media-rss)