### PR TITLE
Track Wiki Pages Deletes and Moves

### DIFF
--- a/TASVideos.Core/Services/ExternalMediaPublisher/ExternalMediaPublisher.cs
+++ b/TASVideos.Core/Services/ExternalMediaPublisher/ExternalMediaPublisher.cs
@@ -36,13 +36,14 @@ public class
 
 public static class ExternalMediaPublisherExtensions
 {
-	public static async Task SendMessage(this ExternalMediaPublisher publisher, string group, string message)
+	public static async Task SendMessage(this ExternalMediaPublisher publisher, string group, string message, string body = "")
 	{
 		await publisher.Send(new Post
 		{
 			Type = PostType.General,
 			Group = group,
 			Title = message,
+			Body = body
 		});
 	}
 

--- a/TASVideos/Pages/Shared/_WikiLayoutFooter.cshtml
+++ b/TASVideos/Pages/Shared/_WikiLayoutFooter.cshtml
@@ -43,7 +43,8 @@ else
 </a>
 <delete-button permission="DeleteWikiPages"
 			   asp-href="/Wiki/DeletedPages/DeletePage?path=@Model.PageName"
-			   warning-message="Are you sure you want to delete this page?"
+				warning-message="Are you sure you want to delete this page?"
+				ask-reason="true"
 			   class="btn btn-danger btn-sm">
 	<i class="fa fa-times"></i> Delete
 </delete-button>

--- a/TASVideos/Pages/Wiki/DeletedPages.cshtml.cs
+++ b/TASVideos/Pages/Wiki/DeletedPages.cshtml.cs
@@ -56,7 +56,7 @@ public class DeletedPagesModel(IWikiPages wikiPages, ApplicationDbContext db, Ex
 				return Page();
 			}
 
-			await publisher.SendMessage(PostGroups.Wiki, $"Page {path} DELETED by {User.Name()} ({{result}} revisions\") Reason: {reason}");
+			await publisher.SendMessage(PostGroups.Wiki, $"Page {path} DELETED by {User.Name()} ({{result}} revisions\")", reason);
 		}
 
 		return BasePageRedirect("DeletedPages");

--- a/TASVideos/Pages/Wiki/DeletedPages.cshtml.cs
+++ b/TASVideos/Pages/Wiki/DeletedPages.cshtml.cs
@@ -21,7 +21,7 @@ public class DeletedPagesModel(IWikiPages wikiPages, ApplicationDbContext db, Ex
 			.ToListAsync();
 	}
 
-	public async Task<IActionResult> OnPostDeletePage(string path)
+	public async Task<IActionResult> OnPostDeletePage(string path, string reason)
 	{
 		if (!User.Has(PermissionTo.DeleteWikiPages))
 		{
@@ -30,6 +30,24 @@ public class DeletedPagesModel(IWikiPages wikiPages, ApplicationDbContext db, Ex
 
 		if (!string.IsNullOrWhiteSpace(path))
 		{
+			if (!string.IsNullOrWhiteSpace(reason))
+			{
+				var page = await wikiPages.Page(path);
+				if (page is null)
+				{
+					return BadRequest();
+				}
+
+				await wikiPages.Add(new WikiCreateRequest
+				{
+					PageName = page.PageName,
+					Markup = page.Markup,
+					RevisionMessage = $"Page deleted, reason: {reason}",
+					MinorEdit = true,
+					AuthorId = User.GetUserId()
+				});
+			}
+
 			var result = await wikiPages.Delete(path);
 
 			if (result == -1)
@@ -38,7 +56,7 @@ public class DeletedPagesModel(IWikiPages wikiPages, ApplicationDbContext db, Ex
 				return Page();
 			}
 
-			await publisher.SendMessage(PostGroups.Wiki, $"Page {path} DELETED by {User.Name()} ({{result}} revisions\")");
+			await publisher.SendMessage(PostGroups.Wiki, $"Page {path} DELETED by {User.Name()} ({{result}} revisions\") Reason: {reason}");
 		}
 
 		return BasePageRedirect("DeletedPages");

--- a/TASVideos/Pages/Wiki/Move.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Move.cshtml.cs
@@ -55,6 +55,17 @@ public class MoveModel(IWikiPages wikiPages, ExternalMediaPublisher publisher) :
 
 		var result = await wikiPages.Move(OriginalPageName, DestinationPageName);
 
+		// At a dummy commit to track the move
+		var page = (await wikiPages.Page(DestinationPageName))!;
+		await wikiPages.Add(new WikiCreateRequest
+		{
+			PageName = DestinationPageName,
+			Markup = page.Markup,
+			RevisionMessage = $"Page Moved from {OriginalPageName}",
+			AuthorId = User.GetUserId(),
+			MinorEdit = false
+		});
+
 		if (!result)
 		{
 			ModelState.AddModelError("", "Unable to move page, the page may have been modified during the saving of this operation.");

--- a/TASVideos/Pages/Wiki/Move.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Move.cshtml.cs
@@ -61,7 +61,7 @@ public class MoveModel(IWikiPages wikiPages, ExternalMediaPublisher publisher) :
 		{
 			PageName = DestinationPageName,
 			Markup = page.Markup,
-			RevisionMessage = $"Page Moved from {OriginalPageName}",
+			RevisionMessage = $"Page Moved from {OriginalPageName} to {DestinationPageName}",
 			AuthorId = User.GetUserId(),
 			MinorEdit = false
 		});

--- a/TASVideos/Pages/Wiki/Move.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Move.cshtml.cs
@@ -45,7 +45,7 @@ public class MoveModel(IWikiPages wikiPages, ExternalMediaPublisher publisher) :
 
 		if (await wikiPages.Exists(DestinationPageName, includeDeleted: true))
 		{
-			ModelState.AddModelError("Move.DestinationPageName", "The destination page already exists.");
+			ModelState.AddModelError("DestinationPageName", "The destination page already exists.");
 		}
 
 		if (!ModelState.IsValid)

--- a/TASVideos/Pages/Wiki/RenderDeleted.cshtml
+++ b/TASVideos/Pages/Wiki/RenderDeleted.cshtml
@@ -1,29 +1,30 @@
 ﻿@page
 @model RenderDeletedModel
 @{
-	ViewData.SetTitle($"Viewing Deleted Page: {Model.WikiPage.PageName}");
+	ViewData.SetTitle($"Viewing Deleted Page: {Model.WikiPages.First().PageName}");
 }
-<h4>Revision: @Model.WikiPage.Revision</h4>
 
-<ul>
-	<li>
-		Revision: @Model.WikiPage.Revision
-	</li>
-	<li>
-		Latest? @(Model.WikiPage.IsCurrent().ToYesNo())
-	</li>
-	<li>
-		Author: <profile-link username="@Model.WikiPage.Author!.UserName"></profile-link>
-	</li>
-	<li>
-		Revision Message: @Model.WikiPage.RevisionMessage
-	</li>
-	<li>
-		Minor Edit? @Model.WikiPage.MinorEdit.ToYesNo()
-	</li>
-</ul>
+<table class="table">
+	<tr>
+		<th>Revision</th>
+		<th>IsCurrent</th>
+		<th>Author</th>
+		<th>Revision</th>
+		<th>Minor Edit</th>
+	</tr>
+	@foreach (var revision in Model.WikiPages.OrderByDescending(wp => wp.Revision))
+	{
+		<tr>
+			<td>@revision.Revision</td>
+			<td>@revision.IsCurrent().ToYesNo()</td>
+			<td>@revision.Author!.UserName</td>
+			<td>@revision.RevisionMessage</td>
+			<td>@revision.MinorEdit</td>
+		</tr>
+	}
+</table>
 
 <h4>Markup</h4>
 <info-alert>
-	@Model.WikiPage.Markup
+	@Model.WikiPages.MaxBy(f => f.Revision)!.Markup
 </info-alert>

--- a/TASVideos/Pages/Wiki/RenderDeleted.cshtml.cs
+++ b/TASVideos/Pages/Wiki/RenderDeleted.cshtml.cs
@@ -21,13 +21,9 @@ public class RenderDeletedModel(ApplicationDbContext db) : BasePageModel
 			? query.Where(wp => wp.Revision == revision)
 			: query.ThatAreCurrent();
 
-		var pages = await query.ToListAsync();
-		if (pages.Count == 0)
-		{
-			return NotFound();
-		}
-
-		WikiPages = pages;
-		return Page();
+		WikiPages = await query.ToListAsync();
+		return WikiPages.Count == 0
+			? NotFound()
+			: Page();
 	}
 }

--- a/TASVideos/Pages/Wiki/RenderDeleted.cshtml.cs
+++ b/TASVideos/Pages/Wiki/RenderDeleted.cshtml.cs
@@ -3,7 +3,7 @@
 [RequirePermission(PermissionTo.SeeDeletedWikiPages)]
 public class RenderDeletedModel(ApplicationDbContext db) : BasePageModel
 {
-	public WikiPage WikiPage { get; set; } = null!;
+	public List<WikiPage> WikiPages { get; set; } = [];
 
 	public async Task<IActionResult> OnGet(string? url, int? revision = null)
 	{
@@ -21,14 +21,13 @@ public class RenderDeletedModel(ApplicationDbContext db) : BasePageModel
 			? query.Where(wp => wp.Revision == revision)
 			: query.ThatAreCurrent();
 
-		var page = await query.FirstOrDefaultAsync();
-		if (page is null)
+		var pages = await query.ToListAsync();
+		if (pages.Count == 0)
 		{
 			return NotFound();
 		}
 
-		WikiPage = page;
-
+		WikiPages = pages;
 		return Page();
 	}
 }

--- a/TASVideos/TagHelpers/DeleteButtonTagHelper.cs
+++ b/TASVideos/TagHelpers/DeleteButtonTagHelper.cs
@@ -17,6 +17,8 @@ public class DeleteButtonTagHelper(IHtmlHelper helper) : TagHelper
 
 	public string ActionName { get; set; } = "Delete";
 
+	public bool AskReason { get; set; }
+
 	public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
 	{
 		var existingClassAttr = output.Attributes.FirstOrDefault(a => a.Name == "class");
@@ -33,29 +35,42 @@ public class DeleteButtonTagHelper(IHtmlHelper helper) : TagHelper
 
 		var antiForgeryToken = helper.AntiForgeryToken().GetString();
 
-		output.Content.SetHtmlContent($"""
-										<button type='button' class='btn btn-danger {existingCssClass}' data-bs-toggle='modal' data-bs-target='#areYouSureModal{uniqueId}'>{content}</button>
-										<div id='areYouSureModal{uniqueId}' class='modal fade' role='dialog'>
-											<div class='modal-dialog'>
-												<div class='modal-content'>
-													<div class='modal-header'>
-														<h5 class='modal-title text-danger'>Delete Warning!</h5>
-														<button type='button' class='btn-close' data-bs-dismiss='modal'></button>
-													</div>
-													<div class='modal-body'>
-														<p>{TagHelperExtensions.Text(WarningMessage)}</p>
-													</div>
-													<div class='modal-footer'>
-														<form action='{WebUtility.UrlDecode(AspHref)}' method='post'>
-															{antiForgeryToken}
-															<button type='submit' class='text-center btn btn-danger'>{ActionName}</button>
-														</form>
-														<button type='button' class='btn btn-secondary' data-bs-dismiss='modal'>Cancel</button>
-													</div>
-												</div>
-											</div>
-										</div>
-										""");
+		string reasonInput = "";
+		if (AskReason)
+		{
+			reasonInput = """
+							<div class="container">
+								<label for="reason">Reason</label>
+								<textarea rows="4" id="reason" name="reason" class="form-control"></textarea>
+							</div>
+							""";
+		}
+
+		output.Content.SetHtmlContent(
+			$"""
+				<button type='button' class='btn btn-danger {existingCssClass}' data-bs-toggle='modal' data-bs-target='#areYouSureModal{uniqueId}'>{content}</button>
+				<div id='areYouSureModal{uniqueId}' class='modal fade' role='dialog'>
+					<div class='modal-dialog'>
+						<div class='modal-content'>
+							<div class='modal-header'>
+								<h5 class='modal-title text-danger'>Delete Warning!</h5>
+								<button type='button' class='btn-close' data-bs-dismiss='modal'></button>
+							</div>
+							<div class='modal-body'>
+								<p>{TagHelperExtensions.Text(WarningMessage)}</p>
+							</div>
+							<form action='{WebUtility.UrlDecode(AspHref)}' method='post'>
+								<div class='modal-footer'>
+									{antiForgeryToken}
+									{reasonInput}
+									<button type='submit' class='text-center btn btn-danger'>{ActionName}</button>
+									<button type='button' class='btn btn-secondary' data-bs-dismiss='modal'>Cancel</button>
+								</div>
+							</form>
+						</div>
+					</div>
+				</div>
+				""");
 	}
 
 	private static string UniqueId()


### PR DESCRIPTION
resolves #866 

Provides a reason field on the delete modal.  If provided it will create a dummy revision with the reason as the revision edit, it will also put the reason in the external media messages.

Also page moves will create a dummy edit that shows where the page moved from