### PR TITLE
Revert "escape formatting symbols for discord publisher"

### DIFF
--- a/TASVideos.Core/Services/ExternalMediaPublisher/Distributors/DiscordDistributor.cs
+++ b/TASVideos.Core/Services/ExternalMediaPublisher/Distributors/DiscordDistributor.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.Logging;
 using TASVideos.Core.Settings;
 using TASVideos.Core.HttpClientExtensions;
-using System.Text.RegularExpressions;
 
 namespace TASVideos.Core.Services.ExternalMediaPublisher.Distributors;
 
@@ -73,26 +72,20 @@ public sealed class DiscordDistributor : IPostDistributor
 
 	private class DiscordMessage
 	{
-		private readonly Regex CharacterToBeEscaped = new Regex(@"([\\_*~#\-`<>|])");
-		private const string EscapeRule = @"\$1";
-
 		// Generate the Discord message letting Discord take care of the Embed from Open Graph Metadata
 		public DiscordMessage(IPostable post)
 		{
-			var body = CharacterToBeEscaped.Replace(post.Body, EscapeRule);
-			var title = CharacterToBeEscaped.Replace(post.Title, EscapeRule);
-			var formattedTitle = CharacterToBeEscaped.Replace(post.FormattedTitle, EscapeRule);
-			body = string.IsNullOrWhiteSpace(body) ? "" : $" ({body})";
+			var body = string.IsNullOrWhiteSpace(post.Body) ? "" : $" ({post.Body})";
 			if (string.IsNullOrWhiteSpace(post.Link))
 			{
-				Content = $"{title}{body}";
+				Content = $"{post.Title}{body}";
 			}
 			else
 			{
 				var link = post.Type == PostType.Announcement ? post.Link : $"<{post.Link}>";
-				Content = string.IsNullOrWhiteSpace(formattedTitle)
-					? $"{title}{body} {link}"
-					: $"{string.Format(formattedTitle, link)}{body}";
+				Content = string.IsNullOrWhiteSpace(post.FormattedTitle)
+					? $"{post.Title}{body} {link}"
+					: $"{string.Format(post.FormattedTitle, link)}{body}";
 			}
 		}
 


### PR DESCRIPTION
This reverts commit df97a929affe1527755f95a1be73da9a8f7a87c3. The commit implemented a very simple way of escaping by simply putting a backslash in front of every character allowing custom formatting.

The reason for this revert is a bug in Discord Markdown formatting:
Inside masked links, instead of hiding the escape backslashes like everywhere else, it instead shows them.
There is no way to prevent formatting inside masked links.

![image](https://github.com/TASVideos/tasvideos/assets/22375320/0a86a5ed-d733-4d45-a65e-fc6b5e70f3bc)

I reported a bug to Discord using their bug report tool. I also looked around in different places and it seems they keep this bug for "security reasons" https://github.com/discord/discord-api-docs/issues/6185#issuecomment-1666006809 , even if all other Markdowns do it right.

For example it works in GitHub Markdown:
`*format*` -> *format*
`\*escaped\*` -> \*escaped\*
`[*format*](http://a.b)` -> [*format*](http://a.b)
`[\*wtfdiscord\*](http://a.b)` -> [\*wtfdiscord\*](http://a.b)