### PR TITLE
Fix more monospace background color bugs

### DIFF
--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -9,13 +9,18 @@
 	--bs-link-color-rgb: 13,110,253;
 	--bs-link-hover-color: #0a58ca;
 	--bs-link-hover-color-rgb: 10,88,202;
+	--code-bg: var(--bs-body-bg);
 
 	.card {
 		--bs-card-cap-bg: var(--bs-gray-200);
 	}
 
-	pre {
-		--bs-card-cap-bg: var(--bs-white);
+	.card, .tab-content {
+		--code-bg: var(--bs-gray-200);
+
+		figure {
+			--code-bg: var(--bs-body-bg);
+		}
 	}
 }
 @include color-mode(dark) {
@@ -28,8 +33,20 @@
 	--bs-link-color: #5099f1;
 	--bs-link-color-rgb: 80,153,241;
 
-	.card, figure, pre {
+	.card {
 		--bs-card-cap-bg: #212529;
+	}
+
+	.card {
+		--code-bg: var(--bs-body-bg);
+
+		figure {
+			--code-bg: var(--bs-tertiary-bg);
+		}
+	}
+
+	.tab-content {
+		--code-bg: var(--bs-tertiary-bg);
 	}
 
 	.table {
@@ -542,12 +559,7 @@ tt {
 }
 
 tt, code, kbd, pre, samp, .wiki blockquote {
-	background: var(--bs-card-cap-bg);
-}
-:not(.card-body) > .wiki {
-	tt, code, kbd, pre, samp, .wiki blockquote {
-		background: var(--bs-body-bg);
-	}
+	background: var(--code-bg);
 }
 
 tt, code, kbd, pre, samp, dt, .wiki blockquote {

--- a/TASVideos/wwwroot/css/partials/_prism-dark.scss
+++ b/TASVideos/wwwroot/css/partials/_prism-dark.scss
@@ -40,14 +40,12 @@
 		padding: 1em;
 		margin: .5em 0;
 		overflow: auto;
-		background: #1e1e1e;
 	}
 
 	:not(pre) > code[class*="language-"] {
 		padding: .1em .3em;
 		border-radius: .3em;
 		color: #db4c69;
-		background: #1e1e1e;
 	}
 	/*********************************************************
 * Tokens

--- a/TASVideos/wwwroot/css/partials/_prism.scss
+++ b/TASVideos/wwwroot/css/partials/_prism.scss
@@ -9,7 +9,6 @@ http://prismjs.com/download.html?themes=prism&languages=markup+css+clike+javascr
 code[class*="language-"],
 pre[class*="language-"] {
 	color: black;
-	background: none;
 	text-shadow: 0 1px white;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	text-align: left;
@@ -53,17 +52,6 @@ pre[class*="language-"] {
 	padding: 1em;
 	margin: .5em 0;
 	overflow: auto;
-}
-
-:not(pre) > code[class*="language-"],
-pre[class*="language-"] {
-	background: var(--bs-card-cap-bg);
-}
-:not(.card-body) > .wiki {
-	:not(pre) > code[class*="language-"],
-	pre[class*="language-"] {
-		background: var(--bs-body-bg);
-	}
 }
 
 /* Inline code */


### PR DESCRIPTION
I think this should be all of them.
A big problem was how the old style kept using `--bs-card-cap-bg`, which was available everywhere in bootstrap 5.1, however in 5.3 it's only available in `card`s.