### PR TITLE
Minor UI adjustments

### DIFF
--- a/TASVideos/appsettings.Development.json
+++ b/TASVideos/appsettings.Development.json
@@ -31,9 +31,5 @@
         }
       }
     ]
-  },
-  "webOptimizer": {
-    "enableCaching": false,
-    "enableTagHelperBundling": false
   }
 }

--- a/TASVideos/appsettings.Production.json
+++ b/TASVideos/appsettings.Production.json
@@ -30,9 +30,5 @@
         }
       }
     ]
-  },
-  "webOptimizer": {
-    "enableCaching": true,
-    "enableTagHelperBundling": true
   }
 }

--- a/TASVideos/appsettings.Staging.json
+++ b/TASVideos/appsettings.Staging.json
@@ -26,9 +26,5 @@
         }
       }
     ]
-  },
-  "webOptimizer": {
-    "enableCaching": false,
-    "enableTagHelperBundling": false
   }
 }

--- a/TASVideos/appsettings.json
+++ b/TASVideos/appsettings.json
@@ -9,5 +9,9 @@
   "SubmissionRate": {
     "Submissions": 3,
     "Days": 7
+  },
+  "webOptimizer": {
+    "enableCaching": true,
+    "enableTagHelperBundling": true
   }
 }

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -242,6 +242,10 @@ article.wiki, .postbody {
 	div.p {
 		margin-top: 0;
 		margin-bottom: 1rem;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	&-edit {
@@ -260,6 +264,12 @@ article.wiki, .postbody {
 	sillyquote {
 		display: block;
 	}
+}
+
+ol, ul, dl {
+    &:last-child {
+        margin-bottom: 0;
+    }
 }
 
 .error-code {


### PR DESCRIPTION
Changes Development WebOptimizer settings so that developers don't need to Ctrl+F5 to see their changes (just like in Production). See the commit message for details.

Also removes bottom margin on certain last child elements. This prevents the problem with poorly aligned boxes (i.e. Fencepost Error), while keeping the margin for all other situations where it's necessary.

( Before | After )
![image](https://github.com/TASVideos/tasvideos/assets/22375320/2e726dbd-2e41-40bc-a926-efb1f39f824a)
![image](https://github.com/TASVideos/tasvideos/assets/22375320/3afc4924-f807-4273-bd41-805c214dbc17)
