### PR TITLE
Implement text for wikiLink module

### DIFF
--- a/TASVideos.WikiEngine/NodeImplementations.cs
+++ b/TASVideos.WikiEngine/NodeImplementations.cs
@@ -464,8 +464,16 @@ public class Module : INode
 		// to the end user.  TODO:  __wikiLink really needs to be its own AST type.
 		if (Name == "__wikiLink")
 		{
-			Parameters.TryGetValue("displaytext", out var ret);
-			return ret ?? "";
+			if (Parameters.TryGetValue("displaytext", out var displaytext))
+			{
+				return displaytext;
+			}
+			else if (Parameters.TryGetValue("href", out var href))
+			{
+				return href[1..];
+			}
+
+			return "";
 		}
 
 		return "";
@@ -492,8 +500,9 @@ public class Module : INode
 		// See comment above
 		if (Name == "__wikiLink")
 		{
-			Parameters.TryGetValue("displaytext", out var content);
-			return new[] { new Text(CharStart, content ?? "") { CharEnd = CharEnd } };
+			Parameters.TryGetValue("displaytext", out var displaytext);
+			Parameters.TryGetValue("href", out var href);
+			return new[] { new Text(CharStart, displaytext ?? href?[1..] ?? "") { CharEnd = CharEnd } };
 		}
 
 		return Enumerable.Empty<INode>();

--- a/TASVideos/ViewComponents/WikiLink.cs
+++ b/TASVideos/ViewComponents/WikiLink.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using TASVideos.Core.Services.Wiki;
 using TASVideos.Data;
 using TASVideos.Data.Helpers;
 using TASVideos.WikiEngine;
@@ -6,6 +7,7 @@ using TASVideos.WikiEngine;
 namespace TASVideos.ViewComponents;
 
 [WikiModule(WikiModules.WikiLink)]
+[TextModule]
 public class WikiLink : ViewComponent
 {
 	private readonly ApplicationDbContext _db;
@@ -16,6 +18,17 @@ public class WikiLink : ViewComponent
 	}
 
 	public async Task<IViewComponentResult> InvokeAsync(string href, string? displayText)
+	{
+		return View(await InvokeInternal(href, displayText));
+	}
+
+	public async Task<string> RenderTextAsync(IWikiPage? pageData, string href, string? displayText)
+	{
+		WikiLinkModel wikiLinkModel = await InvokeInternal(href, displayText);
+		return wikiLinkModel.DisplayText;
+	}
+
+	private async Task<WikiLinkModel> InvokeInternal(string href, string? displayText)
 	{
 		int? id;
 		string? titleText = null;
@@ -63,12 +76,12 @@ public class WikiLink : ViewComponent
 			displayText = href[1..];
 		}
 
-		return View(new WikiLinkModel
+		return new WikiLinkModel
 		{
 			Href = href,
 			DisplayText = displayText,
 			Title = titleText,
-		});
+		};
 	}
 
 	private async Task<string?> GetPublicationTitle(int id)


### PR DESCRIPTION
Resolves #1760 . (Text missing from Youtube Descriptions)
Also resolves Text missing from TOC, which is a different method.

This implements InnerText of __wikiLinks being href if displaytext is empty. (For TOCs)
It also implements RenderTextAsync by using the same method as InvokeAsync, but only taking the display name. (For Youtube)

**NOTE**: One problem remaining is that on YouTube, the wiki links won't be a link, only text. That's because I can't format it into the `displaytext ( href )` format, as with links, because I don't have the `writerHelper` that is used to convert the href to a full url. Trying to inject it gives `System.InvalidOperationException: Unable to resolve service for type 'TASVideos.WikiEngine.AST.IWriterHelper' while attempting to activate 'TASVideos.ViewComponents.WikiLink'.`

However, a non-link is better than no text at all.