### PR TITLE
Fix rendering of certain wiki links

### DIFF
--- a/TASVideos.WikiEngine/MakeBracketed.cs
+++ b/TASVideos.WikiEngine/MakeBracketed.cs
@@ -230,20 +230,20 @@ public static partial class Builtins
 			// If no labeling text was needed, a module is needed for DB lookups (eg `[4022S]`)
 			// DB lookup will be required for links like [4022S], so use __wikiLink
 			// TODO:  __wikilink should probably be its own AST type??
-			return MakeModuleInternal(charStart, charEnd, "__wikiLink|href=" + NormalizeUrl("=" + pp[0]));
+			return MakeModuleInternal(charStart, charEnd, "__wikiLink|href=" + NormalizeUrl("=" + pp[0]) + "|implicitdisplaytext=" + pp[0]);
 		}
 
 		// In other cases, return raw literal text.  This doesn't quite match the old wiki, which could look for formatting in these, but should be good enough
-		return new[] { new Text(charStart, "[" + text + "]") { CharEnd = charEnd } };
+		return [new Text(charStart, "[" + text + "]") { CharEnd = charEnd }];
 	}
 
 	internal static INode MakeLink(int charStart, int charEnd, string text, INode child)
 	{
 		var href = NormalizeUrl(text);
 		var attrs = new List<KeyValuePair<string, string>>
-			{
-				Attr("href", href)
-			};
+		{
+			Attr("href", href)
+		};
 		if (href[0] == '#' || href[0] == '/' && (href.Length == 1 || href[1] != '/'))
 		{
 			// internal

--- a/TASVideos/WikiModules/WikiLink.cshtml.cs
+++ b/TASVideos/WikiModules/WikiLink.cshtml.cs
@@ -12,19 +12,19 @@ public class WikiLink(ApplicationDbContext db) : WikiViewComponent
 	public string DisplayText { get; set; } = "";
 	public string? Title { get; set; }
 
-	public async Task<IViewComponentResult> InvokeAsync(string href, string? displayText)
+	public async Task<IViewComponentResult> InvokeAsync(string href, string? displayText, string? implicitDisplayText)
 	{
-		await GenerateLink(href, displayText);
+		await GenerateLink(href, displayText, implicitDisplayText);
 		return View();
 	}
 
-	public async Task<string> RenderTextAsync(IWikiPage? pageData, string href, string? displayText)
+	public async Task<string> RenderTextAsync(IWikiPage? pageData, string href, string? displayText, string? implicitDisplayText)
 	{
-		await GenerateLink(href, displayText);
+		await GenerateLink(href, displayText, implicitDisplayText);
 		return DisplayText;
 	}
 
-	private async Task GenerateLink(string href, string? displayText)
+	private async Task GenerateLink(string href, string? displayText, string? implicitDisplayText)
 	{
 		int? id;
 		string? titleText = null;
@@ -69,7 +69,7 @@ public class WikiLink(ApplicationDbContext db) : WikiViewComponent
 
 		if (string.IsNullOrWhiteSpace(displayText))
 		{
-			displayText = href[1..];
+			displayText = implicitDisplayText ?? href[1..];
 		}
 
 		Href = href;


### PR DESCRIPTION
When the link has no display text, but the normalized form differs from the unnormalized form, we were missing formatting since 1c8034d679136dec196126ffcfa1fbac5f0c07f6.

Fixes https://github.com/TASVideos/tasvideos/issues/1858.