### PR TITLE
Properly round player points for Former Players

### DIFF
--- a/TASVideos.Core/Services/PointsService/PointsService.cs
+++ b/TASVideos.Core/Services/PointsService/PointsService.cs
@@ -38,7 +38,7 @@ internal class PointsService(
 			.ToListAsync();
 
 		var averageRatings = await AverageNumberOfRatingsPerPublication();
-		playerPoints = Math.Round(PointsCalculator.PlayerPoints(publications, averageRatings), 1);
+		playerPoints = Math.Ceiling(PointsCalculator.PlayerPoints(publications, averageRatings) * 10) / 10;
 
 		cache.Set(cacheKey, playerPoints);
 		return (playerPoints, PointsCalculator.PlayerRank((decimal)playerPoints));

--- a/tests/TASVideos.Core.Tests/Services/PointsServiceTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/PointsServiceTests.cs
@@ -63,4 +63,28 @@ public class PointsServiceTests
 		const int expected = numMovies * PlayerPointConstants.MinimumPlayerPointsForPublication;
 		Assert.AreEqual(expected, actual);
 	}
+
+	[TestMethod]
+	public async Task PlayerPoints_OnlyObsoletedPublications_NonZero()
+	{
+		_db.AddUser(1, Author);
+		var publicationClass = new PublicationClass { Weight = 1, Name = "Test" };
+		_db.PublicationClasses.Add(publicationClass);
+		await _db.SaveChangesAsync();
+
+		var user = _db.Users.Single();
+		var newPub = new Publication();
+		var oldPub = new Publication
+		{
+			Authors = [new PublicationAuthor { UserId = user.Id }],
+			ObsoletedBy = newPub,
+			PublicationClass = publicationClass,
+		};
+		_db.Publications.Add(oldPub);
+		_db.Publications.Add(newPub);
+		await _db.SaveChangesAsync();
+
+		var (actual, _) = await _pointsService.PlayerPoints(user.Id);
+		Assert.IsTrue(actual > 0);
+	}
 }


### PR DESCRIPTION
Former Players have a score of like 0.00000001, ever so slightly above 0. The previous rounding rounded it to 0, which made it the same as if they didn't have any publications.
We have to use Ceiling to properly detect former players.

![image](https://github.com/TASVideos/tasvideos/assets/22375320/89276a0f-e568-44dc-9a56-28dcd043f8c8)
