### PR TITLE
Avatar preview

### DIFF
--- a/TASVideos/Pages/Profile/Models/ProfileSettingsModel.cs
+++ b/TASVideos/Pages/Profile/Models/ProfileSettingsModel.cs
@@ -26,6 +26,7 @@ public class ProfileSettingsModel
 	public string? Signature { get; set; }
 
 	[Url]
+	[Display(Name = "Avatar URL")]
 	public string? Avatar { get; set; }
 
 	[Url]

--- a/TASVideos/Pages/Profile/Settings.cshtml
+++ b/TASVideos/Pages/Profile/Settings.cshtml
@@ -96,12 +96,14 @@
 		<label asp-for="Settings.Avatar"></label>
 		<input type="text" asp-for="Settings.Avatar" class="form-control" />
 	</fullrow>
-	<fullrow class="mt-2" id="avatar-preview" show="!string.IsNullOrWhiteSpace(Model.Settings.Avatar)">
-		<label>Preview</label>
-		<button id="preview-btn" type="button" class="btn btn-secondary btn-sm">
-			<span class="fa fa-refresh"></span>
-		</button><br />
-		<img id="avatar-img" src="@Model.Settings.Avatar" class="float-start m-2" />
+	<fullrow class="mt-2" id="avatar-preview">
+		<div show="!string.IsNullOrWhiteSpace(Model.Settings.Avatar)" class="float-end">
+			<button id="preview-btn" type="button" class="btn btn-secondary btn-sm m-2">
+				<span class="fa fa-refresh"></span>
+			</button>
+			<label>Preview</label><br />
+			<img id="avatar-img" src="@Model.Settings.Avatar" class="m-2" />
+		</div>
 		<small>
 			@await Component.RenderWiki("System/AvatarRequirements")
 		</small>

--- a/TASVideos/Pages/Profile/Settings.cshtml
+++ b/TASVideos/Pages/Profile/Settings.cshtml
@@ -92,35 +92,31 @@
 		</column>
 	</row>
 	<hr />
-	<row>
-		<column md="6">
-			<label asp-for="Settings.Avatar"></label>
-			<input type="text" asp-for="Settings.Avatar" class="form-control" />
-		</column>
-		<column id="avatar-preview" md="6" class="mt-md-0 mt-3" show="!string.IsNullOrWhiteSpace(Model.Settings.Avatar)">
-			<label>Preview</label>
-			<button id="preview-btn" type="button" class="btn btn-secondary btn-sm">
-				<span class="fa fa-refresh"></span>
-			</button><br />
-			<img id="avatar-img" src="@Model.Settings.Avatar" class="float-start m-2" />
-			<small>
-				@await Component.RenderWiki("System/AvatarRequirements")
-			</small>
-		</column>
-	</row>
-	<row permission="UseMoodAvatars">
-		<column md="6">
-			<label asp-for="Settings.MoodAvatar"></label>
-			<input type="text" asp-for="Settings.MoodAvatar" class="form-control" />
-			<a asp-page="/Forum/MoodReport" asp-route-username="@Model.Settings.Username">Check Mood Avatars</a>
-		</column>
-		<column md="6">
-			<small>
-				@await Component.RenderWiki("System/MoodAvatarRequirements")
-			</small>
-		</column>
-	</row>
 	<fullrow class="mt-3">
+		<label asp-for="Settings.Avatar"></label>
+		<input type="text" asp-for="Settings.Avatar" class="form-control" />
+	</fullrow>
+	<fullrow class="mt-2" id="avatar-preview" show="!string.IsNullOrWhiteSpace(Model.Settings.Avatar)">
+		<label>Preview</label>
+		<button id="preview-btn" type="button" class="btn btn-secondary btn-sm">
+			<span class="fa fa-refresh"></span>
+		</button><br />
+		<img id="avatar-img" src="@Model.Settings.Avatar" class="float-start m-2" />
+		<small>
+			@await Component.RenderWiki("System/AvatarRequirements")
+		</small>
+	</fullrow>
+	<fullrow permission="UseMoodAvatars">
+		<label asp-for="Settings.MoodAvatar"></label>
+		<input type="text" asp-for="Settings.MoodAvatar" class="form-control" />
+		<a asp-page="/Forum/MoodReport" asp-route-username="@Model.Settings.Username">Check Mood Avatars</a>
+	</fullrow>
+	<fullrow permission="UseMoodAvatars" class="mt-3">
+		<small>
+			@await Component.RenderWiki("System/MoodAvatarRequirements")
+		</small>
+	</fullrow>
+	<fullrow permission="EditSignature" class="mt-3">
 		<label asp-for="Settings.Signature"></label>
 		<textarea asp-for="Settings.Signature" class="form-control" rows="5" disabled="@(!User.Has(PermissionTo.EditSignature))"></textarea>
 	</fullrow>

--- a/TASVideos/Pages/Profile/Settings.cshtml
+++ b/TASVideos/Pages/Profile/Settings.cshtml
@@ -118,7 +118,7 @@
 	</fullrow>
 	<fullrow permission="EditSignature" class="mt-3">
 		<label asp-for="Settings.Signature"></label>
-		<textarea asp-for="Settings.Signature" class="form-control" rows="5" disabled="@(!User.Has(PermissionTo.EditSignature))"></textarea>
+		<textarea asp-for="Settings.Signature" class="form-control" rows="5"></textarea>
 	</fullrow>
 	<hr />
 	<div class="text-center">

--- a/TASVideos/Pages/Profile/Settings.cshtml
+++ b/TASVideos/Pages/Profile/Settings.cshtml
@@ -118,7 +118,7 @@
 	</fullrow>
 	<fullrow permission="EditSignature" class="mt-3">
 		<label asp-for="Settings.Signature"></label>
-		<textarea asp-for="Settings.Signature" class="form-control" rows="5"></textarea>
+		<textarea asp-for="Settings.Signature" class="form-control" rows="5" disabled="@(!User.Has(PermissionTo.EditSignature))"></textarea>
 	</fullrow>
 	<hr />
 	<div class="text-center">


### PR DESCRIPTION
turn avatar URLs and requirements into fullrows:
avatar URLs are wide fields, and requirement text is editable wiki text of uncapped height, so they look weird if put side by side

hide signature for users without the permission instead of disabling it

use consistent label for normal avatar url

before

![1](https://user-images.githubusercontent.com/7092625/235429338-ab02a19d-9e78-4764-9a5b-eee14b7ed8b0.png)

![изображение](https://user-images.githubusercontent.com/7092625/235454127-ae16ed85-e036-4d99-88fc-62116c7482c6.png)

after

![2](https://user-images.githubusercontent.com/7092625/235453447-2db8b230-6342-4f6e-8f7e-d67ddaa31544.png)

![изображение](https://user-images.githubusercontent.com/7092625/235454163-994330f1-32eb-42e9-aa80-fda4b0d9b7fd.png)
