### PR TITLE
Normalize tab-pane

### DIFF
--- a/TASVideos.WikiEngine/MakeTabs.cs
+++ b/TASVideos.WikiEngine/MakeTabs.cs
@@ -44,7 +44,7 @@ public static partial class Builtins
 								new Text(child.CharStart, child.Attributes["data-name"])
 							})
 				}));
-			content.Add(new Element(child.CharStart, "div", new[] { Attr("id", id), Attr("class", "tab-pane" + (first ? " active" : " fade")) }, child.Children));
+			content.Add(new Element(child.CharStart, "div", new[] { Attr("id", id), Attr("class", "tab-pane fade" + (first ? " active show" : "")) }, child.Children));
 			first = false;
 		}
 

--- a/TASVideos/Pages/Games/Index.cshtml
+++ b/TASVideos/Pages/Games/Index.cshtml
@@ -104,7 +104,7 @@
 	<div class="tab-content">
 		@foreach (var movie in Model.Movies)
 		{
-			<div id="tab-@(movie.Movie.Id)M" class="tab-pane@(movie==Model.Movies.First() ? " active" : " fade")">
+			<div id="tab-@(movie.Movie.Id)M" class="tab-pane fade@(movie==Model.Movies.First() ? " active show" : "")">
 				<partial name="Components/DisplayMiniMovie/Default" model="movie.Movie" />
 			</div>
 		}

--- a/TASVideos/Pages/Shared/_Ratings.cshtml
+++ b/TASVideos/Pages/Shared/_Ratings.cshtml
@@ -27,7 +27,7 @@
 
 	<!-- Tab panes -->
 	<div class="tab-content">
-		<div role="tabpanel" class="tab-pane active" id="current">
+		<div role="tabpanel" class="tab-pane fade active show" id="current">
 			<table class="table table-bordered">
 				<tr>
 					<th>Movie</th>
@@ -42,7 +42,7 @@
 				}
 			</table>
 		</div>
-		<div role="tabpanel" class="tab-pane" id="obsolete">
+		<div role="tabpanel" class="tab-pane fade" id="obsolete">
 			<table class="table table-bordered">
 				<tr>
 					<th>Movie</th>


### PR DESCRIPTION
Currently the fade doesn't work on the first tab of any of our wiki tabs.
E.g. currently on the Publications on https://tasvideos.org/1G try clicking the second tab and notice the fade, then click on the first tab and notice the lack of fade.

This PR normalizes the behavior so every tab works the same.
If we ever want to remove the fade we just need to remove `fade` from every `tab-pane`.