### PR TITLE
Make sure doubles are converted to strings invariantly when necessary

### DIFF
--- a/TASVideos.ForumEngine/Node.cs
+++ b/TASVideos.ForumEngine/Node.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Globalization;
+using System.Text;
 using System.Web;
 using TASVideos.Common;
 
@@ -396,7 +397,7 @@ public class Element : INode
 				if (double.TryParse(sizeStr, out var sizeDouble))
 				{
 					// default font size of the old site was 12px, so if size was given without a unit, divide by 12 and use em
-					w.Attribute("style", $"font-size: {sizeDouble / 12}em");
+					w.Attribute("style", $"font-size: {(sizeDouble / 12).ToString(CultureInfo.InvariantCulture)}em");
 				}
 				else
 				{

--- a/TASVideos.ForumEngine/Node.cs
+++ b/TASVideos.ForumEngine/Node.cs
@@ -351,7 +351,7 @@ public class Element : INode
 					var fps = 60.0;
 					if (ss.Length > 1)
 					{
-						double.TryParse(ss[1], out fps);
+						double.TryParse(ss[1], NumberStyles.Float | NumberStyles.AllowThousands, NumberFormatInfo.InvariantInfo, out fps);
 					}
 
 					if (fps <= 0)
@@ -394,7 +394,7 @@ public class Element : INode
 
 				// TODO: More fully featured anti-style injection
 				var sizeStr = Options.Split(';')[0];
-				if (double.TryParse(sizeStr, out var sizeDouble))
+				if (double.TryParse(sizeStr, NumberStyles.Float | NumberStyles.AllowThousands, NumberFormatInfo.InvariantInfo, out var sizeDouble))
 				{
 					// default font size of the old site was 12px, so if size was given without a unit, divide by 12 and use em
 					w.Attribute("style", $"font-size: {(sizeDouble / 12).ToString(CultureInfo.InvariantCulture)}em");

--- a/TASVideos.Parsers/Parsers/Ltm.cs
+++ b/TASVideos.Parsers/Parsers/Ltm.cs
@@ -1,4 +1,5 @@
-﻿using SharpCompress.Readers;
+﻿using System.Globalization;
+using SharpCompress.Readers;
 using TASVideos.MovieParsers.Result;
 
 namespace TASVideos.MovieParsers.Parsers;
@@ -160,7 +161,7 @@ internal class Ltm : ParserBase, IParser
 		if (split.Length > 1)
 		{
 			var doubleStr = split.Skip(1).First();
-			var result = double.TryParse(doubleStr, out double val);
+			var result = double.TryParse(doubleStr, NumberStyles.Float | NumberStyles.AllowThousands, NumberFormatInfo.InvariantInfo, out double val);
 			if (result)
 			{
 				return val;

--- a/TASVideos/Pages/Publications/Catalog.cshtml.cs
+++ b/TASVideos/Pages/Publications/Catalog.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Globalization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using TASVideos.Core.Services.ExternalMediaPublisher;
@@ -126,7 +127,7 @@ public class CatalogModel : BasePageModel
 			}
 			else if (publication.SystemFrameRateId != Catalog.SystemFrameRateId)
 			{
-				externalMessages.Add($"Framerate changed from {publication.SystemFrameRate!.FrameRate} to {systemFramerate.FrameRate}");
+				externalMessages.Add($"Framerate changed from {publication.SystemFrameRate!.FrameRate.ToString(CultureInfo.InvariantCulture)} to {systemFramerate.FrameRate.ToString(CultureInfo.InvariantCulture)}");
 				publication.SystemFrameRateId = Catalog.SystemFrameRateId;
 				publication.SystemFrameRate = systemFramerate;
 			}

--- a/TASVideos/Pages/Submissions/Catalog.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Catalog.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Globalization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using TASVideos.Core.Services.ExternalMediaPublisher;
@@ -125,7 +126,7 @@ public class CatalogModel : BasePageModel
 			}
 			else
 			{
-				externalMessages.Add($"Framerate changed from {submission.SystemFrameRate?.FrameRate ?? 0.0} to {systemFramerate.FrameRate}");
+				externalMessages.Add($"Framerate changed from {(submission.SystemFrameRate?.FrameRate ?? 0.0).ToString(CultureInfo.InvariantCulture)} to {systemFramerate.FrameRate.ToString(CultureInfo.InvariantCulture)}");
 				submission.SystemFrameRateId = Catalog.SystemFrameRateId!.Value;
 				submission.SystemFrameRate = systemFramerate;
 			}

--- a/TASVideos/Pages/Systems/EditFramerate.cshtml.cs
+++ b/TASVideos/Pages/Systems/EditFramerate.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using TASVideos.Core.Services;
@@ -77,7 +78,7 @@ public class EditFramerateModel : BasePageModel
 		frameRate.Preliminary = FrameRate.Preliminary;
 		frameRate.Obsolete = FrameRate.Obsolete;
 
-		var displayName = $"{FrameRate.SystemCode} {FrameRate.RegionCode} {FrameRate.FrameRate}";
+		var displayName = $"{FrameRate.SystemCode} {FrameRate.RegionCode} {FrameRate.FrameRate.ToString(CultureInfo.InvariantCulture)}";
 		await ConcurrentSave(
 			_db,
 			$"FrameRate {displayName} updated.",


### PR DESCRIPTION
- Resolves #1515 .
- Also resolves a newly found bug where people with comma as decimal separators did not see forum post text size changes. `[size=7]Hello.[/size]` was shown as regular sized text.

<hr>

And now I want to ramble. So here we go:
I would like to point out that always using locale by default for conversions was a very wrong choice. The fact that `$"font-size: {fontsize};"` can go wrong is absurd. I've already had to deal with so many bugs that appeared just because all the devs are only on the US locale which is also the one where everything works. If I had the choice, I'd make a middleware at the very top, add `CultureInfo.CurrentCulture = CultureInfo.InvariantCulture` to remove any custom cultures, and have fixed every past and future bug. I'm not saying this is the fault of our code, I just dislike the choice of .NET to localize everything automatically and by default.

<hr>

Oh maybe someone is wondering how I made sure to catch every instance of this. Well I wrote my own full Roslyn Analyzer to catch every double to string conversion, both explicit and implicit, and then analyzed the whole code base.

How do we make sure these kinds of bugs don't appear in the future? We can't! Hurray localization.