### PR TITLE
Change recaptcha elements for invisible v2 usage

### DIFF
--- a/TASVideos/Pages/Account/EmailConfirmationSent.cshtml
+++ b/TASVideos/Pages/Account/EmailConfirmationSent.cshtml
@@ -7,7 +7,7 @@
 
 @await Component.RenderWiki(SystemWiki.EmailConfirmationSentMessage)
 
-<form method="post">
+<form method="post" id="email-confirmation-form">
 	<row>
 		<column md="6">
 			<fieldset>
@@ -20,14 +20,22 @@
 				<input asp-for="Email" class="form-control" autocomplete="off" />
 				<span asp-validation-for="Email" class="text-danger"></span>
 			</fieldset>
-			<environment exclude="Development">
-				<fieldset>
-					<recaptcha />
-				</fieldset>
-			</environment>
 		</column>
 	</row>
 	<div class="text-center">
-		<button type="submit" class="btn btn-secondary">Resend Confirmation Email</button>
+		<environment exclude="Development">
+			<recaptcha class-name="btn btn-secondary" callback="onSubmit" text="Resend Confirmation Email"/>
+		</environment>
+		<environment include="Development">
+			<button type="submit" class="btn btn-secondary">Resend Confirmation Email</button>
+		</environment>
 	</div>
 </form>
+
+@section Scripts {
+	<script>
+	function onSubmit() {
+		document.getElementById("email-confirmation-form").submit();
+	}
+    </script>
+}

--- a/TASVideos/Pages/Account/EmailConfirmationSent.cshtml
+++ b/TASVideos/Pages/Account/EmailConfirmationSent.cshtml
@@ -37,5 +37,5 @@
 	function onSubmit() {
 		document.getElementById("email-confirmation-form").submit();
 	}
-    </script>
+	</script>
 }

--- a/TASVideos/Pages/Account/Register.cshtml
+++ b/TASVideos/Pages/Account/Register.cshtml
@@ -7,7 +7,7 @@
 <h4>Create a new account.</h4>
 <hr />
 <div asp-validation-summary="All" class="text-danger"></div>
-<form method="post">
+<form method="post" id="register-form">
 	<row>
 		<column md="6">
 			<fieldset>
@@ -53,15 +53,15 @@
 				Also make sure you've read the <a href="/SiteRules">Site Rules</a>.<br/>
 				Your data will be stored according to our <a href="/System/PrivacyPolicy">Privacy Policy</a>.
 			</fieldset>
-			<environment exclude="Development">
-				<fieldset>
-					<recaptcha />
-				</fieldset>
-			</environment>
 		</column>
 	</row>
 	<div class="text-center">
-		<button type="submit" class="btn btn-secondary">Register</button>
+		<environment exclude="Development">
+			<recaptcha class-name="btn btn-secondary" callback="onSubmit" text="Register"/>
+		</environment>
+		<environment include="Development">
+			<button type="submit" class="btn btn-secondary">Register</button>
+		</environment>
 	</div>
 </form>
 
@@ -77,4 +77,9 @@
 			timezone.setAttribute('selected', 'selected');
 		}
 	</script>
+	<script>
+	function onSubmit() {
+		document.getElementById("register-form").submit();
+	}
+    </script>
 }

--- a/TASVideos/Pages/Account/Register.cshtml
+++ b/TASVideos/Pages/Account/Register.cshtml
@@ -81,5 +81,5 @@
 	function onSubmit() {
 		document.getElementById("register-form").submit();
 	}
-    </script>
+	</script>
 }


### PR DESCRIPTION
Server appsettings.json will need to have the recaptcha version changed from `v3` to `v2invisible` for this to make sense.

Fixes issues with people trying to register onto the site but can't due to the v3 score being too low and no puzzle fallback is in place (and can't be in place for v3 due to the library limitations).
