### PR TITLE
Always sort Two Column Select alphabetically by the display text

### DIFF
--- a/TASVideos/TagHelpers/TwoColumnSelectTagHelper.cs
+++ b/TASVideos/TagHelpers/TwoColumnSelectTagHelper.cs
@@ -253,7 +253,7 @@ public class TwoColumnSelectTagHelper : TagHelper
 					let tmpAry = [];
 					let selectedValue = elem[elem.selectedIndex] != undefined ? elem[elem.selectedIndex] : null
 					for (let i = 0; i < elem.options.length;i++) tmpAry.push(elem.options[i]);
-					tmpAry.sort(function(a, b){{ return (parseInt(a.value) < parseInt(b.value)) ? -1 : 1; }});
+					tmpAry.sort(function(a, b){{ return (a.innerText < b.innerText) ? -1 : 1; }});
 					while (elem.options.length > 0) elem.options[0] = null;
 					for (let i = 0; i < tmpAry.length; i++) {{
 						elem.options[i] = tmpAry[i];
@@ -261,6 +261,8 @@ public class TwoColumnSelectTagHelper : TagHelper
 
 					return;
 				}}
+
+				sortLists();
 			}}
 			</script>";
 


### PR DESCRIPTION
Resolves #1496 .
This change always sorts two column select, and also sorts them alphabetically instead of by the value integer.

For the most control, ideally the javascript would keep the initial order, so we provide an arbitrary ordering. But I had like 10 minutes to implement a fix someone wanted. so I did this. Alphabetical ordering should always be fine anyway.