### PR TITLE
Swap icon on collapsed forum welcome banner

### DIFF
--- a/TASVideos/Pages/Forum/_ForumHeader.cshtml
+++ b/TASVideos/Pages/Forum/_ForumHeader.cshtml
@@ -1,5 +1,5 @@
 ﻿<small>
-	<i id="forum-header-restore" class="fa fa-plus border border-info btn-info p-1 mb-1 border-r d-none" style="cursor: pointer; border-radius: 5px"></i>
+	<i id="forum-header-restore" class="fa fa-chevron-down border border-info btn-info p-1 mb-1 border-r d-none" style="cursor: pointer; border-radius: 5px"></i>
 </small>
 <info-alert id="forum-header" class="d-none">
 	<button id="forum-header-dismiss" type="button" class="btn-close float-end" aria-label="close"></button>


### PR DESCRIPTION
Current '+' icon suggests creating or adding something (a subforum?).

Before and after:
![comparison](https://cdn.discordapp.com/attachments/738421558783246467/1137014989153116230/Screenshot_20230804_233100.png)

Critics said:

"fair"
—feos

"true"
—Masterjun

"reasonable"
—Randomno