### PR TITLE
Remove unused HTML IDs appearing on every page

### DIFF
--- a/TASVideos/Pages/Shared/_LoginPartial.cshtml
+++ b/TASVideos/Pages/Shared/_LoginPartial.cshtml
@@ -13,20 +13,20 @@
 {
     <navbar class="flex-wrap justify-content-end">
         <nav-item activate="Messages">
-            <a id="Inbox" class="nav-link text-nowrap" asp-page="/Messages/Inbox">
+            <a class="nav-link text-nowrap" asp-page="/Messages/Inbox">
                 <span condition="notificationCount > 0" class="badge bg-danger text-white">@notificationCount</span>
                 <span condition="notificationCount > 0" class="sr-only">unread messages</span>
                 <span class="fa fa-envelope"></span>
             </a>
         </nav-item>
         <nav-item activate="Profile">
-            <a id="Manage" class="nav-link" asp-page="/Profile/Index" title="Manage">
+            <a class="nav-link" asp-page="/Profile/Index" title="Manage">
                 <i class="fa fa-user d-inline"></i>&nbsp;@User.Name()
             </a>
         </nav-item>
         <nav-item>
-            <form asp-page="/Account/Logout" method="post" id="logoutForm" asp-antiforgery="false">
-                <button id="Logout" type="submit" class="btn btn-link navbar-btn nav-link text-nowrap fs-6 border-0"><i class="fa fa-sign-out"></i> Log out</button>
+            <form asp-page="/Account/Logout" method="post" asp-antiforgery="false">
+                <button type="submit" class="btn btn-link navbar-btn nav-link text-nowrap fs-6 border-0"><i class="fa fa-sign-out"></i> Log out</button>
             </form>
         </nav-item>
         <nav-item activate="Search">
@@ -45,10 +45,10 @@ else
 {
 	<navbar>
 		<nav-item activate="Register">
-			<a id="Register" class="nav-link" asp-page="/Account/Register">Register</a>
+			<a class="nav-link" asp-page="/Account/Register">Register</a>
 		</nav-item>
 		<nav-item activate="Login">
-			<a id="Login" class="nav-link text-nowrap" asp-page="/Account/Login" asp-route-returnUrl="@Context.CurrentPathToReturnUrl()"><i class="fa fa-sign-in"></i> Log in</a>
+			<a class="nav-link text-nowrap" asp-page="/Account/Login" asp-route-returnUrl="@Context.CurrentPathToReturnUrl()"><i class="fa fa-sign-in"></i> Log in</a>
 		</nav-item>
 		<nav-item activate="Search">
 			<form method="GET" action="/Search/Index">

--- a/TASVideos/Pages/Shared/_NavBarPartial.cshtml
+++ b/TASVideos/Pages/Shared/_NavBarPartial.cshtml
@@ -1,60 +1,60 @@
 @using static TASVideos.Data.Entity.PermissionTo;
 <navbar class="flex-wrap me-2 me-md-0 fw-bold">
 	<nav-item activate="Home">
-		<a id="Home" class="nav-link" href="/">Home</a>
+		<a class="nav-link" href="/">Home</a>
 	</nav-item>
 	<nav-item activate="Games">
-		<a id="Games" class="nav-link" asp-page="/Games/List">Games</a>
+		<a class="nav-link" asp-page="/Games/List">Games</a>
 	</nav-item>
-	<nav-dropdown id="MoviesDropdown" activate="Movies">
-		<a id="Classes" class="dropdown-item" href="/Class">Movie Classes</a>
-		<a id="Publications" class="dropdown-item" href="/Movies">Publications</a>
-		<a id="Submissions" class="dropdown-item" asp-page="/Submissions/Index">Submissions</a>
-		<a id="Userfiles" class="dropdown-item" href="/Userfiles">User Files</a>
+	<nav-dropdown activate="Movies">
+		<a class="dropdown-item" href="/Class">Movie Classes</a>
+		<a class="dropdown-item" href="/Movies">Publications</a>
+		<a class="dropdown-item" asp-page="/Submissions/Index">Submissions</a>
+		<a class="dropdown-item" href="/Userfiles">User Files</a>
 	</nav-dropdown>
 	<nav-item activate="Forum">
-		<a id="Forum" class="nav-link" asp-page="/Forum/Index">Forum</a>
+		<a class="nav-link" asp-page="/Forum/Index">Forum</a>
 	</nav-item>
 	<nav-item activate="LiveChat">
-		<a id="LiveChat" class="nav-link" href="/LiveChat">Chat</a>
+		<a class="nav-link" href="/LiveChat">Chat</a>
 	</nav-item>
-	<nav-dropdown id="ArticlesDropdown" activate="Articles">
-		<a id="Articles" class="dropdown-item" href="/ArticleIndex">Article Index</a>
-		<a id="GameResources" class="dropdown-item" href="/GameResources">Game Resources</a>
-		<a id="Emulators" class="dropdown-item" href="/EmulatorResources">Emulators</a>
+	<nav-dropdown activate="Articles">
+		<a class="dropdown-item" href="/ArticleIndex">Article Index</a>
+		<a class="dropdown-item" href="/GameResources">Game Resources</a>
+		<a class="dropdown-item" href="/EmulatorResources">Emulators</a>
 	</nav-dropdown>
 	<nav-item activate="Staff">
-		<a id="Staff" class="nav-link" href="/Staff">Staff</a>
+		<a class="nav-link" href="/Staff">Staff</a>
 	</nav-item>
 	<nav-item activate="WelcomeToTASVideos">
-		<a id="Welcome" class="nav-link" href="/WelcomeToTASVideos">About</a>
+		<a class="nav-link" href="/WelcomeToTASVideos">About</a>
 	</nav-item>
-	<nav-dropdown id="AdminDropdown" activate="Admin"
+	<nav-dropdown activate="Admin"
 				  permissions="new[] { ViewPrivateUserData, EditUsers, EditRoles, TagMaintenance, GameSystemMaintenance, CreateAwards }">
-		<a id="MediaPosts" class="dropdown-item" href="/MediaPosts">Media Posts</a>
-		<a id="Users" permissions="new[] { ViewPrivateUserData, EditUsers }" class="dropdown-item" asp-page="/Users/List">Users</a>
-		<a id="Roles" class="dropdown-item" asp-page="/Roles/List">Roles</a>
-		<a id="Permissions" class="dropdown-item" asp-page="/Permissions/Index">Permissions</a>
-		<a id="TagMaintenance" permission="TagMaintenance" class="dropdown-item" asp-page="/Tags/Index">Tag Maintenance</a>
-		<a id="FlagMaintenance" permission="FlagMaintenance" class="dropdown-item" asp-page="/Flags/Index">Flag Maintenance</a>
-		<a id="GenreMaintenance" permission="TagMaintenance" class="dropdown-item" asp-page="/Genres/Index">Genre Maintenance</a>
-		<a id="TierMaintenance" permission="ClassMaintenance" class="dropdown-item" asp-page="/PublicationClasses/Index">Class Maintenance</a>
-		<a id="AwardsEditor" permission="CreateAwards" class="dropdown-item" asp-page="/AwardsEditor/Index">Awards Editor</a>
-		<a id="Systems" permission="GameSystemMaintenance" class="dropdown-item" asp-page="/Systems/Index">Systems</a>
+		<a class="dropdown-item" href="/MediaPosts">Media Posts</a>
+		<a permissions="new[] { ViewPrivateUserData, EditUsers }" class="dropdown-item" asp-page="/Users/List">Users</a>
+		<a class="dropdown-item" asp-page="/Roles/List">Roles</a>
+		<a class="dropdown-item" asp-page="/Permissions/Index">Permissions</a>
+		<a permission="TagMaintenance" class="dropdown-item" asp-page="/Tags/Index">Tag Maintenance</a>
+		<a permission="FlagMaintenance" class="dropdown-item" asp-page="/Flags/Index">Flag Maintenance</a>
+		<a permission="TagMaintenance" class="dropdown-item" asp-page="/Genres/Index">Genre Maintenance</a>
+		<a permission="ClassMaintenance" class="dropdown-item" asp-page="/PublicationClasses/Index">Class Maintenance</a>
+		<a permission="CreateAwards" class="dropdown-item" asp-page="/AwardsEditor/Index">Awards Editor</a>
+		<a permission="GameSystemMaintenance" class="dropdown-item" asp-page="/Systems/Index">Systems</a>
 	</nav-dropdown>
-	<nav-dropdown id="WikiDropdown" activate="Wiki"
+	<nav-dropdown activate="Wiki"
 				  permissions="new[] { EditWikiPages, EditSystemPages, MoveWikiPages, DeleteWikiPages }">
-		<a id="SandBox" class="dropdown-item" href="/SandBox">SandBox</a>
-		<a id="RecentChanges" class="dropdown-item" href="/RecentChanges">Recent Changes</a>
-		<a id="Orphans" class="dropdown-item" href="/WikiOrphans">Orphans</a>
-		<a id="Todo" class="dropdown-item" href="/TODO">To Do</a>
-		<a id="SystemPages" class="dropdown-item" href="/System">System Pages</a>
-		<a id="DeletedPages" permission="SeeDeletedWikiPages" asp-page="/Wiki/DeletedPages" class="dropdown-item">Deleted Pages</a>
+		<a class="dropdown-item" href="/SandBox">SandBox</a>
+		<a class="dropdown-item" href="/RecentChanges">Recent Changes</a>
+		<a class="dropdown-item" href="/WikiOrphans">Orphans</a>
+		<a class="dropdown-item" href="/TODO">To Do</a>
+		<a class="dropdown-item" href="/System">System Pages</a>
+		<a permission="SeeDeletedWikiPages" asp-page="/Wiki/DeletedPages" class="dropdown-item">Deleted Pages</a>
 	</nav-dropdown>
-	<nav-dropdown id="DarkDropdown" activate='<i class="fa fa-adjust"></i>'>
-		<button id="Dark" class="dropdown-item" onclick="setTheme('dark')"><i class="fa-regular fa-moon"></i> Dark</button>
-		<button id="Light" class="dropdown-item" onclick="setTheme('light')"><i class="fa-regular fa-sun"></i> Light</button>
-		<button id="Auto" class="dropdown-item" onclick="setTheme('auto')">Auto</button>
+	<nav-dropdown activate='<i class="fa fa-adjust"></i>'>
+		<button class="dropdown-item" onclick="setTheme('dark')"><i class="fa-regular fa-moon"></i> Dark</button>
+		<button class="dropdown-item" onclick="setTheme('light')"><i class="fa-regular fa-sun"></i> Light</button>
+		<button class="dropdown-item" onclick="setTheme('auto')">Auto</button>
 	</nav-dropdown>
 	
 </navbar>


### PR DESCRIPTION
This basically reverts #612 and #613 which where merged but never used for tests afterwards.

This fixes the issue where our TOC could not navigate to headers that collided with these IDs, e.g. https://tasvideos.org/ReverseEngineering#Emulators

In general, we should use HTML IDs very sparingly, because of exactly this feature we want to support. (If we ever want Selenium tests like the two PRs were a preparation for, we should consider just using html classes, which can then be selected.)