### PR TITLE
Fix memory cache values never expiring

### DIFF
--- a/TASVideos.Core/Services/Cache/MemoryCacheService.cs
+++ b/TASVideos.Core/Services/Cache/MemoryCacheService.cs
@@ -26,8 +26,6 @@ public class MemoryCacheService : ICacheService
 
 	public void Set(string key, object? data, int? cacheTime)
 	{
-		using var entry = _cache.CreateEntry(key);
-		entry.Value = data;
 		_cache.Set(key, data, new TimeSpan(0, 0, cacheTime ?? _settings.CacheSettings.CacheDurationInSeconds));
 	}
 }


### PR DESCRIPTION
Calling `CreateEntry` and calling `Set` is not correct.
Either we fully set the entry manually without `Set`, or we *only* use `Set`.