### PR TITLE
Migration after .NET 8 update

### DIFF
--- a/TASVideos.Data/Migrations/20240207204032_DotNet8Update.Designer.cs
+++ b/TASVideos.Data/Migrations/20240207204032_DotNet8Update.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using TASVideos.Data;
 namespace TASVideos.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240207204032_DotNet8Update")]
+    partial class DotNet8Update
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TASVideos.Data/Migrations/20240207204032_DotNet8Update.cs
+++ b/TASVideos.Data/Migrations/20240207204032_DotNet8Update.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TASVideos.Data.Migrations;
+
+/// <inheritdoc />
+public partial class DotNet8Update : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropForeignKey(
+			name: "fk_forum_topics_submissions_submission_id1",
+			table: "forum_topics");
+
+		migrationBuilder.AddForeignKey(
+			name: "fk_forum_topics_submissions_submission_id",
+			table: "forum_topics",
+			column: "submission_id",
+			principalTable: "submissions",
+			principalColumn: "id");
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropForeignKey(
+			name: "fk_forum_topics_submissions_submission_id",
+			table: "forum_topics");
+
+		migrationBuilder.AddForeignKey(
+			name: "fk_forum_topics_submissions_submission_id1",
+			table: "forum_topics",
+			column: "submission_id",
+			principalTable: "submissions",
+			principalColumn: "id");
+	}
+}


### PR DESCRIPTION
This runs a migration generation without any changes to our model. Due to the various updates to .NET 8, one foreign key is to be renamed.
The Snapshot also changes some numerics to decimals, but I suppose EF Core didn't make a migration because [both types are equivalent in PostgreSQL](https://www.postgresql.org/docs/current/datatype-numeric.html).