### PR TITLE
improve goal editing

### DIFF
--- a/TASVideos/Pages/Games/Goals/List.cshtml
+++ b/TASVideos/Pages/Games/Goals/List.cshtml
@@ -22,12 +22,15 @@
 		.ThenBy(g => g.DisplayName))
 	{
 		var canDelete = !goal.Publications.Any() && !goal.Submissions.Any();
-		<tr>
+		<tr id="@goal.Id">
 			<td condition="@(goal.Id == Model.GoalToEdit && goal.DisplayName != "baseline")">
 				<form method="post" class="d-flex gap-2" asp-page-handler="Edit">
-					<input type="hidden" name="gameGoalId" value="@Model.GoalToEdit" />
-					<input type="text" name="newGoalName" class="form-control" value="@goal.DisplayName" />
-					<button type="submit" class="btn btn-secondary">Save</button>
+					<column>
+						<input type="hidden" name="gameGoalId" value="@Model.GoalToEdit" />
+						<input type="text" name="newGoalName" class="form-control" value="@goal.DisplayName" />
+						<button type="submit" class="btn btn-primary btn-sm mt-1"><i class="fa fa-save"></i> Save</button>
+						<a asp-page="List" asp-fragment="@goal.Id" asp-route-gameId="@Model.GameId" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-times"></i> Cancel</a>
+					</column>
 				</form>
 			</td>
 			<td condition="@(goal.Id != Model.GoalToEdit || goal.DisplayName == "baseline")">
@@ -57,7 +60,15 @@
 			</td>
 			<td>
 				<div class="btn-toolbar">
-					<a asp-page="List" asp-route-goalToEdit="@goal.Id" permission="CatalogMovies" condition="@(goal.Id != Model.GoalToEdit && goal.DisplayName != "baseline")" asp-route-gameId="@Model.GameId" class="btn btn-sm btn-primary"><i class="fa fa-pencil"></i> Edit</a>
+					<a asp-page="List"
+					   asp-fragment="@goal.Id"
+					   asp-route-gameId="@Model.GameId"
+					   asp-route-goalToEdit="@goal.Id"
+					   permission="CatalogMovies"
+					   condition="@(goal.Id != Model.GoalToEdit && goal.DisplayName != "baseline")"
+					   class="btn btn-sm btn-primary">
+					   <i class="fa fa-pencil"></i> Edit
+					</a>
 					<a condition="canDelete" asp-page-handler="Delete" asp-route-gameGroupId="@goal.Id" class="btn btn-sm btn-danger"><i class="fa fa-remove"></i> Delete</a>
 				</div>
 			</td>

--- a/TASVideos/Pages/Games/Goals/List.cshtml
+++ b/TASVideos/Pages/Games/Goals/List.cshtml
@@ -22,14 +22,14 @@
 		.ThenBy(g => g.DisplayName))
 	{
 		var canDelete = !goal.Publications.Any() && !goal.Submissions.Any();
-		<tr id="row-@goal.Id">
+		<tr id="goal-@goal.Id">
 			<td condition="@(goal.Id == Model.GoalToEdit && goal.DisplayName != "baseline")">
 				<form method="post" class="d-flex gap-2" asp-page-handler="Edit">
 					<full-row>
 						<input type="hidden" name="gameGoalId" value="@Model.GoalToEdit" />
 						<input type="text" name="newGoalName" class="form-control" value="@goal.DisplayName" />
 						<button type="submit" class="btn btn-primary btn-sm mt-1"><i class="fa fa-save"></i> Save</button>
-						<a asp-page="List" asp-fragment="row-@goal.Id" asp-route-gameId="@Model.GameId" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-times"></i> Cancel</a>
+						<a asp-page="List" asp-fragment="goal-@goal.Id" asp-route-gameId="@Model.GameId" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-times"></i> Cancel</a>
 					</full-row>
 				</form>
 			</td>
@@ -61,7 +61,7 @@
 			<td>
 				<div class="btn-toolbar">
 					<a asp-page="List"
-					   asp-fragment="row-@goal.Id"
+					   asp-fragment="goal-@goal.Id"
 					   asp-route-gameId="@Model.GameId"
 					   asp-route-goalToEdit="@goal.Id"
 					   permission="CatalogMovies"

--- a/TASVideos/Pages/Games/Goals/List.cshtml
+++ b/TASVideos/Pages/Games/Goals/List.cshtml
@@ -22,14 +22,14 @@
 		.ThenBy(g => g.DisplayName))
 	{
 		var canDelete = !goal.Publications.Any() && !goal.Submissions.Any();
-		<tr id="@goal.Id">
+		<tr id="row-@goal.Id">
 			<td condition="@(goal.Id == Model.GoalToEdit && goal.DisplayName != "baseline")">
 				<form method="post" class="d-flex gap-2" asp-page-handler="Edit">
 					<full-row>
 						<input type="hidden" name="gameGoalId" value="@Model.GoalToEdit" />
 						<input type="text" name="newGoalName" class="form-control" value="@goal.DisplayName" />
 						<button type="submit" class="btn btn-primary btn-sm mt-1"><i class="fa fa-save"></i> Save</button>
-						<a asp-page="List" asp-fragment="@goal.Id" asp-route-gameId="@Model.GameId" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-times"></i> Cancel</a>
+						<a asp-page="List" asp-fragment="row-@goal.Id" asp-route-gameId="@Model.GameId" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-times"></i> Cancel</a>
 					</full-row>
 				</form>
 			</td>
@@ -61,7 +61,7 @@
 			<td>
 				<div class="btn-toolbar">
 					<a asp-page="List"
-					   asp-fragment="@goal.Id"
+					   asp-fragment="row-@goal.Id"
 					   asp-route-gameId="@Model.GameId"
 					   asp-route-goalToEdit="@goal.Id"
 					   permission="CatalogMovies"

--- a/TASVideos/Pages/Games/Goals/List.cshtml
+++ b/TASVideos/Pages/Games/Goals/List.cshtml
@@ -25,12 +25,12 @@
 		<tr id="@goal.Id">
 			<td condition="@(goal.Id == Model.GoalToEdit && goal.DisplayName != "baseline")">
 				<form method="post" class="d-flex gap-2" asp-page-handler="Edit">
-					<column>
+					<full-row>
 						<input type="hidden" name="gameGoalId" value="@Model.GoalToEdit" />
 						<input type="text" name="newGoalName" class="form-control" value="@goal.DisplayName" />
 						<button type="submit" class="btn btn-primary btn-sm mt-1"><i class="fa fa-save"></i> Save</button>
 						<a asp-page="List" asp-fragment="@goal.Id" asp-route-gameId="@Model.GameId" class="btn btn-secondary btn-sm mt-1"><i class="fa fa-times"></i> Cancel</a>
-					</column>
+					</full-row>
 				</form>
 			</td>
 			<td condition="@(goal.Id != Model.GoalToEdit || goal.DisplayName == "baseline")">

--- a/TASVideos/wwwroot/js/catalog.js
+++ b/TASVideos/wwwroot/js/catalog.js
@@ -65,6 +65,6 @@
 	}
 
 	gameGoalBtn.onclick = function () {
-		document.location = `/Games/${gameModel.value}/Goals/List?goalToEdit=${gameGoalModel.value}&returnUrl=${returnUrl}`;
+		document.location = `/Games/${gameModel.value}/Goals/List?returnUrl=${returnUrl}`;
 	}
 }


### PR DESCRIPTION
- scroll to goal we're editing
- add cancel button
- move buttons to the next row and make them small (buttons on the same row as text field makes the field text barely readable)
- don't pass goalToEdit when hitting Manage button (having to manage means we need a new goal, and only very rarely we need to edit an existing one, which should not be encouraged by UI as a default action)

before

![изображение](https://github.com/TASVideos/tasvideos/assets/7092625/a6dc9ec7-ab6a-4af7-8dd7-d90b4426c921)

after

![изображение](https://github.com/TASVideos/tasvideos/assets/7092625/c4cc6677-3610-409e-8142-31be2800d37d)
