### PR TITLE
Change TopicFeed module poster links

### DIFF
--- a/TASVideos/Pages/Shared/Components/TopicFeed/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/TopicFeed/Default.cshtml
@@ -14,7 +14,7 @@
 				<h5 condition="Model.HideContent"><a class="collapsed" data-bs-toggle="collapse" href="/Forum/Posts/@(post.Id)" data-bs-target="#@collapseId" role="button" aria-expanded="false"><i class="fa fa-chevron-circle-down"></i> @post.Subject</a></h5>
 				<h6 class="card-subtitle mb-2 text-muted">
 					<small>
-						posted by <a href="/@post.PosterName">@post.PosterName</a> <timezone-convert asp-for="@post.CreateTimestamp" in-line="true" />
+						posted by <profile-link username="@post.PosterName"></profile-link> <timezone-convert asp-for="@post.CreateTimestamp" in-line="true" />
 					</small>
 				</h6>
 				<div condition="Model.HideContent" class="collapse card-text" id="collapse-content-@post.Id">


### PR DESCRIPTION
Previously would link to e.g. https://tasvideos.org/feos, now it properly goes to https://tasvideos.org/Users/Profile/feos. Used on the front page news feed.