### PR TITLE
Align awards display

### DIFF
--- a/TASVideos/Pages/Shared/_Award.cshtml
+++ b/TASVideos/Pages/Shared/_Award.cshtml
@@ -6,7 +6,7 @@
 		: 48;
 }
 
-<a href="/Awards/@Model.Year.ToString()#@(Model.ShortName)_@Model.Year" title="Award - @Model.Description">
+<a class="align-bottom" href="/Awards/@Model.Year.ToString()#@(Model.ShortName)_@Model.Year" title="Award - @Model.Description">
 	<img style="max-height: @(maxHeight)px;"
 		srcset="/awards/@(awardName).png 1x,
 	 /awards/@(awardName)-2x.png 2x,


### PR DESCRIPTION
With the new padding-removed awards images, we can now align them properly.

(before | after)
![image](https://github.com/TASVideos/tasvideos/assets/22375320/d0fb1770-eabe-4445-bb61-ced5cd4fc077)
