### PR TITLE
Restore PageTitle on Submission Page

### DIFF
--- a/TASVideos/Pages/Submissions/View.cshtml
+++ b/TASVideos/Pages/Submissions/View.cshtml
@@ -57,6 +57,12 @@
 	}
 }
 
+@section PageTitle {
+	<div class="container mb-2">
+		<h1 class="card card-header d-block">@($"Submission {Model.Submission.Title}")</h1>
+	</div>
+}
+
 <row class="mt-2">
 	<div class="col-lg-6" condition="hasEncode">
 		@*Boilerplate bootstrap stuff *@


### PR DESCRIPTION
This restores the PageTitle section that was removed in a9bf6069d402f5e8d4b2888030aca2e8a6d5f913 .
I don't know why it was removed.