### PR TITLE
subs/pubs: clarify Authors labels

### DIFF
--- a/TASVideos/Pages/Publications/Models/PublicationEditModel.cs
+++ b/TASVideos/Pages/Publications/Models/PublicationEditModel.cs
@@ -12,7 +12,7 @@ public class PublicationEditModel
 
 	public string MovieFileName { get; set; } = "";
 
-	[Display(Name = "External Coauthors", Description = "Only authors not registered for TASVideos should be listed here. If multiple authors, separate the names with a comma.")]
+	[Display(Name = "External Coauthor(s)", Description = "Only authors not registered for TASVideos should be listed here. If multiple authors, separate the names with a comma.")]
 	public string? AdditionalAuthors { get; set; }
 
 	[Display(Name = "Author(s)")]

--- a/TASVideos/Pages/Publications/Models/PublicationEditModel.cs
+++ b/TASVideos/Pages/Publications/Models/PublicationEditModel.cs
@@ -12,10 +12,10 @@ public class PublicationEditModel
 
 	public string MovieFileName { get; set; } = "";
 
-	[Display(Name = "Additional Authors", Description = "Only authors not registered for TASVideos should be listed here. If multiple authors, separate the names with a comma.")]
+	[Display(Name = "External Coauthors", Description = "Only authors not registered for TASVideos should be listed here. If multiple authors, separate the names with a comma.")]
 	public string? AdditionalAuthors { get; set; }
 
-	[Display(Name = "Author")]
+	[Display(Name = "Author(s)")]
 	public IEnumerable<string> Authors { get; set; } = new List<string>();
 
 	[Display(Name = "Publication Class")]

--- a/TASVideos/Pages/Submissions/Models/SubmissionCreateModel.cs
+++ b/TASVideos/Pages/Submissions/Models/SubmissionCreateModel.cs
@@ -37,7 +37,7 @@ public class SubmissionCreateModel
 	[MinLength(1)]
 	public IList<string> Authors { get; set; } = new List<string>();
 
-	[Display(Name = "Additional Authors", Description = "Only authors not registered for TASVideos should be listed here. If multiple authors, separate the names with a comma.")]
+	[Display(Name = "External Coauthors", Description = "Only authors not registered for TASVideos should be listed here. If multiple authors, separate the names with a comma.")]
 	public string? AdditionalAuthors { get; set; }
 
 	[Required]

--- a/TASVideos/Pages/Submissions/Models/SubmissionCreateModel.cs
+++ b/TASVideos/Pages/Submissions/Models/SubmissionCreateModel.cs
@@ -37,7 +37,7 @@ public class SubmissionCreateModel
 	[MinLength(1)]
 	public IList<string> Authors { get; set; } = new List<string>();
 
-	[Display(Name = "External Coauthors", Description = "Only authors not registered for TASVideos should be listed here. If multiple authors, separate the names with a comma.")]
+	[Display(Name = "External Coauthor(s)", Description = "Only authors not registered for TASVideos should be listed here. If multiple authors, separate the names with a comma.")]
 	public string? AdditionalAuthors { get; set; }
 
 	[Required]

--- a/TASVideos/Pages/Submissions/Models/SubmissionEditModel.cs
+++ b/TASVideos/Pages/Submissions/Models/SubmissionEditModel.cs
@@ -63,7 +63,7 @@ public class SubmissionEditModel
 
 	public int RerecordCount { get; set; }
 
-	[Display(Name = "Author")]
+	[Display(Name = "Author(s)")]
 	public IEnumerable<string> Authors { get; set; } = new List<string>();
 
 	[Display(Name = "Submitter")]
@@ -87,7 +87,7 @@ public class SubmissionEditModel
 	[Display(Name = "Publisher")]
 	public string? Publisher { get; set; }
 
-	[Display(Name = "Additional Authors", Description = "Only authors not registered for TASVideos should be listed here. If multiple authors, separate the names with a comma.")]
+	[Display(Name = "External Coauthors", Description = "Only authors not registered for TASVideos should be listed here. If multiple authors, separate the names with a comma.")]
 	public string? AdditionalAuthors { get; set; }
 
 	public string Title { get; set; } = "";

--- a/TASVideos/Pages/Submissions/Models/SubmissionEditModel.cs
+++ b/TASVideos/Pages/Submissions/Models/SubmissionEditModel.cs
@@ -87,7 +87,7 @@ public class SubmissionEditModel
 	[Display(Name = "Publisher")]
 	public string? Publisher { get; set; }
 
-	[Display(Name = "External Coauthors", Description = "Only authors not registered for TASVideos should be listed here. If multiple authors, separate the names with a comma.")]
+	[Display(Name = "External Coauthor(s)", Description = "Only authors not registered for TASVideos should be listed here. If multiple authors, separate the names with a comma.")]
 	public string? AdditionalAuthors { get; set; }
 
 	public string Title { get; set; } = "";


### PR DESCRIPTION
Just text-changes.

(There is a separate issue of similar text and schemas being in three separate places).