### PR TITLE
better way to display video downloads

### DIFF
--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -225,7 +225,7 @@
 					<span condition="Model.MirrorSiteUrls.Any()">
 						@foreach (var url in Model.MirrorSiteUrls)
 						{
-							string text = System.IO.Path.GetExtension(url.Url!).Replace(".", "").ToUpper();
+							var text = System.IO.Path.GetExtension(url.Url!).Replace(".", "").ToUpper();
 							if (text == "MKV")
 							{
 								text = "High Quality " + text;

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -221,14 +221,24 @@
 			</div>
 			<div class="col-auto">
 				<small condition="Model.MirrorSiteUrls.Any()">
-					A/V files:<br />
+					Video Downloads:<br />
 					<span condition="Model.MirrorSiteUrls.Any()">
 						@foreach (var url in Model.MirrorSiteUrls)
 						{
-							<a href="@url.Url" class="ms-2">
-								@(string.IsNullOrWhiteSpace(url.DisplayName) ? "A/V file" : url.DisplayName) via Mirror
-								<br/>
-							</a>
+							string text = System.IO.Path.GetExtension(url.Url!).Replace(".", "").ToUpper();
+							if (text == "MKV")
+							{
+								text = "High Quality " + text;
+							}
+							else if (text == "MP4")
+							{
+								text = "Compatibility " + text;
+							}
+							if (!string.IsNullOrEmpty(url.DisplayName))
+							{
+								text = text + $" ({url.DisplayName})";
+							}
+							<a href="@url.Url" class="ms-2">@text<br/></a>
 						}
 					</span>
 				</small>


### PR DESCRIPTION
Switching back to HQ MKV/Compat MP4 like old site had, except new pubs only have the latter.

There are few cases when an MKV is 512kb (encoded using streamable presets so it's not HQ, but neither is it streamable due to container) to put .ass subtitles in there. I think it's no big deal if we still automatically call them HQ MKV in the GUI, just because having to add exceptions for those would complicate things for little benefit, and .ass is technically higher quality subtitle than .srt (not in terms of resolution but in terms of other traits), and MKV is still not as compatible anyway.

fix #1704