### PR TITLE
Escape username links for media publishers

### DIFF
--- a/TASVideos.Core/Extensions/WikiHelper.cs
+++ b/TASVideos.Core/Extensions/WikiHelper.cs
@@ -157,6 +157,21 @@ public static class WikiHelper
 			.First();
 	}
 
+	public static string EscapeUserName(string pageName)
+	{
+		if (!IsHomePage(pageName))
+		{
+			return pageName;
+		}
+		string[] splitPage = pageName.Trim('/').Split('/');
+		if (splitPage.Length >= 2)
+		{
+			splitPage[1] = Uri.EscapeDataString(splitPage[1]);
+		}
+
+		return string.Join('/', splitPage);
+	}
+
 	public static bool IsSystemPage(string? pageName)
 	{
 		return !string.IsNullOrWhiteSpace(pageName)

--- a/TASVideos/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/TASVideos/Pages/Account/ConfirmEmail.cshtml.cs
@@ -59,7 +59,7 @@ public class ConfirmEmailModel : BasePageModel
 		await _publisher.SendUserManagement(
 			$"User {user.UserName} activated",
 			"",
-			$"Users/Profile/{user.UserName}");
+			$"Users/Profile/{Uri.EscapeDataString(user.UserName)}");
 		await _userMaintenanceLogger.Log(user.Id, $"User activated from {IpAddress}");
 		await _tasVideoAgent.SendWelcomeMessage(user.Id);
 		return Page();

--- a/TASVideos/Pages/Account/Register.cshtml.cs
+++ b/TASVideos/Pages/Account/Register.cshtml.cs
@@ -134,7 +134,7 @@ public class RegisterModel : BasePageModel
 				await _publisher.SendUserManagement(
 					$"New User registered! {user.UserName}",
 					"",
-					$"Users/Profile/{user.UserName}");
+					$"Users/Profile/{Uri.EscapeDataString(user.UserName)}");
 				await _userMaintenanceLogger.Log(user.Id, $"New registration from {IpAddress}");
 				await _emailService.EmailConfirmation(Email, callbackUrl);
 

--- a/TASVideos/Pages/Users/Edit.cshtml.cs
+++ b/TASVideos/Pages/Users/Edit.cshtml.cs
@@ -126,7 +126,7 @@ public class EditModel : BasePageModel
 			await _publisher.SendUserManagement(
 				message,
 				"",
-				$"Users/Profile/{user.UserName}");
+				$"Users/Profile/{Uri.EscapeDataString(user.UserName!)}");
 			await _userMaintenanceLogger.Log(user.Id, message, User.GetUserId());
 			await _userManager.UserNameChanged(user, userNameChange);
 		}
@@ -167,7 +167,7 @@ public class EditModel : BasePageModel
 			await _publisher.SendUserManagement(
 				$"User {user.UserName} edited by {User.Name()}",
 				message,
-				$"Users/Profile/{user.UserName}");
+				$"Users/Profile/{Uri.EscapeDataString(user.UserName!)}");
 			await _userMaintenanceLogger.Log(user.Id, message, User.GetUserId());
 		}
 

--- a/TASVideos/Pages/Wiki/DeletedPages.cshtml.cs
+++ b/TASVideos/Pages/Wiki/DeletedPages.cshtml.cs
@@ -113,7 +113,7 @@ public class DeletedPagesModel : BasePageModel
 		await _publisher.SendGeneralWiki(
 				$"Page {path} UNDELETED by {User.Name()}",
 				"",
-				path);
+				WikiHelper.EscapeUserName(path));
 
 		return BaseRedirect("/" + path);
 	}

--- a/TASVideos/Pages/Wiki/Edit.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Edit.cshtml.cs
@@ -159,6 +159,6 @@ public class EditModel : BasePageModel
 		await _publisher.SendGeneralWiki(
 			$"Page {Path} {(page.Revision > 1 ? "edited" : "created")} by {User.Name()}",
 			$"{page.RevisionMessage}",
-			Path!);
+			WikiHelper.EscapeUserName(Path!));
 	}
 }

--- a/TASVideos/Pages/Wiki/Move.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Move.cshtml.cs
@@ -76,7 +76,7 @@ public class MoveModel : BasePageModel
 		await _publisher.SendGeneralWiki(
 			$"Page {Move.OriginalPageName} moved to {Move.DestinationPageName} by {User.Name()}",
 			"",
-			Move.DestinationPageName);
+			WikiHelper.EscapeUserName(Move.DestinationPageName));
 
 		return BaseRedirect("/" + Move.DestinationPageName);
 	}

--- a/tests/TASVideos.Test/Extensions/WikiHelperTests.cs
+++ b/tests/TASVideos.Test/Extensions/WikiHelperTests.cs
@@ -232,4 +232,20 @@ public class WikiHelperTests
 		var actual = WikiHelper.ProcessLink(pageName);
 		Assert.AreEqual(expected, actual);
 	}
+
+	[TestMethod]
+	[DataRow("", "")]
+	[DataRow(" ", " ")]
+	[DataRow("/", "/")]
+	[DataRow("/Test", "/Test")]
+	[DataRow("HomePages", "HomePages")]
+	[DataRow("HomePages/TestUser", "HomePages/TestUser")]
+	[DataRow("HomePages/User With Space", "HomePages/User%20With%20Space")]
+	[DataRow("HomePages/User With Space/AndMore", "HomePages/User%20With%20Space/AndMore")]
+	[DataRow("HomePages/[^_^]", "HomePages/%5B%5E_%5E%5D")]
+	public void EscapeUserName(string pageName, string expected)
+	{
+		var actual = WikiHelper.EscapeUserName(pageName);
+		Assert.AreEqual(expected, actual);
+	}
 }


### PR DESCRIPTION
Resolves #1523 .
Escapes usernames for media publisher links in the two places they're sent: Wiki HomePages, and User Profiles.

This technically also resolves #1462 , which was originally half-resolved by disallowing new accounts to register with spaces in their username.