### PR TITLE
Limit diff processing time

### DIFF
--- a/TASVideos/wwwroot/js/diff_view.js
+++ b/TASVideos/wwwroot/js/diff_view.js
@@ -4,7 +4,7 @@ function renderDiff(from, to, destEl, inline, contextSize) {
 	}
 
 	const dmp = new diff_match_patch();
-	dmp.Diff_Timeout = 0;
+	dmp.Diff_Timeout = 5;
 	dmp.Diff_EditCost = 20;
 
 	const d = dmp.diff_main(cleanCr(from.text), cleanCr(to.text));


### PR DESCRIPTION
The units are in seconds here, and it's counting the total time spent diffing the entire file, so with this PR the call to `dmp.diff_main` should not take more than almost exactly 5 seconds.

I don't know what an ideal value is; if it runs out of time, you get diffs that are technically correct but can miss sameness and so can be misleading.  This will at least stop it from completely trashing the tab.

Fixes #1649