### PR TITLE
Add version number to layout js files for cache busting

### DIFF
--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -20,7 +20,7 @@
 		<link rel="stylesheet" href="/css/forum.css" />
 	}
 
-	<script src="~/js/site-head.js"></script>
+	<script src="~/js/site-head.js" asp-append-version="true"></script>
 
 	<link rel="alternate" href="/news.rss" type="application/rss+xml" title="TASVideos RSS News Feed">
 	<link rel="alternate" href="/submissions.rss" type="application/rss+xml" title="TASVideos RSS Submission Feed">
@@ -130,8 +130,8 @@
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"
 			integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm"
 			crossorigin="anonymous"></script>
-	<script src="~/js/site.js"></script>
-	<script src="~/js/prism.js"></script>
+	<script src="~/js/site.js" asp-append-version="true"></script>
+	<script src="~/js/prism.js" asp-append-version="true"></script>
 	@await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>


### PR DESCRIPTION
This uses the tag helper feature "asp-append-version" to append a version string to the js files, so that when they change, browsers will request the file anew instead of using their cache.