### PR TITLE
Fix regression of tag retention support when obsoleting movies

### DIFF
--- a/TASVideos/Pages/Submissions/Publish.cshtml
+++ b/TASVideos/Pages/Submissions/Publish.cshtml
@@ -155,11 +155,6 @@
 		let originalDescription = "@Model.Submission.MovieMarkup";
 		const obsoletionModel = document.getElementById("@Html.IdFor(m => m.Submission.MovieToObsolete)");
 		const descriptionModel = document.getElementById("@Html.IdFor(m => m.Submission.MovieMarkup)");
-		const dblClickEvent = new MouseEvent('dblclick', {
-			'view': window,
-			'bubbles': true,
-			'cancelable': true
-		});
 
 		descriptionModel.onchange = function() {
 			originalDescription = descriptionModel.value;
@@ -181,15 +176,12 @@
 					descriptionModel.value = t.markup;
 					originalDescription = oldValue;
 
-					document.getElementById(`${selectedTagsId}removeAllBtn`).click();
 					document.getElementById("obsoleted-by").innerHTML = t.title ? t.title : "Unknown publication";
 
-					for (let i in t.tags) {
-						const tagItem = document.querySelector(`[name='AvailableTags'] option[value="${t.tags[i]}"]`);
-						tagItem.selected = true;
+					for (let option of document.querySelectorAll(`#${selectedTagsId} option`)) {
+						option.selected = t.tags.includes(Number(option.value));
 					}
-
-					document.getElementById(`${selectedTagsId}addBtn`).click();
+					engageSelectImprover('@Html.IdFor(m => m.Submission.SelectedTags)');
 				});
 		}
 	</script>


### PR DESCRIPTION
This fixes the regression of #804 when the select improver was implemented in c55d4302a11ffcd8d4a2f82d04dcadf3fc1b1405.

In particular, the tags were no longer copied from the selected obsoleted movie. But now it works again.