### PR TITLE
remove redirect that supports legacy homepages  

### DIFF
--- a/TASVideos/Pages/Wiki/Render.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Render.cshtml.cs
@@ -64,13 +64,6 @@ public class RenderModel : BasePageModel
 			return Page();
 		}
 
-		var homePage = await _wikiPages.Page("HomePages/" + url);
-		if (homePage != null)
-		{
-			// We redirected on invalid url homepages, now we have to do the same for valid ones
-			return Redirect("/HomePages/" + url);
-		}
-
 		// Account for garbage revision values
 		if (revision.HasValue && await _wikiPages.Exists(url))
 		{


### PR DESCRIPTION
Previously /user would redirect to /HomePages/user, but this can be exploited, and old legacy links have been cleaned up, and users are consistently using the [user:] module.  I think we can safely remove this workaround