### PR TITLE
Allow case edits in Game Goals

### DIFF
--- a/TASVideos/Pages/Games/Goals/List.cshtml.cs
+++ b/TASVideos/Pages/Games/Goals/List.cshtml.cs
@@ -86,7 +86,7 @@ public class ListModel(ApplicationDbContext db) : BasePageModel
 
 		var oldGoalName = gameGoal.DisplayName;
 
-		if (string.Equals(gameGoal.DisplayName, newGoalName, StringComparison.InvariantCulture))
+		if (string.Equals(gameGoal.DisplayName, newGoalName, StringComparison.InvariantCultureIgnoreCase))
 		{
 			gameGoal.DisplayName = newGoalName;
 			SetMessage(await db.TrySaveChanges(), $"Goal changed from {oldGoalName} to {newGoalName} successfully", $"Unable to change goal from {oldGoalName} to {newGoalName}");

--- a/TASVideos/Pages/Games/Goals/List.cshtml.cs
+++ b/TASVideos/Pages/Games/Goals/List.cshtml.cs
@@ -84,26 +84,19 @@ public class ListModel(ApplicationDbContext db) : BasePageModel
 			return NotFound();
 		}
 
-		var oldGoalName = gameGoal.DisplayName;
-
-		if (string.Equals(gameGoal.DisplayName, newGoalName, StringComparison.InvariantCultureIgnoreCase))
-		{
-			gameGoal.DisplayName = newGoalName;
-			SetMessage(await db.TrySaveChanges(), $"Goal changed from {oldGoalName} to {newGoalName} successfully", $"Unable to change goal from {oldGoalName} to {newGoalName}");
-			return BackToList();
-		}
-
 		if (gameGoal.DisplayName == "baseline")
 		{
 			ErrorStatusMessage("Cannot edit baseline goal.");
 			return BackToList();
 		}
 
-		if (await db.GameGoals.AnyAsync(gg => gg.GameId == GameId && gg.DisplayName == newGoalName))
+		if (await db.GameGoals.AnyAsync(gg => gg.GameId == GameId && gg.DisplayName == newGoalName && gg.Id != gameGoal.Id))
 		{
 			ErrorStatusMessage($"Cannot change goal to {newGoalName} because it already exists.");
 			return BackToList();
 		}
+
+		var oldGoalName = gameGoal.DisplayName;
 
 		gameGoal.DisplayName = newGoalName;
 


### PR DESCRIPTION
Resolves #1868 .

@adelikat ~~I assume my edit is what that particular code block was meant to do in the first place. If my assumption is wrong you should definitely look at this.
(Because we use case-insensitive columns, right? Requiring us to preempt the DB and manually allow changes if the only difference is their case.)~~
I removed that whole if-block, but I wasn't quite sure what its purpose was. I assumed it had something to do with our DB using case-insensitive columns, but this shouldn't matter here.