### PR TITLE
Add title to movie links in wiki

### DIFF
--- a/TASVideos.WikiEngine/MakeBracketed.cs
+++ b/TASVideos.WikiEngine/MakeBracketed.cs
@@ -227,14 +227,14 @@ public static partial class Builtins
 		{
 			if (pp.Length >= 2)
 			{
-				// same as the IsLink(pp[0]) && pp.Length >= 2 case, except add the '=' because it was implicitly resolved to an internal link
-				return new[] { MakeLink(charStart, charEnd, NormalizeUrl("=" + pp[0]), new Text(charStart, pp[1]) { CharEnd = charEnd }) };
+				// These need DB lookup for title attributes in some cases
+				return MakeModuleInternal(charStart, charEnd, "__wikiLink|href=" + NormalizeUrl("=" + pp[0]) + "|displaytext=" + pp[1]);
 			}
 
 			// If no labeling text was needed, a module is needed for DB lookups (eg `[4022S]`)
 			// DB lookup will be required for links like [4022S], so use __wikiLink
 			// TODO:  __wikilink should probably be its own AST type??
-			return MakeModuleInternal(charStart, charEnd, "__wikiLink|href=" + NormalizeUrl("=" + pp[0]) + "|displaytext=" + pp[0]);
+			return MakeModuleInternal(charStart, charEnd, "__wikiLink|href=" + NormalizeUrl("=" + pp[0]));
 		}
 
 		// In other cases, return raw literal text.  This doesn't quite match the old wiki, which could look for formatting in these, but should be good enough

--- a/TASVideos/Pages/Shared/Components/WikiLink/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/WikiLink/Default.cshtml
@@ -1,2 +1,2 @@
 ﻿@model WikiLinkModel
-<a href="@Model.Href" title=@Model.Title>@Model.DisplayText</a>
+<a href="@Model.Href" title="@Model.Title">@Model.DisplayText</a>

--- a/TASVideos/Pages/Shared/Components/WikiLink/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/WikiLink/Default.cshtml
@@ -1,2 +1,2 @@
 ﻿@model WikiLinkModel
-<a href="@Model.Href">@Model.DisplayText</a>
+<a href="@Model.Href" title=@Model.Title>@Model.DisplayText</a>

--- a/TASVideos/ViewComponents/Models/WikiLinkModel.cs
+++ b/TASVideos/ViewComponents/Models/WikiLinkModel.cs
@@ -4,4 +4,5 @@ public class WikiLinkModel
 {
 	public string Href { get; set; } = "";
 	public string DisplayText { get; set; } = "";
+	public string? Title { get; set; }
 }

--- a/TASVideos/ViewComponents/WikiLink.cs
+++ b/TASVideos/ViewComponents/WikiLink.cs
@@ -40,6 +40,14 @@ public class WikiLink : ViewComponent
 				titleText = $"[{id.Value}] " + title;
 			}
 		}
+		else if ((id = SubmissionHelper.IsGamePageLink(href)).HasValue)
+		{
+			var title = await GetGameTitle(id.Value);
+			if (!string.IsNullOrWhiteSpace(title))
+			{
+				titleText = title;
+			}
+		}
 
 		if (titleText != null)
 		{
@@ -75,5 +83,12 @@ public class WikiLink : ViewComponent
 		return (await _db.Submissions
 			.Select(s => new { s.Id, s.Title })
 			.SingleOrDefaultAsync(s => s.Id == id))?.Title;
+	}
+
+	private async Task<string?> GetGameTitle(int id)
+	{
+		return (await _db.Games
+			.Select(g => new { g.Id, g.DisplayName })
+			.SingleOrDefaultAsync(g => g.Id == id))?.DisplayName;
 	}
 }


### PR DESCRIPTION
This matches behavior in the old site, where a ##M / ##S / ##G link with link text provided would still get the standard text as a title.

```
[1M]             ->       <a href=/1M>[1] Some Really Awesome Movie</a>
[1M|foo]         ->       <a href=/1M title="[1] Some Really Awesome Movie">foo</a>
```

The implementation logic be reasonably straightforward; it just has to process substitutions and replacements in a specific order to get the fallback behavior we need.

fixes #1349