### PR TITLE
fix module:GameName on general GameResources subpages

### DIFF
--- a/TASVideos/Pages/Shared/Components/GameName/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/GameName/Default.cshtml
@@ -1,7 +1,7 @@
 ﻿@model IList<GameNameModel>
 @if (Model.Any(g => g.IsSystem))
 {
-	<text><span>@Model.First().System</span></text>
+	<text><span>@Model.First().System games</span></text>
 }
 else
 {

--- a/TASVideos/ViewComponents/GameName.cs
+++ b/TASVideos/ViewComponents/GameName.cs
@@ -23,10 +23,9 @@ public class GameName : ViewComponent
 		{
 			var system = await _db.GameSystems
 				.SingleOrDefaultAsync(s => s.Code == path.SystemGameResourcePath());
-			if (system is not null)
-			{
-				gameList.Add(new GameNameModel { System = system.DisplayName });
-			}
+			gameList.Add(new GameNameModel { System = system is not null
+				? system.DisplayName
+				: "various" });
 		}
 		else
 		{


### PR DESCRIPTION
Somewhat hacky? The idea is to reword it to "[system] **games**" when there's a system, because those pages don't actually have any info about the system itself, only about its games. And when there's no system to display, that means we're on a general subpage, so we say "**various** games" instead.

fix #1688