### PR TITLE
Show official games first in search

### DIFF
--- a/TASVideos/Pages/Search/Index.cshtml.cs
+++ b/TASVideos/Pages/Search/Index.cshtml.cs
@@ -73,7 +73,7 @@ public class IndexModel : BasePageModel
 
 			GameResults = await _db.Games
 				.Where(g => EF.Functions.ToTsVector(g.DisplayName + " || " + g.Aliases + " || " + g.Abbreviation).Matches(EF.Functions.WebSearchToTsQuery(SearchTerms)))
-				.OrderBy(g => g.DisplayName)
+				.OrderBy(g => g.GameGenres.Select(gg => gg.GenreId).Contains(14)).ThenBy(g => g.DisplayName)
 				.Skip(skip)
 				.Take(PageSize + 1)
 				.Select(g => new GameSearchModel(

--- a/TASVideos/Pages/Search/Index.cshtml.cs
+++ b/TASVideos/Pages/Search/Index.cshtml.cs
@@ -73,7 +73,7 @@ public class IndexModel : BasePageModel
 
 			GameResults = await _db.Games
 				.Where(g => EF.Functions.ToTsVector(g.DisplayName + " || " + g.Aliases + " || " + g.Abbreviation).Matches(EF.Functions.WebSearchToTsQuery(SearchTerms)))
-				.OrderBy(g => g.GameGenres.Select(gg => gg.GenreId).Contains(14)).ThenBy(g => g.DisplayName)
+				.OrderBy(g => g.GameGenres.Select(gg => gg.Genre!.DisplayName).Contains("Unofficial game")).ThenBy(g => g.DisplayName)
 				.Skip(skip)
 				.Take(PageSize + 1)
 				.Select(g => new GameSearchModel(


### PR DESCRIPTION
Resolves #1260

Basically for example when we search "super mario bros" the actual game is not even visible in the first page as there a lot of ROM hacks that take priority alphabetically. So I am checking whether "Unofficial Game" is one of the genres of the game entry and if so they will be displayed at the end of the list.