### PR TITLE
Escape formatting symbols for Discord publisher

### DIFF
--- a/TASVideos.Core/Services/ExternalMediaPublisher/Distributors/DiscordDistributor.cs
+++ b/TASVideos.Core/Services/ExternalMediaPublisher/Distributors/DiscordDistributor.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using TASVideos.Core.Settings;
 using TASVideos.Core.HttpClientExtensions;
+using System.Text.RegularExpressions;
 
 namespace TASVideos.Core.Services.ExternalMediaPublisher.Distributors;
 
@@ -72,20 +73,26 @@ public sealed class DiscordDistributor : IPostDistributor
 
 	private class DiscordMessage
 	{
+		private readonly Regex CharacterToBeEscaped = new Regex(@"([\\_*~#\-`<>|])");
+		private const string EscapeRule = @"\$1";
+
 		// Generate the Discord message letting Discord take care of the Embed from Open Graph Metadata
 		public DiscordMessage(IPostable post)
 		{
-			var body = string.IsNullOrWhiteSpace(post.Body) ? "" : $" ({post.Body})";
+			var body = CharacterToBeEscaped.Replace(post.Body, EscapeRule);
+			var title = CharacterToBeEscaped.Replace(post.Title, EscapeRule);
+			var formattedTitle = CharacterToBeEscaped.Replace(post.FormattedTitle, EscapeRule);
+			body = string.IsNullOrWhiteSpace(body) ? "" : $" ({body})";
 			if (string.IsNullOrWhiteSpace(post.Link))
 			{
-				Content = $"{post.Title}{body}";
+				Content = $"{title}{body}";
 			}
 			else
 			{
 				var link = post.Type == PostType.Announcement ? post.Link : $"<{post.Link}>";
-				Content = string.IsNullOrWhiteSpace(post.FormattedTitle)
-					? $"{post.Title}{body} {link}"
-					: $"{string.Format(post.FormattedTitle, link)}{body}";
+				Content = string.IsNullOrWhiteSpace(formattedTitle)
+					? $"{title}{body} {link}"
+					: $"{string.Format(formattedTitle, link)}{body}";
 			}
 		}
 


### PR DESCRIPTION
Resolves #1698 .
Escapes the formatting symbols Discord uses, so that we don't accidentally format.
(Before | After)
![image](https://github.com/TASVideos/tasvideos/assets/22375320/8d7197f2-dc03-4e25-99ac-cf49e7a51120)

Sadly, I can't add ( ) [ ] to the list of escaped characters, due to the implementation of #1684 . It would break our own formatting, and there is no way to differentiate between our own formatting and accidental formatting at that point in the code.