### PR TITLE
Fix parsing lsmv movies that contain branches

### DIFF
--- a/TASVideos.Parsers/Parsers/Lsmv.cs
+++ b/TASVideos.Parsers/Parsers/Lsmv.cs
@@ -129,7 +129,9 @@ internal class Lsmv : ParserBase, IParser
 			result.WarnNoRerecords();
 		}
 
-		var inputLog = archive.Entry(InputFile);
+		// guard against extra branch input files, which have a number in their name
+		var inputLog = archive.Entries.SingleOrDefault(
+			e => e.Name.ToLower().StartsWith(InputFile) && !e.Name.Any(char.IsDigit));
 		if (inputLog is null)
 		{
 			return Error($"Missing {InputFile}, can not parse");


### PR DESCRIPTION
Similar to the issue tasproj files had, the fix is [mostly a copy paste from there](https://github.com/TASVideos/tasvideos/blob/028424f991e3e5a43e8df310a4de46c722f4f4a0/TASVideos.Parsers/Parsers/Bk2.cs#L48-L50).

Fixes the "real file" for https://tasvideos.org/8214S being unable to be submitted.