### PR TITLE
Show Username on Log Page

### DIFF
--- a/TASVideos/Pages/Logs/Index.cshtml
+++ b/TASVideos/Pages/Logs/Index.cshtml
@@ -12,7 +12,7 @@
 		
 		<tr>
 			<td>@entry.RowId</td>
-			<td>@entry.UserId</td>
+			<td>@entry.UserName</td>
 			<td>
 				<timezone-convert asp-for="@entry.Created"/>
 			</td>

--- a/TASVideos/Pages/Logs/Index.cshtml.cs
+++ b/TASVideos/Pages/Logs/Index.cshtml.cs
@@ -30,7 +30,7 @@ public class IndexModel : BasePageModel
 	public async Task<IActionResult> OnGet()
 	{
 		var query = _db.AutoHistory
-			.GroupJoin(_db.Users, outerKey => outerKey.UserId, innerKey => innerKey.Id, (h, user) => new {h, user})
+			.GroupJoin(_db.Users, outerKey => outerKey.UserId, innerKey => innerKey.Id, (h, user) => new { h, user })
 			.SelectMany(g => g.user.DefaultIfEmpty(), (g, user) => new LogEntry
 			{
 				RowId = g.h.RowId,

--- a/TASVideos/Pages/Logs/Index.cshtml.cs
+++ b/TASVideos/Pages/Logs/Index.cshtml.cs
@@ -30,14 +30,15 @@ public class IndexModel : BasePageModel
 	public async Task<IActionResult> OnGet()
 	{
 		var query = _db.AutoHistory
-			.Select(h => new LogEntry
+			.GroupJoin(_db.Users, outerKey => outerKey.UserId, innerKey => innerKey.Id, (h, user) => new {h, user})
+			.SelectMany(g => g.user.DefaultIfEmpty(), (g, user) => new LogEntry
 			{
-				RowId = h.RowId,
-				UserId = h.UserId,
-				Created = h.Created,
-				TableName = h.TableName,
-				Changed = h.Changed,
-				Kind = h.Kind,
+				RowId = g.h.RowId,
+				UserName = user == null ? "Unknown_User" : user.UserName,
+				Created = g.h.Created,
+				TableName = g.h.TableName,
+				Changed = g.h.Changed,
+				Kind = g.h.Kind,
 			});
 
 		if (!string.IsNullOrWhiteSpace(Table))
@@ -70,7 +71,7 @@ public class IndexModel : BasePageModel
 		public string RowId { get; init; } = "";
 
 		[Sortable]
-		public int UserId { get; init; }
+		public string UserName { get; init; }
 
 		[Sortable]
 		public DateTime Created { get; init; } = DateTime.UtcNow;


### PR DESCRIPTION
Resolves #1584 .

Because these are logs, using EF Core directly for the relationship felt weird, because it would create foreign keys and we don't really want those.
So this solution implements a manual join. In fact, a LEFT JOIN, because we still want to show logs that have no fitting UserId set.

The [Microsoft docs](https://learn.microsoft.com/en-us/ef/core/querying/complex-query-operators#left-join) show how EF Core converts a "GroupJoin(), SelectMany(), DefaultIfEmpty()" combination into a LEFT JOIN.
And this works as expected (notice the LEFT JOIN):
```
﻿[18:49:09 INF] Executed DbCommand (5ms) [Parameters=[@__Table_0='Games', @__rowStr_1='1', @__p_3='25', @__p_2='0'], CommandType='Text', CommandTimeout='30']
﻿SELECT a.row_id AS "RowId", CASE
﻿    WHEN (u.id IS NULL) THEN 'Unknown_User'
﻿    ELSE u.user_name
﻿END AS "UserName", a.created AS "Created", a.table_name AS "TableName", a.changed AS "Changed", a.kind AS "Kind"
﻿FROM auto_history AS a
﻿LEFT JOIN users AS u ON a.user_id = u.id
﻿WHERE (a.table_name = @__Table_0) AND (a.row_id = @__rowStr_1)
﻿ORDER BY a.created DESC
﻿LIMIT @__p_3 OFFSET @__p_2
```