### PR TITLE
implement custom localization

### DIFF
--- a/TASVideos.Common/Constants.cs
+++ b/TASVideos.Common/Constants.cs
@@ -24,6 +24,8 @@ public static class CacheKeys
 	public const string AwardsCache = "AwardsCache";
 	public const string UnreadMessageCount = "UnreadMessageCountCache-";
 	public const string MovieTokens = "MovieTokenData";
+	public const string UsersWithCustomLocale = "UsersWithCustomLocale";
+	public const string CustomUserLocalePrefix = "CustomUserLocale-";
 }
 
 // These perform site functions, maybe they should be in the database?

--- a/TASVideos.Core/Services/UserManager.cs
+++ b/TASVideos.Core/Services/UserManager.cs
@@ -550,4 +550,10 @@ public class UserManager : UserManager<User>
 
 		return true;
 	}
+
+	public void ClearCustomLocaleCache(int userId)
+	{
+		_cache.Remove(CacheKeys.UsersWithCustomLocale);
+		_cache.Remove(CacheKeys.CustomUserLocalePrefix + userId);
+	}
 }

--- a/TASVideos.Data/Entity/User.cs
+++ b/TASVideos.Data/Entity/User.cs
@@ -75,6 +75,10 @@ public class User : IdentityUser<int>, ITrackable
 
 	public UserPreference? AutoWatchTopic { get; set; }
 
+	public UserDateFormat DateFormat { get; set; } = UserDateFormat.Auto;
+	public UserTimeFormat TimeFormat { get; set; } = UserTimeFormat.Auto;
+	public UserDecimalFormat DecimalFormat { get; set; } = UserDecimalFormat.Auto;
+
 	public virtual ICollection<UserRole> UserRoles { get; set; } = new HashSet<UserRole>();
 	public virtual ICollection<SubmissionAuthor> Submissions { get; set; } = new HashSet<SubmissionAuthor>();
 	public virtual ICollection<PublicationAuthor> Publications { get; set; } = new HashSet<PublicationAuthor>();
@@ -130,6 +134,54 @@ public enum PreferredPronounTypes
 	Other
 }
 
+public enum UserDateFormat
+{
+	[Display(Name = "Automatic")]
+	Auto = 0,
+
+	[Display(Name = "yyyy-MM-dd (2024-02-29)")]
+	YMMDD,
+
+	[Display(Name = "dd/MM/yyyy (29/02/2024)")]
+	DDMMY,
+
+	[Display(Name = "dd.MM.yyyy (29.02.2024)")]
+	DDMMYDot,
+
+	[Display(Name = "d/M/yyyy (29/2/2024)")]
+	DMY,
+
+	[Display(Name = "MM/dd/yyyy (02/29/2024)")]
+	MMDDY,
+
+	[Display(Name = "M/d/yyyy (2/29/2024)")]
+	MDY,
+}
+
+public enum UserTimeFormat
+{
+	[Display(Name = "Automatic")]
+	Auto = 0,
+
+	[Display(Name = "24-hour clock (17:35)")]
+	Clock24Hour,
+
+	[Display(Name = "12-hour clock (5:35 PM)")]
+	Clock12Hour
+}
+
+public enum UserDecimalFormat
+{
+	[Display(Name = "Automatic")]
+	Auto = 0,
+
+	[Display(Name = "Dot (1.23)")]
+	Dot,
+
+	[Display(Name = "Comma (1,23)")]
+	Comma
+}
+
 public static class UserExtensions
 {
 	public static async Task<bool> Exists(this IQueryable<User> query, string userName)
@@ -167,5 +219,10 @@ public static class UserExtensions
 	public static IQueryable<User> ForUsers(this IQueryable<User> query, IEnumerable<string> users)
 	{
 		return query.Where(u => users.Contains(u.UserName));
+	}
+
+	public static IQueryable<User> ThatHaveCustomLocale(this IQueryable<User> query)
+	{
+		return query.Where(u => u.DateFormat != UserDateFormat.Auto || u.TimeFormat != UserTimeFormat.Auto || u.DecimalFormat != UserDecimalFormat.Auto);
 	}
 }

--- a/TASVideos.Data/Migrations/20240228201932_AddUserLocaleSettings.Designer.cs
+++ b/TASVideos.Data/Migrations/20240228201932_AddUserLocaleSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using TASVideos.Data;
 namespace TASVideos.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240228201932_AddUserLocaleSettings")]
+    partial class AddUserLocaleSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TASVideos.Data/Migrations/20240228201932_AddUserLocaleSettings.cs
+++ b/TASVideos.Data/Migrations/20240228201932_AddUserLocaleSettings.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TASVideos.Data.Migrations;
+
+/// <inheritdoc />
+public partial class AddUserLocaleSettings : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.AddColumn<int>(
+			name: "date_format",
+			table: "users",
+			type: "integer",
+			nullable: false,
+			defaultValue: 0);
+
+		migrationBuilder.AddColumn<int>(
+			name: "decimal_format",
+			table: "users",
+			type: "integer",
+			nullable: false,
+			defaultValue: 0);
+
+		migrationBuilder.AddColumn<int>(
+			name: "time_format",
+			table: "users",
+			type: "integer",
+			nullable: false,
+			defaultValue: 0);
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropColumn(
+			name: "date_format",
+			table: "users");
+
+		migrationBuilder.DropColumn(
+			name: "decimal_format",
+			table: "users");
+
+		migrationBuilder.DropColumn(
+			name: "time_format",
+			table: "users");
+	}
+}

--- a/TASVideos/Middleware/CustomLocalizationMiddleware.cs
+++ b/TASVideos/Middleware/CustomLocalizationMiddleware.cs
@@ -1,0 +1,131 @@
+﻿using System.Globalization;
+using TASVideos.Core.Services;
+using TASVideos.Data;
+using TASVideos.Data.Entity;
+
+namespace TASVideos.Middleware;
+
+public class CustomLocalizationMiddleware
+{
+	private readonly RequestDelegate _next;
+
+	public CustomLocalizationMiddleware(RequestDelegate next)
+	{
+		_next = next;
+	}
+
+	public async Task Invoke(HttpContext context, ApplicationDbContext db, ICacheService cache)
+	{
+		if (context.User.IsLoggedIn())
+		{
+			if (!cache.TryGetValue(CacheKeys.UsersWithCustomLocale, out HashSet<string> usersWithCustomLocale))
+			{
+				usersWithCustomLocale = (await db.Users
+					.ThatHaveCustomLocale()
+					.Select(u => u.UserName)
+					.ToListAsync())
+					.ToHashSet();
+				cache.Set(CacheKeys.UsersWithCustomLocale, usersWithCustomLocale, Durations.OneYearInSeconds);
+			}
+
+			if (usersWithCustomLocale.Contains(context.User.Name()))
+			{
+				int userId = context.User.GetUserId();
+
+				if (!cache.TryGetValue(CacheKeys.CustomUserLocalePrefix + userId, out CultureInfo customCultureInfo))
+				{
+					CustomCultureData? customCultureData = await db.Users
+						.Where(u => u.Id == userId)
+						.Select(u => new CustomCultureData
+						{
+							DateFormat = u.DateFormat,
+							TimeFormat = u.TimeFormat,
+							DecimalFormat = u.DecimalFormat,
+						})
+						.SingleOrDefaultAsync();
+					customCultureInfo = ConstructCustomCulture(customCultureData);
+					cache.Set(CacheKeys.CustomUserLocalePrefix + userId, customCultureInfo, Durations.OneYearInSeconds);
+				}
+
+				CultureInfo.CurrentCulture = customCultureInfo;
+			}
+		}
+
+		await _next(context);
+	}
+
+	private class CustomCultureData
+	{
+		public UserDateFormat DateFormat { get; set; }
+		public UserTimeFormat TimeFormat { get; set; }
+		public UserDecimalFormat DecimalFormat { get; set; }
+	}
+
+	private CultureInfo ConstructCustomCulture(CustomCultureData? customCultureData)
+	{
+		if (customCultureData == null)
+		{
+			return CultureInfo.CurrentCulture;
+		}
+
+		CultureInfo cultureInfo = (CultureInfo)CultureInfo.CurrentCulture.Clone(); // clone to make it editable
+		switch (customCultureData.DateFormat)
+		{
+			default:
+			case UserDateFormat.Auto:
+				break;
+			case UserDateFormat.YMMDD:
+				cultureInfo.DateTimeFormat.ShortDatePattern = "yyyy-MM-dd";
+				break;
+			case UserDateFormat.DDMMY:
+				cultureInfo.DateTimeFormat.ShortDatePattern = @"dd\/MM\/yyyy";
+				break;
+			case UserDateFormat.DDMMYDot:
+				cultureInfo.DateTimeFormat.ShortDatePattern = "dd.MM.yyyy";
+				break;
+			case UserDateFormat.DMY:
+				cultureInfo.DateTimeFormat.ShortDatePattern = @"d\/M\/yyyy";
+				break;
+			case UserDateFormat.MMDDY:
+				cultureInfo.DateTimeFormat.ShortDatePattern = @"MM\/dd\/yyyy";
+				break;
+			case UserDateFormat.MDY:
+				cultureInfo.DateTimeFormat.ShortDatePattern = @"M\/d\/yyyy";
+				break;
+		}
+
+		switch (customCultureData.TimeFormat)
+		{
+			default:
+			case UserTimeFormat.Auto:
+				break;
+			case UserTimeFormat.Clock24Hour:
+				cultureInfo.DateTimeFormat.ShortTimePattern = @"HH\:mm";
+				cultureInfo.DateTimeFormat.LongTimePattern = @"HH\:mm\:ss";
+				break;
+			case UserTimeFormat.Clock12Hour:
+				cultureInfo.DateTimeFormat.AMDesignator = "AM";
+				cultureInfo.DateTimeFormat.PMDesignator = "PM";
+				cultureInfo.DateTimeFormat.ShortTimePattern = @"h\:mm tt";
+				cultureInfo.DateTimeFormat.LongTimePattern = @"h\:mm\:ss tt";
+				break;
+		}
+
+		switch (customCultureData.DecimalFormat)
+		{
+			default:
+			case UserDecimalFormat.Auto:
+				break;
+			case UserDecimalFormat.Dot:
+				cultureInfo.NumberFormat.NumberDecimalSeparator = ".";
+				cultureInfo.NumberFormat.NumberGroupSeparator = ",";
+				break;
+			case UserDecimalFormat.Comma:
+				cultureInfo.NumberFormat.NumberDecimalSeparator = ",";
+				cultureInfo.NumberFormat.NumberGroupSeparator = ".";
+				break;
+		}
+
+		return cultureInfo;
+	}
+}

--- a/TASVideos/Pages/Profile/Models/ProfileSettingsModel.cs
+++ b/TASVideos/Pages/Profile/Models/ProfileSettingsModel.cs
@@ -42,5 +42,14 @@ public class ProfileSettingsModel
 	[Display(Name = "Automatically Watch Topics When Posting")]
 	public UserPreference AutoWatchTopic { get; set; }
 
+	[Display(Name = "Date Format")]
+	public UserDateFormat UserDateFormat { get; set; }
+
+	[Display(Name = "Time Format")]
+	public UserTimeFormat UserTimeFormat { get; set; }
+
+	[Display(Name = "Decimal Format")]
+	public UserDecimalFormat UserDecimalFormat { get; set; }
+
 	public IEnumerable<RoleDto> Roles { get; set; } = new List<RoleDto>();
 }

--- a/TASVideos/Pages/Profile/Settings.cshtml
+++ b/TASVideos/Pages/Profile/Settings.cshtml
@@ -75,8 +75,9 @@
 		</column>
 		<column lg="6">
 			<fieldset>
-				<label asp-for="Settings.TimeZoneId"></label>
-				<timezone-picker asp-for="Settings.TimeZoneId" class="form-select" />
+				<label asp-for="Settings.PreferredPronouns"></label>
+				<select asp-for="Settings.PreferredPronouns" asp-items="@SettingsModel.AvailablePronouns" class="form-select"></select>
+				<span asp-validation-for="Settings.PreferredPronouns"></span>
 			</fieldset>
 			<fieldset>
 				<label asp-for="Settings.From"></label>
@@ -84,9 +85,30 @@
 				<span asp-validation-for="Settings.From"></span>
 			</fieldset>
 			<fieldset>
-				<label asp-for="Settings.PreferredPronouns"></label>
-				<select asp-for="Settings.PreferredPronouns" asp-items="@SettingsModel.AvailablePronouns" class="form-select"></select>
-				<span asp-validation-for="Settings.PreferredPronouns"></span>
+				<label asp-for="Settings.TimeZoneId"></label>
+				<timezone-picker asp-for="Settings.TimeZoneId" class="form-select" />
+			</fieldset>
+			@{
+				DateTime exampleDate = new DateTime(2024, 2, 29, 17, 35, 0);
+				double exampleNumber = 1.23;
+			}
+			<fieldset>
+				<label asp-for="Settings.UserDateFormat"></label>
+				<label condition="@Model.Settings.UserDateFormat == UserDateFormat.Auto" asp-for="Settings.UserDateFormat" class="text-body-tertiary">(Currently: @exampleDate.ToShortDateString())</label>
+				<select asp-for="Settings.UserDateFormat" asp-items="@SettingsModel.AvailableDateFormats" class="form-select"></select>
+				<span asp-validation-for="Settings.UserDateFormat"></span>
+			</fieldset>
+			<fieldset>
+				<label asp-for="Settings.UserTimeFormat"></label>
+				<label condition="@Model.Settings.UserTimeFormat == UserTimeFormat.Auto" asp-for="Settings.UserTimeFormat" class="text-body-tertiary">(Currently: @exampleDate.ToShortTimeString())</label>
+				<select asp-for="Settings.UserTimeFormat" asp-items="@SettingsModel.AvailableTimeFormats" class="form-select"></select>
+				<span asp-validation-for="Settings.UserTimeFormat"></span>
+			</fieldset>
+			<fieldset>
+				<label asp-for="Settings.UserDecimalFormat"></label>
+				<label condition="@Model.Settings.UserDecimalFormat == UserDecimalFormat.Auto"  asp-for="Settings.UserDecimalFormat" class="text-body-tertiary">(Currently: @exampleNumber)</label>
+				<select asp-for="Settings.UserDecimalFormat" asp-items="@SettingsModel.AvailableDecimalFormats" class="form-select"></select>
+				<span asp-validation-for="Settings.UserDecimalFormat"></span>
 			</fieldset>
 		</column>
 	</row>
@@ -116,28 +138,6 @@
 		<small>
 			@await Component.RenderWiki(SystemWiki.MoodAvatarRequirements)
 		</small>
-	</fullrow>
-	@{
-		DateTime exampleDate = new DateTime(2024, 2, 29, 17, 35, 0);
-		double exampleNumber = 1.23;
-	}
-	<fullrow class="mt-3">
-		<label asp-for="Settings.UserDateFormat"></label>
-		<label condition="@Model.Settings.UserDateFormat == UserDateFormat.Auto" asp-for="Settings.UserDateFormat" class="text-body-tertiary">(Currently: @exampleDate.ToShortDateString())</label>
-		<select asp-for="Settings.UserDateFormat" asp-items="@SettingsModel.AvailableDateFormats" class="form-select"></select>
-		<span asp-validation-for="Settings.UserDateFormat"></span>
-	</fullrow>
-	<fullrow class="mt-3">
-		<label asp-for="Settings.UserTimeFormat"></label>
-		<label condition="@Model.Settings.UserTimeFormat == UserTimeFormat.Auto" asp-for="Settings.UserTimeFormat" class="text-body-tertiary">(Currently: @exampleDate.ToShortTimeString())</label>
-		<select asp-for="Settings.UserTimeFormat" asp-items="@SettingsModel.AvailableTimeFormats" class="form-select"></select>
-		<span asp-validation-for="Settings.UserTimeFormat"></span>
-	</fullrow>
-	<fullrow class="mt-3">
-		<label asp-for="Settings.UserDecimalFormat"></label>
-		<label condition="@Model.Settings.UserDecimalFormat == UserDecimalFormat.Auto"  asp-for="Settings.UserDecimalFormat" class="text-body-tertiary">(Currently: @exampleNumber)</label>
-		<select asp-for="Settings.UserDecimalFormat" asp-items="@SettingsModel.AvailableDecimalFormats" class="form-select"></select>
-		<span asp-validation-for="Settings.UserDecimalFormat"></span>
 	</fullrow>
 	<fullrow permission="EditSignature" class="mt-3">
 		<label asp-for="Settings.Signature"></label>

--- a/TASVideos/Pages/Profile/Settings.cshtml
+++ b/TASVideos/Pages/Profile/Settings.cshtml
@@ -117,6 +117,28 @@
 			@await Component.RenderWiki(SystemWiki.MoodAvatarRequirements)
 		</small>
 	</fullrow>
+	@{
+		DateTime exampleDate = new DateTime(2024, 2, 29, 17, 35, 0);
+		double exampleNumber = 1.23;
+	}
+	<fullrow class="mt-3">
+		<label asp-for="Settings.UserDateFormat"></label>
+		<label condition="@Model.Settings.UserDateFormat == UserDateFormat.Auto" asp-for="Settings.UserDateFormat" class="text-body-tertiary">(Currently: @exampleDate.ToShortDateString())</label>
+		<select asp-for="Settings.UserDateFormat" asp-items="@SettingsModel.AvailableDateFormats" class="form-select"></select>
+		<span asp-validation-for="Settings.UserDateFormat"></span>
+	</fullrow>
+	<fullrow class="mt-3">
+		<label asp-for="Settings.UserTimeFormat"></label>
+		<label condition="@Model.Settings.UserTimeFormat == UserTimeFormat.Auto" asp-for="Settings.UserTimeFormat" class="text-body-tertiary">(Currently: @exampleDate.ToShortTimeString())</label>
+		<select asp-for="Settings.UserTimeFormat" asp-items="@SettingsModel.AvailableTimeFormats" class="form-select"></select>
+		<span asp-validation-for="Settings.UserTimeFormat"></span>
+	</fullrow>
+	<fullrow class="mt-3">
+		<label asp-for="Settings.UserDecimalFormat"></label>
+		<label condition="@Model.Settings.UserDecimalFormat == UserDecimalFormat.Auto"  asp-for="Settings.UserDecimalFormat" class="text-body-tertiary">(Currently: @exampleNumber)</label>
+		<select asp-for="Settings.UserDecimalFormat" asp-items="@SettingsModel.AvailableDecimalFormats" class="form-select"></select>
+		<span asp-validation-for="Settings.UserDecimalFormat"></span>
+	</fullrow>
 	<fullrow permission="EditSignature" class="mt-3">
 		<label asp-for="Settings.Signature"></label>
 		<textarea asp-for="Settings.Signature" class="form-control" rows="5" disabled="@(!User.Has(PermissionTo.EditSignature))"></textarea>

--- a/TASVideos/Startup.cs
+++ b/TASVideos/Startup.cs
@@ -2,6 +2,7 @@
 using TASVideos.Core;
 using TASVideos.Core.Settings;
 using TASVideos.Data;
+using TASVideos.Middleware;
 using TASVideos.Services;
 
 namespace TASVideos;
@@ -65,6 +66,7 @@ public class Startup
 			.UseWebOptimizer()
 			.UseStaticFilesWithExtensionMapping()
 			.UseAuthentication()
+			.UseMiddleware<CustomLocalizationMiddleware>()
 			.UseSwaggerUi(Environment)
 			.UseLogging()
 			.UseMvcWithOptions(env);

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -107,7 +107,7 @@ h4 {
 	}
 }
 
-.form-control {
+.form-control, .form-select {
 	font-size: .875rem;
 
 	&:disabled, &[readonly] {


### PR DESCRIPTION
This PR needs to be checked properly.

Resolves #908 .

It implements 3 user settings to customize the date format, the time format, and the decimal number format (see images below).

## Implementation Details
I build a custom CultureInfo, and then, in **every single request** overwrite CultureInfo.CurrentCulture as soon as possible. By using Middleware.

### Middleware Location
Where to place the Middleware? We actually use the `UseRequestLocalization()` middleware to let .NET select the best culture initially. So I thought immediately afterwards would be a good place to place my overwrite middleware. But it turns out I need the User object, so `UseAuthentication` has to run first. That's why I placed it directly after that.

### Caching
Caching is critical. We don't want to read the DB on every request just for the locale. The first idea was to just cache each user's CultureInfo. This alone would work, but there are two Problems:
1. On every restart the cache is cleared, and each user will do one additional DB call to get their CultureInfo build, again and again.
2. Most users don't use custom cultures, so the cache will be filled with non-modified objects.

That's why I decided to use a second cache. This second cache caches the HashSet of the users that actually use custom locales.

The HashSet cache and the user's own CultureInfo cache is cleared when they change their Profile Settings.

### Hot Path
- **For logged out visitors**: The Middleware checks whether they are logged in. They aren't, so it is skipped.
- **For non-custom-locale users**: After confirming the login, it loads the cached HashSet of custom locale users, and they aren't in there. So it is skipped.
- **For custom-locale users**: After loading the cached HashSet and finding the user, it loads the cached CultureInfo and overwrites the CurrentCulture. Then it is done.

<hr>

![image](https://github.com/TASVideos/tasvideos/assets/22375320/6d2ebf0b-98fc-4572-b189-4a5e96a44752)
