### PR TITLE
Fix css minify bug by updating WebOptimizer.Core nuget package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageVersion Include="GitVersion.MsBuild" Version="5.12.0" />
     <PackageVersion Include="IPAddressRange" Version="6.0.0" />
+    <PackageVersion Include="LigerShark.WebOptimizer.Core" Version="3.0.405" />
     <PackageVersion Include="LigerShark.WebOptimizer.Sass" Version="3.0.84" />
     <PackageVersion Include="MailKit" Version="4.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />

--- a/TASVideos/TASVideos.csproj
+++ b/TASVideos/TASVideos.csproj
@@ -27,6 +27,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="LigerShark.WebOptimizer.Core" />
 		<PackageReference Include="LigerShark.WebOptimizer.Sass" />
 		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" />


### PR DESCRIPTION
There is a bug in a nuget package we use.
The result is that our https://tasvideos.org/css/bootstrap.css gives a minify error of:
```css
/* input(3113,25): run-time error CSS1036: Expected expression, found ';'
input(3910,29): run-time error CSS1036: Expected expression, found ';'
input(4024,30): run-time error CSS1036: Expected expression, found ';'
input(4212,30): run-time error CSS1036: Expected expression, found ';'
input(4587,26): run-time error CSS1036: Expected expression, found ';'
input(4588,29): run-time error CSS1036: Expected expression, found ';'
input(4592,25): run-time error CSS1036: Expected expression, found ';'
input(4597,24): run-time error CSS1036: Expected expression, found ';'
input(4598,21): run-time error CSS1036: Expected expression, found ';'
input(4599,20): run-time error CSS1036: Expected expression, found ';'
input(4914,23): run-time error CSS1036: Expected expression, found ';'
input(4915,34): run-time error CSS1036: Expected expression, found ';'
input(5653,21): run-time error CSS1036: Expected expression, found ';'
input(5718,21): run-time error CSS1036: Expected expression, found ';'
input(5732,25): run-time error CSS1036: Expected expression, found ';'
input(6012,24): run-time error CSS1036: Expected expression, found ';' */
```

We use `LigerShark.WebOptimizer.Sass` which uses `LigerShark.WebOptimizer.Core` which uses `NUglify` which had this bug.
This bug is now fixed, but the dependency chain isn't up to date enough yet, so we force a newer version.

```
The bug is fixed in 
  NUglify >= 1.20.2
which is required in
  WebOptimizer.Core >= 3.0.386
which is not yet required in any of the latest
  WebOptimizer.Sass
```

As soon as a `WebOptimizer.Sass` version requires a `WebOptimizer.Core` version of 3.0.386 or higher, we should revert this PR and just update the the .Sass.