### PR TITLE
Remove latest parameter from WikiTextChangeLog

### DIFF
--- a/TASVideos/Pages/Shared/Components/WikiTextChangeLog/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/WikiTextChangeLog/Default.cshtml
@@ -33,7 +33,6 @@
 					<a
 						asp-page="/Wiki/PageHistory"
 						asp-route-path="@item.PageName"
-						asp-route-latest="true"
 						asp-route-fromRevision="@(item.Revision - 1)"
 						asp-route-toRevision="@item.Revision"
 						class="btn btn-secondary">


### PR DESCRIPTION
The Diff button on [RecentChanges](https://tasvideos.org/RecentChanges) will always go to the latest revision because of this parameter, removing it fixes this.