### PR TITLE
Fix wording in API summaries

### DIFF
--- a/TASVideos.Api/Controllers/ClassesController.cs
+++ b/TASVideos.Api/Controllers/ClassesController.cs
@@ -47,7 +47,7 @@ public class ClassesController : Controller
 	}
 
 	/// <summary>
-	/// Creates a new publication class
+	/// Creates a new publication class.
 	/// </summary>
 	/// <response code="201">The publication class was created successfully.</response>
 	/// <response code="400">The request parameters are invalid.</response>
@@ -77,7 +77,7 @@ public class ClassesController : Controller
 	}
 
 	/// <summary>
-	/// Updates an existing publication class
+	/// Updates an existing publication class.
 	/// </summary>
 	/// <response code="200">The class was updated.</response>
 	/// <response code="400">The request parameters are invalid.</response>
@@ -109,7 +109,7 @@ public class ClassesController : Controller
 	}
 
 	/// <summary>
-	/// Deletes an existing publication publication class
+	/// Deletes an existing publication class.
 	/// </summary>
 	/// <response code="200">The class was deleted successfully.</response>
 	/// <response code="400">The request parameters are invalid.</response>

--- a/TASVideos.Api/Controllers/SubmissionsController.cs
+++ b/TASVideos.Api/Controllers/SubmissionsController.cs
@@ -20,7 +20,7 @@ public class SubmissionsController : Controller
 	/// <summary>
 	/// Returns a submission with the given id.
 	/// </summary>
-	/// <response code="200">Returns the list of publications.</response>
+	/// <response code="200">Returns the list of submissions.</response>
 	/// <response code="400">The request parameters are invalid.</response>
 	/// <response code="404">A submission with the given id was not found.</response>
 	[HttpGet("{id}")]
@@ -37,9 +37,9 @@ public class SubmissionsController : Controller
 	}
 
 	/// <summary>
-	/// Returns a list of publications, filtered by the given criteria.
+	/// Returns a list of submissions, filtered by the given criteria.
 	/// </summary>
-	/// <response code="200">Returns the list of publications.</response>
+	/// <response code="200">Returns the list of submissions.</response>
 	/// <response code="400">The request parameters are invalid.</response>
 	[HttpGet]
 	[Validate]


### PR DESCRIPTION
Mainly changing publications to submissions where appropriate. I also added a couple of full stops but didn't do all of them.