### PR TITLE
Properly bust caches for darkmode stylesheet

### DIFF
--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -12,6 +12,7 @@
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous" />
 	<link rel="stylesheet" href="/css/site.css" />
 	<link rel="stylesheet" id="style-dark-initial" href="/css/darkmode-initial.css" />
+	<link rel="stylesheet" id="style-dark" href="/css/darkmode.css" disabled />
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
 		  integrity="sha512-SfTiTlX6kk+qitfevl/7LibUOeJWlt9rbyDn92a1DqWOw9vWG2MFoays0sgObmWazO5BQPiFucnnEAjpAB+/Sw=="
 		  crossorigin="anonymous"

--- a/TASVideos/wwwroot/js/site-head.js
+++ b/TASVideos/wwwroot/js/site-head.js
@@ -1,16 +1,8 @@
 ﻿function forceDarkMode() {
-	const darkModeStylesheet = document.getElementById("style-dark");
-	if (!darkModeStylesheet) {
-		removeAutoDarkMode();
+	removeAutoDarkMode();
+	document.getElementById("style-dark").disabled = false;
 
-		const newElement = document.createElement("link");
-		newElement.rel = "stylesheet";
-		newElement.id = "style-dark";
-		newElement.href = "/css/darkmode.css";
-		document.head.appendChild(newElement);
-
-		localStorage.setItem("style-dark", "true");
-	}
+	localStorage.setItem("style-dark", "true");
 }
 
 function forceLightMode() {
@@ -21,32 +13,18 @@ function forceLightMode() {
 }
 
 function autoDarkMode() {
-	const initialDarkModeStylesheet = document.getElementById("style-dark-initial");
-	if (!initialDarkModeStylesheet) {
-		removeForcedDarkMode();
+	removeForcedDarkMode();
+	document.getElementById("style-dark-initial").disabled = false;
 
-		const newElement = document.createElement("link");
-		newElement.rel = "stylesheet";
-		newElement.id = "style-dark-initial";
-		newElement.href = "/css/darkmode-initial.css";
-		document.head.appendChild(newElement);
-
-		localStorage.removeItem("style-dark");
-	}
+	localStorage.removeItem("style-dark");
 }
 
 function removeForcedDarkMode() {
-	const darkModeStylesheet = document.getElementById("style-dark");
-	if (darkModeStylesheet) {
-		darkModeStylesheet.parentElement.removeChild(darkModeStylesheet);
-	}
+	document.getElementById("style-dark").disabled = true;
 }
 
 function removeAutoDarkMode() {
-	const initialDarkModeStylesheet = document.getElementById("style-dark-initial");
-	if (initialDarkModeStylesheet) {
-		initialDarkModeStylesheet.parentElement.removeChild(initialDarkModeStylesheet);
-	}
+	document.getElementById("style-dark-initial").disabled = true;
 }
 
 if (localStorage.getItem("style-dark") !== null) {


### PR DESCRIPTION
Our WebOptimizer uses version string hashes on our included stylesheets, so that when they change, browsers *have* to reload them because the filename changed.
However, this seemed to not apply to our darkmode stylesheet:

![image](https://user-images.githubusercontent.com/22375320/229797765-f8d39046-9cf2-48b1-9af9-206191069a59.png)

The reason for this is because we never included the stylesheet in our `_Layout.cshtml`, and only added it dynamically based on user local storage and whether they choose darkmode. They were missing a version hash, and we would have to add more crazy code to compute it ourselves. And without the version hash, the browser would not reload styles when they changed.

This PR changes this behavior by including the stylesheet in the file, but *disabled*! That way, WebOptimizer is able to assign the hash, and we can dynamically enable and disable the stylesheets, instead of creating and removing html elements.