### PR TITLE
Run Migration after Sample Data Generation

### DIFF
--- a/TASVideos.Core/Data/DbInitializer.cs
+++ b/TASVideos.Core/Data/DbInitializer.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.Options;
 using Npgsql;
 using TASVideos.Core.Settings;
 using SharpCompress.Compressors;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace TASVideos.Core.Data;
 
@@ -29,9 +31,13 @@ public static class DbInitializer
 	private static async Task SampleStrategy(DbContext context)
 	{
 		await context.Database.EnsureDeletedAsync();
-		await context.Database.MigrateAsync();
+
+		IRelationalDatabaseCreator creator = context.GetService<IRelationalDatabaseCreator>();
+		await creator.CreateAsync();
 
 		await GenerateDevSampleData(context);
+
+		await context.Database.MigrateAsync();
 
 		// https://github.com/npgsql/npgsql/issues/2366
 		// For NpgSql specifically, if we drop and create SCHEMA while running the application

--- a/TASVideos.Core/Data/DbInitializer.cs
+++ b/TASVideos.Core/Data/DbInitializer.cs
@@ -32,6 +32,7 @@ public static class DbInitializer
 	{
 		await context.Database.EnsureDeletedAsync();
 
+		// create db without filling schema
 		IRelationalDatabaseCreator creator = context.GetService<IRelationalDatabaseCreator>();
 		await creator.CreateAsync();
 

--- a/TASVideos.Data/SampleData/Postgres-PruneFullDbToCreateSampleData.sql
+++ b/TASVideos.Data/SampleData/Postgres-PruneFullDbToCreateSampleData.sql
@@ -6,17 +6,16 @@
 --		Select Plain as the Format
 --		Select UTF8 as the encoding
 --		In the Dump options tab
---			Click data only - Yes
+--			Click data only - No
 --			Schema only - No
 --			Use column inserts - Yes
 --			Use Insert Commands - Yes
 --		Run
---		gzip sample-data.sql.gz and replace temp file
+--		gzip sample-data.sql and replace temp file
 
 DELETE FROM public.ip_bans;
 DELETE FROM public.media_posts;
 DELETE FROM public.user_disallows;
-DELETE FROM public."__EFMigrationsHistory";
 DELETE FROM public.auto_history;
 
 -- Trim user files


### PR DESCRIPTION
For Sample Data Generation, if the code base is on a later migration than the sample data, loading the data gives an error.
This is because we first migrate the sample db to the latest schema with no data, and then try to add the sample data.

This PR changes the code, so that the DB is created without schema, then the schema+data is added from the sample data, and then finally we migrate if necessary.

This also means the schema needs to be exported with the sample data, and the `__EFMigrationsHistory` table needs to stay.