### PR TITLE
Improve Game searches with better ranking

### DIFF
--- a/TASVideos/Pages/Search/Index.cshtml.cs
+++ b/TASVideos/Pages/Search/Index.cshtml.cs
@@ -71,8 +71,9 @@ public class IndexModel : BasePageModel
 				.ToListAsync();
 
 			GameResults = await _db.Games
-				.Where(g => EF.Functions.ToTsVector(g.DisplayName + " || " + g.Aliases + " || " + g.Abbreviation).Matches(EF.Functions.WebSearchToTsQuery(SearchTerms)))
-				.OrderBy(g => g.GameGenres.Select(gg => gg.Genre!.DisplayName).Contains("Unofficial game")).ThenBy(g => g.DisplayName)
+				.Where(g => EF.Functions.ToTsVector("simple", g.DisplayName + " || " + g.Aliases + " || " + g.Abbreviation).Matches(EF.Functions.WebSearchToTsQuery("simple", SearchTerms)))
+				.OrderByDescending(g => EF.Functions.ToTsVector("simple", g.DisplayName + " || " + g.Aliases + " || " + g.Abbreviation).RankCoverDensity(EF.Functions.WebSearchToTsQuery("simple", SearchTerms), NpgsqlTsRankingNormalization.DivideByLength))
+					.ThenBy(g => g.DisplayName)
 				.Skip(skip)
 				.Take(PageSize + 1)
 				.Select(g => new GameSearchModel(


### PR DESCRIPTION
This PR affects the regular search (not advanced search), and only the game search at that.
It now:
- uses "simple" instead of "english" query conversion
- ranks the games using postgres ranking algorithms
- uses postgres to normalize the results by length (shorter matches rank higher, because longer matches have a higher probability of including the terms)

What does "simple" vs "english" mean? Well, the previous code uses `EF.Functions.ToTsVector` and `EF.Functions.WebSearchToTsQuery` with default searching parameters.
It seems postgres or at least our production defaults to "english", meaning it strips common words like `the`, `of`, etc. from the search. This is probably fine when searching inside Wiki Pages and Forum Posts. Not however with Game names.
So this PR changes game search from "english" to "simple", which includes all the words.

Previously the game "The I of It" could not be found because the conversion literally strips every single word and the search was empty.

### Examples (before | after):
![image](https://github.com/TASVideos/tasvideos/assets/22375320/0e443b20-2a64-422a-843f-4edd01f00f1e)

![image](https://github.com/TASVideos/tasvideos/assets/22375320/8d5ed794-94e2-4c7b-8d2e-1527bc4e2ef0)

![image](https://github.com/TASVideos/tasvideos/assets/22375320/5928a9dd-819f-4faf-b7e9-3f7e5743a8ac)
