### PR TITLE
Update WebOptimizer.Sass, and manually provide JavaScript Engine

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,14 +5,16 @@
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageVersion Include="GitVersion.MsBuild" Version="5.12.0" />
     <PackageVersion Include="IPAddressRange" Version="6.0.0" />
+    <PackageVersion Include="JavaScriptEngineSwitcher.V8" Version="3.24.2" />
     <PackageVersion Include="LigerShark.WebOptimizer.Core" Version="3.0.405" />
-    <PackageVersion Include="LigerShark.WebOptimizer.Sass" Version="3.0.84" />
+    <PackageVersion Include="LigerShark.WebOptimizer.Sass" Version="3.0.118" />
     <PackageVersion Include="MailKit" Version="4.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
+    <PackageVersion Include="Microsoft.ClearScript.Complete" Version="7.4.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.AutoHistory" Version="6.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.1" />

--- a/TASVideos/Program.cs
+++ b/TASVideos/Program.cs
@@ -1,4 +1,6 @@
 ﻿using AspNetCore.ReCaptcha;
+using JavaScriptEngineSwitcher.Core;
+using JavaScriptEngineSwitcher.V8;
 using Serilog;
 using TASVideos.Api;
 using TASVideos.Core.Data;
@@ -35,10 +37,12 @@ builder.Services
 	.AddTasvideosApi(settings);
 
 // 3rd Party
+JsEngineSwitcher.AllowCurrentProperty = false;
 builder.Services
 	.AddRazorPages(builder.Environment)
 	.AddIdentity(builder.Environment)
 	.AddReCaptcha(builder.Configuration.GetSection("ReCaptcha"))
+	.AddSingleton<IJsEngineSwitcher>(new JsEngineSwitcher([new V8JsEngineFactory()], V8JsEngine.EngineName))
 	.AddWebOptimizer(pipeline =>
 	{
 		pipeline.AddScssBundle("/css/bootstrap.css", "/css/bootstrap.scss");

--- a/TASVideos/TASVideos.csproj
+++ b/TASVideos/TASVideos.csproj
@@ -27,10 +27,12 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="JavaScriptEngineSwitcher.V8" />
 		<PackageReference Include="LigerShark.WebOptimizer.Core" />
 		<PackageReference Include="LigerShark.WebOptimizer.Sass" />
 		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" />
+		<PackageReference Include="Microsoft.ClearScript.Complete" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
The new WebOptimizer.Sass doesn't provide a JavaScript Engine anymore. We have to add it ourselves.

It expects a Singleton of type `IJsEngineSwitcher`. For this I chose the `JavaScriptEngineSwitcher.V8` which [used to be a dependency](https://www.nuget.org/packages/LigerShark.WebOptimizer.Sass/3.0.91#dependencies-body-tab).
And the other dependencies (the V8 Native packages for each platform) were added with the `Microsoft.ClearScript.Complete` package, to avoid adding them all one by one.