### PR TITLE
Change Published Authors obsolete link to obsolete only

### DIFF
--- a/TASVideos/Pages/Publications/Authors.cshtml
+++ b/TASVideos/Pages/Publications/Authors.cshtml
@@ -27,7 +27,7 @@
 					<a href="/Movies-List-author@(author.Id)">@author.ActivePublicationCount</a>
 				</td>
 				<td>
-					<a href="/Movies-List-author@(author.Id)-obs">@author.ObsoletePublicationCount</a>
+					<a href="/Movies-List-author@(author.Id)-ObsOnly">@author.ObsoletePublicationCount</a>
 				</td>
 			</tr>
 		}


### PR DESCRIPTION
https://tasvideos.org/Publications/Authors

Makes the obsolete movie list links here use obsonly.