### PR TITLE
Fix YouTube hashtags

### DIFF
--- a/TASVideos.Core/Services/Youtube/YouTubeSync.cs
+++ b/TASVideos.Core/Services/Youtube/YouTubeSync.cs
@@ -29,7 +29,7 @@ internal class YouTubeSync(
 {
 	private const int YoutubeTitleMaxLength = 100;
 	private const int BatchSize = 50;
-	private static readonly string[] BaseTags = ["TAS", "TASVideos", "ToolAssisted", "ToolAssistedSpeedrun", "Video Game"];
+	private static readonly string[] BaseTags = ["TAS", "TASVideos", "Tool-Assisted", "Video Game"];
 	private readonly HttpClient _client = httpClientFactory.CreateClient(HttpClients.Youtube)
 		?? throw new InvalidOperationException($"Unable to initialize {HttpClients.Youtube} client");
 

--- a/TASVideos.Core/Services/Youtube/YouTubeSync.cs
+++ b/TASVideos.Core/Services/Youtube/YouTubeSync.cs
@@ -63,7 +63,7 @@ internal class YouTubeSync(
 		descriptionBase += $"\nTAS originally published on {video.PublicationDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}\n\n";
 		var renderedDescription = await textRenderer.RenderWikiForYoutube(video.WikiPage);
 
-		const string hashTags = "\n\n#tas #tasvideos #tool-assisted #speedrun";
+		const string hashTags = "\n\n#tas #tasvideos #toolassisted #toolassistedspeedrun #speedrun";
 
 		var obsoleteStr = video.ObsoletedBy.HasValue ? "[Obsoleted] " : "";
 		var displayStr = !string.IsNullOrWhiteSpace(video.UrlDisplayName) ? $"[{video.UrlDisplayName}] " : "";


### PR DESCRIPTION
`#tool-assisted` doesn't work as a tag, it gets cut off. So we use combined words.