### PR TITLE
Add go-back links to 404 page (`/Wiki/PageDoesNotExist`)

### DIFF
--- a/TASVideos/Pages/Wiki/PageDoesNotExist.cshtml
+++ b/TASVideos/Pages/Wiki/PageDoesNotExist.cshtml
@@ -6,8 +6,10 @@
 	HttpContext.Response.StatusCode = 404;
 }
 <h2>The page you were looking for does not yet exist.</h2>
-<p>Click <a asp-page="/Search/Index" asp-route-searchTerms="@url">search</a> to check for alternative titles or spellings</p>
-Want to create it?
+<p>The page ( <a href="/@url">@($"{HttpContext.Request.ToBaseUrl()}/{url}")</a> ) does not exist. <a href="javascript:history.back()">Click here</a> to go back.</p>
+<p>You can also <a asp-page="/Search/Index" asp-route-searchTerms="@url">search</a> for alternative titles or spellings.</p>
+<hr />
+Want to create the page?
 <br />
 <ul>
 	@if (!User.IsLoggedIn())
@@ -36,4 +38,4 @@ Want to create it?
 </ul>
 
 <p>When creating new pages, always ensure that there is some other page that links to the newly created page. Otherwise your page will just become a <a href="/WikiOrphans">wiki orphan</a> that will be quickly forgotten.</p>
-<p><a asp-page="/Wiki/Referrers" asp-route-path="@url">Click here</a> to find referrers in this wiki, <a href="javascript:history.back()">here</a> to go back 2 steps to the referrer, or <a href="/@url">here</a> go back 1 step and get redirected again.</p>
+<p><a asp-page="/Wiki/Referrers" asp-route-path="@url">Click here</a> to see Referrers to this page.</p>

--- a/TASVideos/Pages/Wiki/PageDoesNotExist.cshtml
+++ b/TASVideos/Pages/Wiki/PageDoesNotExist.cshtml
@@ -5,7 +5,7 @@
 	bool canEdit = WikiHelper.UserCanEditWikiPage(url, User.Name(), User.Permissions());
 	HttpContext.Response.StatusCode = 404;
 }
-<h2>This page does not yet exist.</h2>
+<h2>The page you were looking for does not yet exist.</h2>
 <p>Click <a asp-page="/Search/Index" asp-route-searchTerms="@url">search</a> to check for alternative titles or spellings</p>
 Want to create it?
 <br />
@@ -36,4 +36,4 @@ Want to create it?
 </ul>
 
 <p>When creating new pages, always ensure that there is some other page that links to the newly created page. Otherwise your page will just become a <a href="/WikiOrphans">wiki orphan</a> that will be quickly forgotten.</p>
-<p>Click here to see <a asp-page="/Wiki/Referrers" asp-route-path="@url">Referrers</a></p>
+<p><a asp-page="/Wiki/Referrers" asp-route-path="@url">Click here</a> to find referrers in this wiki, <a href="javascript:history.back()">here</a> to go back 2 steps to the referrer, or <a href="/@url">here</a> go back 1 step and get redirected again.</p>


### PR DESCRIPTION
...and change wording.

The reason I'm adding a link to the "current" page is that you're not on that page, you've been redirected to `/Wiki/PageDoesNotExist`, and the address you intended to go to isn't in your browser history. This isn't a problem unless you manually typed in the address but made a typo, in which case it's a bit of a pain to get the correct address into the address bar.

Wording change is also to reflect that you've been redirected.