### PR TITLE
added space between class icon and pub title for MovieModule and MovieChangeLog

### DIFF
--- a/TASVideos/Pages/Shared/Components/MovieChangeLog/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/MovieChangeLog/Default.cshtml
@@ -17,8 +17,8 @@
 	<fullrow>
 		@foreach (var pub in pubGroup.Pubs)
 		{
-			<div class="ms-2">
-				<div class="float-start" condition="!string.IsNullOrWhiteSpace(pub.ClassIconPath)">
+			<div class="ms-2 mt-1">
+				<div class="float-start me-2" condition="!string.IsNullOrWhiteSpace(pub.ClassIconPath)">
 					<icon path="@pub.ClassIconPath" />
 				</div>
 				<pub-link id="pub.Id">@pub.Name</pub-link>

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -41,7 +41,7 @@
 <card class="border border-primary">
 	<cardheader class="bg-cardprimary p-2">
 		<div class="gx-3 clearfix">
-			<div class="float-start" condition="!string.IsNullOrWhiteSpace(Model.ClassIconPath)">
+			<div class="float-start me-2" condition="!string.IsNullOrWhiteSpace(Model.ClassIconPath)">
 				<icon path="@Model.ClassIconPath" />
 			</div>
 			<div class="float-end">


### PR DESCRIPTION
Also increased line gap so class icon doesn't shift the next line to the right

before

![1](https://github.com/TASVideos/tasvideos/assets/7092625/6ba450c0-c9cd-4f57-afd0-3af549ca6512)

after

![2](https://github.com/TASVideos/tasvideos/assets/7092625/da0422a4-4f73-456c-a39b-0b0b3d7d5547)