### PR TITLE
Forum editor: syntax highlighting POC

### DIFF
--- a/TASVideos/Pages/Forum/Posts/Create.cshtml
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml
@@ -41,7 +41,7 @@
 		<partial name="_CreatePostHelper" model="@("Post_Text")" />
 	</fullrow>
 	<form-group>
-		<textarea asp-for="Post.Text" class="form-control backup-content" rows="20" data-backup-key="backup-post-@Model.TopicId"></textarea>
+		<textarea asp-for="Post.Text" class="form-control backup-content" rows="20" data-backup-key="backup-post-@Model.TopicId" data-tempfixme></textarea>
 		<span asp-validation-for="Post.Text" class="text-danger"></span>
 	</form-group>
 	<fullrow id="backup-restore" class="d-none">
@@ -64,4 +64,5 @@
 @section Scripts {
 	<partial name="_ValidationScriptsPartial" />
 	<script src="~/js/backup-text.js"></script>
+	<script src="~/js/syntax-highlight-forum.js" type="module"></script>
 }

--- a/TASVideos/wwwroot/js/syntax-highlight-forum.js
+++ b/TASVideos/wwwroot/js/syntax-highlight-forum.js
@@ -1,0 +1,55 @@
+function highlight(text) {
+	const r = /\[\/?[a-z*]+\]/g;
+	const results = [];
+	let from = 0;
+	let match;
+	while (match = r.exec(text)) {
+		if (from < match.index) {
+			results.push(text.slice(from, match.index));
+		}
+		const span = document.createElement("span");
+		span.style.color = "blue";
+		span.textContent = match[0];
+		results.push(span);
+		from = match.index + match[0].length;
+	}
+	results.push(text.slice(from));
+	return results;
+}
+
+
+(() => {
+	const textarea = document.querySelector("textarea[data-tempfixme]");
+	if (!textarea) {
+		return;
+	}
+	textarea.style.color = "white"; // Light mode only
+	const parent = textarea.parentElement;
+	parent.style.position = "relative";
+
+	const { paddingLeft, paddingRight, paddingTop, paddingBottom, } = getComputedStyle(textarea)
+
+	const overlay = document.createElement("div");
+	Object.assign(overlay.style, {
+		position: "absolute",
+		inset: 0,
+		pointerEvents: "none",
+		paddingLeft,
+		paddingRight,
+		paddingTop,
+		paddingBottom,
+		border: "1px solid #0000",
+		whiteSpace: "pre-wrap",
+		overflowY: "auto",
+	});
+
+	parent.appendChild(overlay);
+
+	textarea.addEventListener("input", () => {
+		overlay.textContent = "";
+		overlay.append(...highlight(textarea.value));
+	}, { passive: true });
+	textarea.addEventListener("scroll", () => {
+		overlay.scrollTop = textarea.scrollTop;
+	}, { passive: true });
+})();


### PR DESCRIPTION
As far as I know, this is the main "trick" used to do things like this.  If you're not willing to go all the way to contenteditable hell, you just hide the `<textarea>` and then put something that exactly mirrors its content.  I'm not convinced we should do this; it's hard to make it work out just right in every browser, and there may be accessibility concerns.

If we do decide to implement this, a more detailed syntax highlighting model is easily added.


Closes #1574.