### PR TITLE
add avs, bat, and sh to previewable usefiles

### DIFF
--- a/TASVideos.WikiEngine/NewParser.cs
+++ b/TASVideos.WikiEngine/NewParser.cs
@@ -884,7 +884,7 @@ public class NewParser
 			var e = new Element(_index, "code");
 			if (lang != "")
 			{
-				e.Attributes["class"] = "language-" + lang;
+				e.Attributes["class"] = "language-" + PrismNames.FixLanguage(lang);
 			}
 
 			e.Children.Add(new Text(_index, EatSrcEmbedText()) { CharEnd = _index });

--- a/TASVideos.WikiEngine/PrismNames.cs
+++ b/TASVideos.WikiEngine/PrismNames.cs
@@ -1,0 +1,15 @@
+﻿namespace TASVideos.WikiEngine;
+
+public static class PrismNames
+{
+	public static string FixLanguage(string s)
+	{
+		return s switch
+		{
+			"bat" => "batch",
+			"sh" => "shell",
+			"c++" => "cpp",
+			_ => s
+		};
+	}
+}

--- a/TASVideos/Pages/UserFiles/Info.cshtml.cs
+++ b/TASVideos/Pages/UserFiles/Info.cshtml.cs
@@ -11,7 +11,7 @@ namespace TASVideos.Pages.UserFiles;
 [AllowAnonymous]
 public class InfoModel : BasePageModel
 {
-	private static readonly string[] PreviewableExtensions = { "wch", "lua" };
+	private static readonly string[] PreviewableExtensions = {  "avs", "bat", "lua", "sh", "wch" };
 
 	private readonly ApplicationDbContext _db;
 	private readonly IFileService _fileService;

--- a/TASVideos/Pages/UserFiles/Info.cshtml.cs
+++ b/TASVideos/Pages/UserFiles/Info.cshtml.cs
@@ -11,7 +11,7 @@ namespace TASVideos.Pages.UserFiles;
 [AllowAnonymous]
 public class InfoModel : BasePageModel
 {
-	private static readonly string[] PreviewableExtensions = {  "avs", "bat", "lua", "sh", "wch" };
+	private static readonly string[] PreviewableExtensions = { "avs", "bat", "lua", "sh", "wch" };
 
 	private readonly ApplicationDbContext _db;
 	private readonly IFileService _fileService;


### PR DESCRIPTION
we'll be relying on shipping official scripts for different things (mostly pcem), and previewing them makes it transparent for the users what they're downloading.

also added prism name fix for wiki by copying the file from forum engine. doesn't feel right tho.