### PR TITLE
send discord updates to different channels

### DIFF
--- a/TASVideos.Core/Services/ExternalMediaPublisher/Distributors/DiscordDistributor.cs
+++ b/TASVideos.Core/Services/ExternalMediaPublisher/Distributors/DiscordDistributor.cs
@@ -34,9 +34,36 @@ public sealed class DiscordDistributor : IPostDistributor
 
 		var messageContent = new DiscordMessage(post).ToStringContent();
 
-		string channel = post.Type == PostType.Administrative
-			? _settings.PrivateChannelId
-			: _settings.PublicChannelId;
+		string channel;
+
+		if (post.Type == PostType.Administrative)
+		{
+			if (post.Group == PostGroups.UserManagement)
+			{
+				channel = _settings.PrivateUserChannelId;
+			}
+			else
+			{
+				channel = _settings.PrivateChannelId;
+			}
+		}
+		else
+		{
+			if (post.Group == PostGroups.Game)
+			{
+				channel = _settings.PublicGameChannelId;
+			}
+			else if (post.Group == PostGroups.Publication
+				|| post.Group == PostGroups.Submission
+				|| post.Group == PostGroups.UserFiles)
+			{
+				channel = _settings.PublicTasChannelId;
+			}
+			else
+			{
+				channel = _settings.PublicChannelId;
+			}
+		}
 
 		var response = await _client.PostAsync($"channels/{channel}/messages", messageContent);
 		if (!response.IsSuccessStatusCode)

--- a/TASVideos.Core/Settings/AppSettings.cs
+++ b/TASVideos.Core/Settings/AppSettings.cs
@@ -48,14 +48,20 @@ public class AppSettings
 	{
 		public string AccessToken { get; set; } = "";
 		public string PublicChannelId { get; set; } = "";
+		public string PublicTasChannelId { get; set; } = "";
+		public string PublicGameChannelId { get; set; } = "";
 		public string PrivateChannelId { get; set; } = "";
+		public string PrivateUserChannelId { get; set; } = "";
 
 		public bool IsEnabled() => Disable != true
 			&& !string.IsNullOrWhiteSpace(AccessToken)
-			&& !string.IsNullOrWhiteSpace(PublicChannelId);
+			&& !string.IsNullOrWhiteSpace(PublicChannelId)
+			&& !string.IsNullOrWhiteSpace(PublicTasChannelId)
+			&& !string.IsNullOrWhiteSpace(PublicGameChannelId);
 
 		public bool IsPrivateChannelEnabled() => IsEnabled()
-			&& !string.IsNullOrWhiteSpace(PrivateChannelId);
+			&& !string.IsNullOrWhiteSpace(PrivateChannelId)
+			&& !string.IsNullOrWhiteSpace(PrivateUserChannelId);
 	}
 
 	public class TwitterConnection : DistributorConnection

--- a/TASVideos/Pages/Publications/Catalog.cshtml.cs
+++ b/TASVideos/Pages/Publications/Catalog.cshtml.cs
@@ -173,7 +173,7 @@ public class CatalogModel : BasePageModel
 		var result = await ConcurrentSave(_db, $"{Id}M catalog updated", $"Unable to save {Id}M catalog");
 		if (result && !Catalog.MinorEdit)
 		{
-			await _publisher.SendPublicationEdit(
+			await _publisher.SendGameManagement(
 				$"{Id}M Catalog edited by {User.Name()}",
 				$"{string.Join(", ", externalMessages)} | {publication.Title}",
 				$"{Id}M");

--- a/TASVideos/Pages/Submissions/Catalog.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Catalog.cshtml.cs
@@ -190,7 +190,7 @@ public class CatalogModel : BasePageModel
 		var result = await ConcurrentSave(_db, $"{Id}S catalog updated", $"Unable to save {Id}S catalog");
 		if (result && !Catalog.MinorEdit)
 		{
-			await _publisher.SendSubmissionEdit(
+			await _publisher.SendGameManagement(
 				$"{Id}S Catalog edited by {User.Name()}",
 				$"{string.Join(", ", externalMessages)} | {submission.Title}",
 				$"{Id}S");


### PR DESCRIPTION
* public
  * updates - forum/wiki
  * tas-updates - pubs/subs/userfiles
  * game-updates - game updates
* hidden
  * hidden-updates - staff forum, hidden userfiles
  * user-updates - user updates

fixes #731
fixes #1267

One thing we need to discuss is whether we want all catalog updates to be considered `PostGroups.Game`. I think it makes sense to do it since cataloging doesn't **change** movies per se, but it does assign game info which is usually created right before that and just for that. And cataloging is something we need to encourage, so there's gonna be a lot of it, and it would spam the movies channel making it harder to find **changes** to movies. Minor edit could be used for cataloging but then it becomes harder to track.