### PR TITLE
Reenable Production WebOptimizer Cache and TagHelper Bundling

### DIFF
--- a/TASVideos/appsettings.Production.json
+++ b/TASVideos/appsettings.Production.json
@@ -29,7 +29,7 @@
     ]
   },
   "webOptimizer": {
-    "enableCaching": false,
-    "enableTagHelperBundling": false
+    "enableCaching": true,
+    "enableTagHelperBundling": true
   }
 }


### PR DESCRIPTION
Refixing what was fixed in #427 but then broke in 2daac909845787d6b810e3bc558c23b4f5e26e1d , maybe because of copy-paste.

[Quoting](https://github.com/TASVideos/tasvideos/pull/427#issuecomment-919195214) @TiKevin83 
> EnableCaching defaults to true for stylesheets loaded through the weboptimizer taghelpers, so adding the definition to prod appsettings would be unnecessary

Technically it would be enough to remove it again, so they default to true. But since this situation was caused by the information not being there, I'm suggesting intentionally setting it to true, even if it's the default.

I'm not sure what the Staging appsetting should use. If it's like Production it should also be set to true. If not then it is fine as-is.