### PR TITLE
On Posts, show player rank last, right before the player points

### DIFF
--- a/TASVideos/Pages/Forum/Models/IForumPostEntry.cs
+++ b/TASVideos/Pages/Forum/Models/IForumPostEntry.cs
@@ -32,6 +32,7 @@ public interface IForumPostEntry
 	public string? PosterAvatar { get; }
 	public string? PosterMoodUrlBase { get; }
 	public IList<string> PosterRoles { get; }
+	public string? PosterPlayerRank { get; }
 	public PreferredPronounTypes PosterPronouns { get; }
 	public IEnumerable<AwardAssignmentSummary> Awards { get; }
 }

--- a/TASVideos/Pages/Forum/Posts/Models/ForumPostEntry.cs
+++ b/TASVideos/Pages/Forum/Posts/Models/ForumPostEntry.cs
@@ -23,6 +23,7 @@ public class ForumPostEntry : IForumPostEntry
 	public ForumPostMood PosterMood { get; set; }
 	public PreferredPronounTypes PosterPronouns { get; set; }
 	public IList<string> PosterRoles { get; set; } = [];
+	public string? PosterPlayerRank { get; set; }
 	public string Text { get; set; } = "";
 	public DateTime? PostEditedTimestamp { get; set; }
 	public string? Subject { get; set; }

--- a/TASVideos/Pages/Forum/Posts/Models/UserPostsModel.cs
+++ b/TASVideos/Pages/Forum/Posts/Models/UserPostsModel.cs
@@ -41,6 +41,7 @@ public class UserPagePost : IForumPostEntry
 	public string? PosterAvatar { get; set; }
 	public string? PosterMoodUrlBase { get; set; }
 	public IList<string> PosterRoles { get; set; } = [];
+	public string? PosterPlayerRank { get; set; }
 	public PreferredPronounTypes PosterPronouns { get; set; }
 	public IEnumerable<AwardAssignmentSummary> Awards { get; set; } = [];
 }

--- a/TASVideos/Pages/Forum/Posts/User.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/User.cshtml.cs
@@ -81,11 +81,6 @@ public class UserModel(
 
 		var (points, rank) = await pointsService.PlayerPoints(user.Id);
 
-		if (!string.IsNullOrWhiteSpace(rank))
-		{
-			user.Roles.Add(rank);
-		}
-
 		foreach (var post in Posts)
 		{
 			post.PosterName = user.UserName;
@@ -97,6 +92,7 @@ public class UserModel(
 			post.PosterAvatar = user.Avatar;
 			post.PosterMoodUrlBase = user.MoodAvatarUrlBase;
 			post.PosterRoles = user.Roles;
+			post.PosterPlayerRank = rank;
 			post.PosterPronouns = user.PreferredPronouns;
 			post.Awards = userAwards;
 		}

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
@@ -144,10 +144,7 @@ public class IndexModel(
 			post.Awards = await awards.ForUser(post.PosterId);
 			var (points, rank) = await pointsService.PlayerPoints(post.PosterId);
 			post.PosterPlayerPoints = points;
-			if (!string.IsNullOrWhiteSpace(rank))
-			{
-				post.PosterRoles.Add(rank);
-			}
+			post.PosterPlayerRank = rank;
 		}
 
 		if (Topic.Poll is not null)

--- a/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
@@ -75,7 +75,7 @@
 									<small condition="@(Model.PosterPronouns != PreferredPronounTypes.Unspecified)" class="text-body-tertiary col-auto col-md-12" style="line-height: 22px;">@Html.DisplayFor(m => m.PosterPronouns)</small>
 								</row>
 								<div class="ms-2 ms-md-0" style="line-height: 1">
-									<small>@string.Join(", ", Model.PosterRoles.Select(s => s.Replace(' ', '\u00A0')).OrderBy(s => s))
+									<small>@string.Join(", ", Model.PosterRoles.OrderBy(s => s).Append(Model.PosterPlayerRank).Where(s => !string.IsNullOrEmpty(s)).Select(s => s!.Replace(' ', '\u00A0')))
 										<span condition="Model.PosterPlayerPoints >= 5">(@Math.Round(Model.PosterPlayerPoints))</span>
 									</small>
 								</div>


### PR DESCRIPTION
Instead of
`Editor, Experienced player, Reviewer (633)`,
it will now show
`Editor, Reviewer, Experienced player (633)`.