### PR TITLE
Properly calculate Submission game name for lists

### DIFF
--- a/TASVideos/Extensions/EntityExtensions.cs
+++ b/TASVideos/Extensions/EntityExtensions.cs
@@ -169,7 +169,7 @@ public static class EntityExtensions
 			{
 				Id = s.Id,
 				System = s.System!.Code,
-				GameName = s.GameName,
+				GameName = s.GameVersion != null && !string.IsNullOrWhiteSpace(s.GameVersion.TitleOverride) ? s.GameVersion.TitleOverride : s.Game != null ? s.Game.DisplayName : s.GameName,
 				Frames = s.Frames,
 				FrameRate = s.SystemFrameRate!.FrameRate,
 				Branch = s.Branch,


### PR DESCRIPTION
Resolves #1546 .

Uses TitleOverride if applicable, then use catalogged game name, and finally use submitted game name.
Now works the same as Submission Title generation.