### PR TITLE
Improve game search ranking

### DIFF
--- a/TASVideos/Pages/Search/Index.cshtml.cs
+++ b/TASVideos/Pages/Search/Index.cshtml.cs
@@ -72,7 +72,8 @@ public class IndexModel : BasePageModel
 
 			GameResults = await _db.Games
 				.Where(g => EF.Functions.ToTsVector("simple", g.DisplayName + " || " + g.Aliases + " || " + g.Abbreviation).Matches(EF.Functions.WebSearchToTsQuery("simple", SearchTerms)))
-				.OrderByDescending(g => EF.Functions.ToTsVector("simple", g.DisplayName + " || " + g.Aliases + " || " + g.Abbreviation).RankCoverDensity(EF.Functions.WebSearchToTsQuery("simple", SearchTerms), NpgsqlTsRankingNormalization.DivideByLength))
+				.OrderByDescending(g => EF.Functions.ToTsVector("simple", g.DisplayName).ToStripped().Rank(EF.Functions.WebSearchToTsQuery("simple", SearchTerms), NpgsqlTsRankingNormalization.DivideByLength))
+					.ThenBy(g => g.DisplayName.Length)
 					.ThenBy(g => g.DisplayName)
 				.Skip(skip)
 				.Take(PageSize + 1)

--- a/TASVideos/Pages/Search/Index.cshtml.cs
+++ b/TASVideos/Pages/Search/Index.cshtml.cs
@@ -71,8 +71,8 @@ public class IndexModel : BasePageModel
 				.ToListAsync();
 
 			GameResults = await _db.Games
-				.Where(g => EF.Functions.ToTsVector("simple", g.DisplayName + " || " + g.Aliases + " || " + g.Abbreviation).Matches(EF.Functions.WebSearchToTsQuery("simple", SearchTerms)))
-				.OrderByDescending(g => EF.Functions.ToTsVector("simple", g.DisplayName).ToStripped().Rank(EF.Functions.WebSearchToTsQuery("simple", SearchTerms), NpgsqlTsRankingNormalization.DivideByLength))
+				.Where(g => EF.Functions.ToTsVector("simple", g.DisplayName.Replace("/", " ") + " || " + g.Aliases + " || " + g.Abbreviation).Matches(EF.Functions.WebSearchToTsQuery("simple", SearchTerms)))
+				.OrderByDescending(g => EF.Functions.ToTsVector("simple", g.DisplayName.Replace("/", " ")).ToStripped().Rank(EF.Functions.WebSearchToTsQuery("simple", SearchTerms), NpgsqlTsRankingNormalization.DivideByLength))
 					.ThenBy(g => g.DisplayName.Length)
 					.ThenBy(g => g.DisplayName)
 				.Skip(skip)


### PR DESCRIPTION
This PR simplifies the ranking of game results, and thus makes them better.

Previously, Games with multiple matches got a boost in ranking, so that a "super mario" search would rank "Super Mario Super Mario" higher than the exact match "Super Mario", among other things.
Now, it uses `ToStripped()` to remove the information of how often it matched.

Also, the Aliases and Abbreviations are not taken into account in the ranking anymore. It worked against our favor, because many many metadata meant that it ranked lower, because a lot of the metadata didn't match.

The `Where` condition remains unchanged, so this PR doesn't change what is shown, only how it is ranked.

Before | After
![image](https://github.com/TASVideos/tasvideos/assets/22375320/7e3faecc-e5b9-4832-b493-69c07e4c78c0)
![image](https://github.com/TASVideos/tasvideos/assets/22375320/87a65c6e-1ed4-4db9-9f3c-ea053c27e95c)
