### PR TITLE
sub/pubs: main 'Author' -> 'Author(s)' (for clarity and consistency)

### DIFF
--- a/TASVideos/Pages/Publications/Models/PublicationEditModel.cs
+++ b/TASVideos/Pages/Publications/Models/PublicationEditModel.cs
@@ -15,7 +15,7 @@ public class PublicationEditModel
 	[Display(Name = "External Authors", Description = "Only authors not registered for TASVideos should be listed here. If multiple authors, separate the names with a comma.")]
 	public string? AdditionalAuthors { get; set; }
 
-	[Display(Name = "Author")]
+	[Display(Name = "Author(s)")]
 	public IEnumerable<string> Authors { get; set; } = new List<string>();
 
 	[Display(Name = "Publication Class")]

--- a/TASVideos/Pages/Submissions/Models/SubmissionEditModel.cs
+++ b/TASVideos/Pages/Submissions/Models/SubmissionEditModel.cs
@@ -63,7 +63,7 @@ public class SubmissionEditModel
 
 	public int RerecordCount { get; set; }
 
-	[Display(Name = "Author")]
+	[Display(Name = "Author(s)")]
 	public IEnumerable<string> Authors { get; set; } = new List<string>();
 
 	[Display(Name = "Submitter")]


### PR DESCRIPTION
This may seem like a nitpick, but it's easy enough to miss the `+` button and this adds an extra visual clue for how to add authors.

This is just making submission and publication editing consistent with how *creating* a submission already works: https://github.com/TASVideos/tasvideos/blob/ee832ce3bb07d612157d750b1c7a200a4b74177f/TASVideos/Pages/Submissions/Models/SubmissionCreateModel.cs#L36

This is a simplified version of #1619