### PR TITLE
allow line wrap for annotations to make them look like in libtas

### DIFF
--- a/TASVideos/Pages/Shared/_UserFileInfo.cshtml
+++ b/TASVideos/Pages/Shared/_UserFileInfo.cshtml
@@ -75,14 +75,16 @@
 		</div>
 	</cardbody>
 </div>
+
 <div condition="!string.IsNullOrWhiteSpace(Model.Annotations)" class="mb-2">
-	<card>
+	<div class="card border-primary-subtle border mb-2">
 		<cardheader><h4>Annotations</h4></cardheader>
 		<cardbody>
-			@Model.Annotations
+			<pre style="white-space: pre-wrap">@Model.Annotations</pre>
 		</cardbody>
-	</card>
+	</div>
 </div>
+
 <div condition="!string.IsNullOrWhiteSpace(Model.ContentPreview)">
 	<wiki-markup markup="@ToMarkup(Model.ContentPreview, Model.Extension)"></wiki-markup>
 </div>

--- a/TASVideos/Pages/Shared/_UserFileInfo.cshtml
+++ b/TASVideos/Pages/Shared/_UserFileInfo.cshtml
@@ -10,7 +10,7 @@
 	}
 }
 
-<div class="card border-primary-subtle border mb-2">
+<card class="border-primary-subtle border mb-2">
 	<cardheader>
 		<h4 class="mt-2">
 			#@Model.Id <span condition="Model.Hidden"><i>(unlisted)</i> </span>- @Model.Title
@@ -74,13 +74,13 @@
 			<wiki-markup markup=@Model.Description></wiki-markup>
 		</div>
 	</cardbody>
-</div>
+</card>
 
 <div condition="!string.IsNullOrWhiteSpace(Model.Annotations)" class="mb-2">
 	<card class="border-primary-subtle border mb-2">
 		<cardheader><h4>Annotations</h4></cardheader>
 		<cardbody>
-			<pre style="white-space: pre-wrap">@Model.Annotations</pre>
+			<pre class="annotations-text">@Model.Annotations</pre>
 		</cardbody>
 	</card>
 </div>
@@ -91,7 +91,7 @@
 <div condition="!Model.HideComments">
 	@foreach (var comment in Model.Comments.OrderBy(c => c.CreationTimeStamp))
 	{
-		<div class="card border-primary-subtle border mb-2" condition="@(Model.Comments.Any())">
+		<card class="border-primary-subtle border mb-2" condition="@(Model.Comments.Any())">
 			<cardheader>
 				<row>
 					<div class="col">
@@ -137,10 +137,10 @@
 					</form>
 				</div>
 			</cardbody>
-		</div>
+		</card>
 	}
 
-	<div class="card border-primary-subtle border mb-2" permission="CreateForumPosts">
+	<card class="border-primary-subtle border mb-2" permission="CreateForumPosts">
 		<cardheader>
 			<h4>Comment:</h4>
 		</cardheader>
@@ -152,5 +152,11 @@
 				<button type="submit" class="btn btn-primary mt-3 mb-3"><i class="fa fa-plus"></i> Post</button>
 			</form>
 		</cardbody>
-	</div>
+	</card>
 </div>
+
+<style>
+	.annotations-text {
+		white-space: pre-wrap;
+	}
+</style>

--- a/TASVideos/Pages/Shared/_UserFileInfo.cshtml
+++ b/TASVideos/Pages/Shared/_UserFileInfo.cshtml
@@ -77,12 +77,12 @@
 </div>
 
 <div condition="!string.IsNullOrWhiteSpace(Model.Annotations)" class="mb-2">
-	<div class="card border-primary-subtle border mb-2">
+	<card class="border-primary-subtle border mb-2">
 		<cardheader><h4>Annotations</h4></cardheader>
 		<cardbody>
 			<pre style="white-space: pre-wrap">@Model.Annotations</pre>
 		</cardbody>
-	</div>
+	</card>
 </div>
 
 <div condition="!string.IsNullOrWhiteSpace(Model.ContentPreview)">

--- a/TASVideos/Pages/Submissions/View.cshtml
+++ b/TASVideos/Pages/Submissions/View.cshtml
@@ -183,8 +183,9 @@
 					<i class="fa fa-chevron-circle-down"></i> Annotations
 				</a>
 			</label>
-			<pre id="collapse-content-annotations" class="collapse">
-				@Model.Submission.Annotations
+			<pre id="collapse-content-annotations"
+				 class="collapse"
+				 style="white-space: pre-wrap">@Model.Submission.Annotations
 			</pre>
 		</div>
 


### PR DESCRIPTION
they are not code (aside from a few samples) so people format them as normal text and we don't want to avoid line wrapping, yet we want to avoid parsing them as our wiki

fixed 4 tabs in front of annotations

added `pre` and proper border for userfile annotations card

fix #1744