### PR TITLE
Redirect module

### DIFF
--- a/TASVideos.WikiEngine/WikiModules.cs
+++ b/TASVideos.WikiEngine/WikiModules.cs
@@ -37,6 +37,7 @@ public static class WikiModules
 	public const string PlayerPointsTable = "playerpointstable";
 	public const string PublicationHistory = "publicationhistory";
 	public const string PublicationPoints = "publicationpoints";
+	public const string Redirect = "redirect";
 	public const string Screenshots = "screenshots";
 	public const string SupportedMovieTypes = "supportedmovietypes";
 	public const string TabularMovieList = "tabularmovielist";

--- a/TASVideos/ViewComponents/Redirect.cs
+++ b/TASVideos/ViewComponents/Redirect.cs
@@ -10,7 +10,16 @@ public class Redirect : ViewComponent
 	{
 		HttpContext context = ViewContext.HttpContext;
 
-		context.Response.Redirect("/" + page);
+		string redirectValue = context.Request.Query["redirect"];
+
+		if (redirectValue == "no")
+		{
+			return Content("Redirects to: " + page);
+		}
+		else
+		{
+			context.Response.Redirect("/" + page + "?redirect=no");
+		}
 
 		return Content("");
 	}

--- a/TASVideos/ViewComponents/Redirect.cs
+++ b/TASVideos/ViewComponents/Redirect.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Mvc;
+using TASVideos.WikiEngine;
+
+namespace TASVideos.ViewComponents;
+
+[WikiModule(WikiModules.Redirect)]
+public class Redirect : ViewComponent
+{
+	public IViewComponentResult Invoke(string page)
+	{
+		HttpContext context = ViewContext.HttpContext;
+
+		context.Response.Redirect(page);
+
+		return Content("");
+	}
+}

--- a/TASVideos/ViewComponents/Redirect.cs
+++ b/TASVideos/ViewComponents/Redirect.cs
@@ -10,7 +10,7 @@ public class Redirect : ViewComponent
 	{
 		HttpContext context = ViewContext.HttpContext;
 
-		context.Response.Redirect(page);
+		context.Response.Redirect("/" + page);
 
 		return Content("");
 	}


### PR DESCRIPTION
#268 

Technically it works but it's garbage. I couldn't even figure out how to get the base URL and redirect to the specified path rather than a whole website. That's the only change that would be necessary to be merged (because it'll change how the module is used), but the whole thing should be redone.

Current usage: `[module:redirect|page=https://tasvideos.org/SandBox]`
Desired usage: `[module:redirect|page=SandBox]`