### PR TITLE
Fix: Users with email not confirmed can't request a resend

### DIFF
--- a/TASVideos.Core/Services/SignInManager.cs
+++ b/TASVideos.Core/Services/SignInManager.cs
@@ -109,4 +109,14 @@ public class SignInManager : SignInManager<User>
 		var baseEmail = email.Split('+')[0]; // Strip off alias
 		return await _db.Users.AnyAsync(u => EF.Functions.Like(u.Email, baseEmail));
 	}
+
+	public async Task<bool> EmailAndUserNameMatch(string username, string email)
+	{
+		if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(username))
+		{
+			return false;
+		}
+
+		return await _db.Users.AnyAsync(u => u.Email == email && u.UserName == username);
+	}
 }

--- a/TASVideos/Pages/Account/EmailConfirmationSent.cshtml
+++ b/TASVideos/Pages/Account/EmailConfirmationSent.cshtml
@@ -1,6 +1,35 @@
 ﻿@page
+@addTagHelper *, AspNetCore.ReCaptcha
+@model EmailConfirmationSentModel
 @{
 	ViewData.SetTitle("Email Sent");
 }
 
 <p>To complete the registration process look for an email in your inbox that will provide further instructions.</p>
+
+<p>In case you didn't receive any email, please enter your username and email below and we will resend it to you.</p>
+
+<form method="post">
+	<row>
+		<column md="6">
+			<form-group>
+				<label asp-for="UserName"></label>
+				<input asp-for="UserName" class="form-control" autocomplete="username" />
+				<span asp-validation-for="UserName" class="text-danger"></span>
+			</form-group>
+			<form-group>
+				<label asp-for="Email"></label>
+				<input asp-for="Email" class="form-control" autocomplete="off" />
+				<span asp-validation-for="Email" class="text-danger"></span>
+			</form-group>
+			<environment exclude="Development">
+				<form-group>
+					<recaptcha />
+				</form-group>
+			</environment>
+		</column>
+	</row>
+	<div class="text-center">
+		<button type="submit" class="btn btn-secondary">Resend Confirmation Email</button>
+	</div>
+</form>

--- a/TASVideos/Pages/Account/EmailConfirmationSent.cshtml
+++ b/TASVideos/Pages/Account/EmailConfirmationSent.cshtml
@@ -5,9 +5,7 @@
 	ViewData.SetTitle("Email Sent");
 }
 
-<p>To complete the registration process look for an email in your inbox that will provide further instructions.</p>
-
-<p>In case you didn't receive any email, please enter your username and email below and we will resend it to you.</p>
+@await Component.RenderWiki("System/EmailConfirmationSentMessage")
 
 <form method="post">
 	<row>

--- a/TASVideos/Pages/Account/EmailConfirmationSent.cshtml.cs
+++ b/TASVideos/Pages/Account/EmailConfirmationSent.cshtml.cs
@@ -1,0 +1,69 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TASVideos.Core.Services;
+using TASVideos.Core.Services.Email;
+using TASVideos.Data;
+
+namespace TASVideos.Pages.Account;
+
+[AllowAnonymous]
+[IpBanCheck]
+public class EmailConfirmationSentModel : BasePageModel
+{
+	private readonly SignInManager _signInManager;
+	private readonly ApplicationDbContext _db;
+	private readonly IEmailService _emailService;
+
+	public EmailConfirmationSentModel(
+		SignInManager signInManager,
+		ApplicationDbContext db,
+		IEmailService emailService)
+	{
+		_signInManager = signInManager;
+		_db = db;
+		_emailService = emailService;
+	}
+
+	[BindProperty]
+	[Required]
+	[StringLength(256)]
+	[Display(Name = "User Name")]
+	public string UserName { get; set; } = "";
+
+	[BindProperty]
+	[Required]
+	[EmailAddress]
+	[Display(Name = "Email")]
+	public string Email { get; set; } = "";
+	public async Task<IActionResult> OnPost()
+	{
+		if (!await _signInManager.EmailAndUserNameMatch(UserName, Email))
+		{
+			ModelState.AddModelError(nameof(Email), "Username and email entered do not match. Please try again.");
+		}
+
+		if (!ModelState.IsValid)
+		{
+			return Page();
+		}
+
+		if (ModelState.IsValid)
+		{
+			var user = _db.Users.Where(u => u.Email == Email && u.UserName == UserName).FirstOrDefault();
+			if (user != null)
+			{
+				var token = await _signInManager.UserManager.GenerateEmailConfirmationTokenAsync(user);
+				var callbackUrl = Url.EmailConfirmationLink(user.Id.ToString(), token, Request.Scheme);
+
+				await _emailService.EmailConfirmation(Email, callbackUrl);
+
+				return _signInManager.UserManager.Options.SignIn.RequireConfirmedEmail
+					? RedirectToPage("EmailConfirmationSent")
+					: BaseReturnUrlRedirect();
+			}
+		}
+
+		return Page();
+	}
+}

--- a/TASVideos/Pages/Account/Login.cshtml.cs
+++ b/TASVideos/Pages/Account/Login.cshtml.cs
@@ -15,15 +15,18 @@ public class LoginModel : BasePageModel
 	private readonly SignInManager _signInManager;
 	private readonly UserManager _userManager;
 	private readonly ApplicationDbContext _db;
+	private readonly IHostEnvironment _env;
 
 	public LoginModel(
 		SignInManager signInManager,
 		UserManager userManager,
-		ApplicationDbContext db)
+		ApplicationDbContext db,
+		IHostEnvironment env)
 	{
 		_signInManager = signInManager;
 		_userManager = userManager;
 		_db = db;
+		_env = env;
 	}
 
 	[BindProperty]
@@ -68,7 +71,7 @@ public class LoginModel : BasePageModel
 		}
 
 		var user = await _db.Users.SingleOrDefaultAsync(u => u.UserName == UserName);
-		if (user != null && !await _userManager.IsEmailConfirmedAsync(user))
+		if (user is not null && !await _userManager.IsEmailConfirmedAsync(user) && !_env.IsDevelopment())
 		{
 			return RedirectToPage("/Account/EmailConfirmationSent");
 		}


### PR DESCRIPTION
If a new user is registering and due to site errors is not able to receive the confirmation email but was still registered in the database, then they are not able to login, even if an admin gives login permissions, since only users with email confirmed can login. Additionally, if the user is registering and then closes the browser, they wouldn't be able to access the EmailConfirmationSent page either. For this reason, an update was made so that if users do not have their email confirmed but they exist in the database, then they will be redirected to the EmailConfirmationSent page, so that they can request a resend, only if the username and email entered match.