### PR TITLE
Support th in tables

### DIFF
--- a/TASVideos.ForumEngine/BbParser.cs
+++ b/TASVideos.ForumEngine/BbParser.cs
@@ -178,6 +178,7 @@ public class BbParser
 		{ "table", new() { SelfNesting = TagInfo.SelfNestingAllowed.No, IsBlock = true } },
 		{ "tr", new() { SelfNesting = TagInfo.SelfNestingAllowed.No, IsBlock = true, RequiredParent = "table" } },
 		{ "td", new() { SelfNesting = TagInfo.SelfNestingAllowed.No, IsBlock = true, RequiredParent = "tr" } },
+		{ "th", new() { SelfNesting = TagInfo.SelfNestingAllowed.No, IsBlock = true, RequiredParent = "tr" } },
 	};
 
 	private static readonly HashSet<string> KnownNonEmptyHtmlTags = new()

--- a/TASVideos.ForumEngine/Node.cs
+++ b/TASVideos.ForumEngine/Node.cs
@@ -179,6 +179,7 @@ public class Element : INode
 			case "table":
 			case "tr":
 			case "td":
+			case "th":
 				await WriteSimpleTag(w, h, Name);
 				break;
 			case "*":


### PR DESCRIPTION
Many other bbcode variants support this, and it's not difficult to add.  Closes #1516.

The same auto-self-closing behavior present in some of the other tags should work here, so this:
```
[table][tr][th]One[td]Two[td]Three[/table]
```
Should parse into this:
```
<table><tr><th>One</th><td>Two</td><td>Three</td></tr></table>
```