### PR TITLE
Change the AntiforgeryToken Cookie from SameSite Strict to Lax

### DIFF
--- a/TASVideos/Extensions/ServiceCollectionExtensions.cs
+++ b/TASVideos/Extensions/ServiceCollectionExtensions.cs
@@ -122,6 +122,11 @@ public static class ServiceCollectionExtensions
 			})
 			.AddRazorRuntimeCompilation();
 
+		services.AddAntiforgery(options =>
+		{
+			options.Cookie.SameSite = SameSiteMode.Lax;
+		});
+
 		services.AddHttpContext();
 		services.AddMvc(options =>
 		{


### PR DESCRIPTION
If the token isn't Lax, if a user visits certain pages on TASVideos from outside (like a google link), the server would refresh your token, which would invalidate all old tabs' tokens, which gives a 400 Error when submitted.

This way the token will not be refreshed so easily.
And there is no need to make the token Strict anyway, because the token in the HTML is the critical point of safety.