### PR TITLE
Add space between some attributes

### DIFF
--- a/TASVideos/Pages/Shared/_NavBarPartial.cshtml
+++ b/TASVideos/Pages/Shared/_NavBarPartial.cshtml
@@ -47,7 +47,7 @@
 		<a id="SandBox" class="dropdown-item" href="/SandBox">SandBox</a>
 		<a id="RecentChanges" class="dropdown-item" href="/RecentChanges">Recent Changes</a>
 		<a id="Orphans" class="dropdown-item" href="/WikiOrphans">Orphans</a>
-		<a id="Todo"class="dropdown-item" href="/TODO">To Do</a>
+		<a id="Todo" class="dropdown-item" href="/TODO">To Do</a>
 		<a id="SystemPages" class="dropdown-item" href="/System">System Pages</a>
 		<a id="DeletedPages" permission="SeeDeletedWikiPages" asp-page="/Wiki/DeletedPages" class="dropdown-item">Deleted Pages</a>
 	</nav-dropdown>


### PR DESCRIPTION
This is legal and parseable, but is atypical syntax use and Firefox complains about it on the source view.