### PR TITLE
Banned until

### DIFF
--- a/TASVideos.Core/Dtos/UserProfile.cs
+++ b/TASVideos.Core/Dtos/UserProfile.cs
@@ -57,6 +57,8 @@ public class UserProfile
 	[DisplayName("Locked Out Status")]
 	public bool IsLockedOut { get; set; }
 
+	public DateTime? BannedUntil { get; set; }
+
 	public string? ModeratorComments { get; set; }
 
 	public int PublicationActiveCount { get; set; }
@@ -77,6 +79,9 @@ public class UserProfile
 	public UserFileSummary UserFiles { get; set; } = new();
 
 	public int SubmissionCount => Submissions.Sum(s => s.Count);
+
+	public bool IsBanned => BannedUntil.HasValue && BannedUntil >= DateTime.UtcNow;
+	public bool BanIsIndefinite => BannedUntil >= DateTime.UtcNow.AddYears(2);
 
 	public class SubmissionEntry
 	{

--- a/TASVideos.Core/Services/SignInManager.cs
+++ b/TASVideos.Core/Services/SignInManager.cs
@@ -36,6 +36,11 @@ public class SignInManager(
 			return (SignInResult.Failed, null);
 		}
 
+		if (user.BannedUntil < DateTime.UtcNow)
+		{
+			return (SignInResult.Failed, null);
+		}
+
 		var claims = await userManager.AddUserPermissionsToClaims(user);
 		var canLogIn = claims.Permissions().Contains(PermissionTo.Login);
 

--- a/TASVideos.Core/Services/SignInManager.cs
+++ b/TASVideos.Core/Services/SignInManager.cs
@@ -36,7 +36,7 @@ public class SignInManager(
 			return (SignInResult.Failed, null);
 		}
 
-		if (user.BannedUntil < DateTime.UtcNow)
+		if (user.IsBanned())
 		{
 			return (SignInResult.Failed, null);
 		}

--- a/TASVideos.Core/Services/UserManager.cs
+++ b/TASVideos.Core/Services/UserManager.cs
@@ -188,6 +188,7 @@ public class UserManager(
 				PublicRatings = u.PublicRatings,
 				TimeZone = u.TimeZoneId,
 				IsLockedOut = u.LockoutEnabled && u.LockoutEnd.HasValue,
+				BannedUntil = u.BannedUntil,
 				PublicationActiveCount = u.Publications
 					.Count(p => !p.Publication!.ObsoletedById.HasValue),
 				PublicationObsoleteCount = u.Publications

--- a/TASVideos.Core/Services/UserManager.cs
+++ b/TASVideos.Core/Services/UserManager.cs
@@ -61,6 +61,7 @@ public class UserManager(
 	{
 		return await db.Users
 			.Where(u => u.Id == userId)
+			.ThatAreNotBanned()
 			.SelectMany(u => u.UserRoles)
 			.SelectMany(ur => ur.Role!.RolePermission)
 			.Select(rp => rp.PermissionId)

--- a/TASVideos.Data/Entity/User.cs
+++ b/TASVideos.Data/Entity/User.cs
@@ -218,4 +218,6 @@ public static class UserExtensions
 
 	public static IQueryable<User> ThatAreNotBanned(this IQueryable<User> query)
 		=> query.Where(u => !u.BannedUntil.HasValue || u.BannedUntil < DateTime.UtcNow);
+
+	public static bool IsBanned(this User user) => user.BannedUntil.HasValue && user.BannedUntil > DateTime.UtcNow;
 }

--- a/TASVideos.Data/Entity/User.cs
+++ b/TASVideos.Data/Entity/User.cs
@@ -186,14 +186,10 @@ public enum UserDecimalFormat
 public static class UserExtensions
 {
 	public static async Task<bool> Exists(this IQueryable<User> query, string userName)
-	{
-		return await query.AnyAsync(q => q.UserName == userName);
-	}
+		=> await query.AnyAsync(q => q.UserName == userName);
 
 	public static IQueryable<User> ThatHaveSubmissions(this IQueryable<User> query)
-	{
-		return query.Where(u => u.Submissions.Any());
-	}
+		=> query.Where(u => u.Submissions.Any());
 
 	public static IQueryable<User> ThatPartiallyMatch(this IQueryable<User> query, string? partial)
 	{
@@ -202,33 +198,24 @@ public static class UserExtensions
 	}
 
 	public static IQueryable<User> ThatArePublishedAuthors(this IQueryable<User> query)
-	{
-		return query.Where(u => u.Publications.Any());
-	}
+		=> query.Where(u => u.Publications.Any());
 
 	public static IQueryable<User> ThatHavePermission(this IQueryable<User> query, PermissionTo permission)
-	{
-		return query.Where(u => u.UserRoles
+		=> query.Where(u => u.UserRoles
 			.Any(r => r.Role!.RolePermission.Any(rp => rp.PermissionId == permission)));
-	}
 
 	public static IQueryable<User> ThatHaveRole(this IQueryable<User> query, string role)
-	{
-		return query.Where(u => u.UserRoles.Any(ur => ur.Role!.Name == role));
-	}
+		=> query.Where(u => u.UserRoles.Any(ur => ur.Role!.Name == role));
 
 	public static IQueryable<User> ForUsers(this IQueryable<User> query, IEnumerable<string> users)
-	{
-		return query.Where(u => users.Contains(u.UserName));
-	}
+		=> query.Where(u => users.Contains(u.UserName));
 
 	public static IQueryable<User> ForUser(this IQueryable<User> query, string? userName)
-	{
-		return query.Where(u => u.UserName == userName);
-	}
+		=> query.Where(u => u.UserName == userName);
 
 	public static IQueryable<User> ThatHaveCustomLocale(this IQueryable<User> query)
-	{
-		return query.Where(u => u.DateFormat != UserDateFormat.Auto || u.TimeFormat != UserTimeFormat.Auto || u.DecimalFormat != UserDecimalFormat.Auto);
-	}
+		=> query.Where(u => u.DateFormat != UserDateFormat.Auto || u.TimeFormat != UserTimeFormat.Auto || u.DecimalFormat != UserDecimalFormat.Auto);
+
+	public static IQueryable<User> ThatAreNotBanned(this IQueryable<User> query)
+		=> query.Where(u => !u.BannedUntil.HasValue || u.BannedUntil < DateTime.UtcNow);
 }

--- a/TASVideos.Data/Entity/User.cs
+++ b/TASVideos.Data/Entity/User.cs
@@ -59,6 +59,8 @@ public class User : IdentityUser<int>, ITrackable
 	[StringLength(250)]
 	public string? MoodAvatarUrlBase { get; set; }
 
+	public DateTime? BannedUntil { get; set; }
+
 	/// <summary>
 	/// Gets or sets a value indicating whether to use
 	/// the user's ratings when calculating a publication's average rating.

--- a/TASVideos.Data/Migrations/20240602180656_BannedUntilColumn.Designer.cs
+++ b/TASVideos.Data/Migrations/20240602180656_BannedUntilColumn.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using TASVideos.Data;
 namespace TASVideos.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240602180656_BannedUntilColumn")]
+    partial class BannedUntilColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TASVideos.Data/Migrations/20240602180656_BannedUntilColumn.cs
+++ b/TASVideos.Data/Migrations/20240602180656_BannedUntilColumn.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TASVideos.Data.Migrations;
+
+/// <inheritdoc />
+public partial class BannedUntilColumn : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.AddColumn<DateTime>(
+			name: "banned_until",
+			table: "users",
+			type: "timestamp without time zone",
+			nullable: true);
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropColumn(
+			name: "banned_until",
+			table: "users");
+	}
+}

--- a/TASVideos/Pages/Forum/Posts/User.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/User.cshtml.cs
@@ -28,6 +28,7 @@ public class UserModel(ApplicationDbContext db, IAwards awards, IPointsService p
 				u.Signature,
 				PostCount = u.Posts.Count,
 				u.PreferredPronouns,
+				u.BannedUntil,
 				Roles = u.UserRoles
 					.Where(ur => !ur.Role!.IsDefault)
 					.Select(ur => ur.Role!.Name)
@@ -84,6 +85,7 @@ public class UserModel(ApplicationDbContext db, IAwards awards, IPointsService p
 			post.PosterPlayerRank = rank;
 			post.PosterPronouns = user.PreferredPronouns;
 			post.Awards = userAwards;
+			post.PosterIsBanned = user.BannedUntil.HasValue && user.BannedUntil > DateTime.UtcNow;
 
 			var isOwnPost = post.PosterId == User.GetUserId();
 			var isOpenTopic = !post.TopicIsLocked;

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
@@ -120,6 +120,7 @@ public class IndexModel(
 				PosterJoined = p.Poster.CreateTimestamp,
 				PosterPostCount = p.Poster.Posts.Count,
 				PosterMood = p.PosterMood,
+				PosterIsBanned = p.Poster.BannedUntil.HasValue && p.Poster.BannedUntil > DateTime.UtcNow,
 				Text = p.Text,
 				PostEditedTimestamp = p.PostEditedTimestamp,
 				Subject = p.Subject,
@@ -345,6 +346,7 @@ public class IndexModel(
 		public string? PosterAvatar { get; set; }
 		public string? PosterLocation { get; set; }
 		public int PosterPostCount { get; set; }
+		public bool PosterIsBanned { get; set; }
 		public double PosterPlayerPoints { get; set; }
 		public DateTime PosterJoined { get; set; }
 		public string? PosterMoodUrlBase { get; set; }
@@ -378,6 +380,23 @@ public class IndexModel(
 			}
 
 			return PosterAvatar;
+		}
+
+		public string CalculatedRoles
+		{
+			get
+			{
+				if (PosterIsBanned)
+				{
+					return "Banned User";
+				}
+
+				return string.Join(",", PosterRoles
+					.OrderBy(s => s)
+					.Append(PosterPlayerRank)
+					.Where(s => !string.IsNullOrEmpty(s))
+					.Select(s => s!.Replace(' ', '\u00A0')));
+			}
 		}
 	}
 }

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
@@ -391,7 +391,7 @@ public class IndexModel(
 					return "Banned User";
 				}
 
-				return string.Join(",", PosterRoles
+				return string.Join(", ", PosterRoles
 					.OrderBy(s => s)
 					.Append(PosterPlayerRank)
 					.Where(s => !string.IsNullOrEmpty(s))

--- a/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
@@ -68,8 +68,8 @@
 									<small condition="@(Model.PosterPronouns != PreferredPronounTypes.Unspecified)" class="text-body-tertiary col-auto col-md-12" style="line-height: 22px;">@Html.DisplayFor(m => m.PosterPronouns)</small>
 								</row>
 								<div class="ms-2 ms-md-0" style="line-height: 1">
-									<small>@string.Join(", ", Model.CalculatedRoles)
-										<span condition="Model.PosterPlayerPoints >= 5">(@Math.Round(Model.PosterPlayerPoints))</span>
+									<small>@Model.CalculatedRoles
+										<span condition="!Model.PosterIsBanned && Model.PosterPlayerPoints >= 5">(@Math.Round(Model.PosterPlayerPoints))</span>
 									</small>
 								</div>
 							</div>

--- a/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
@@ -68,7 +68,7 @@
 									<small condition="@(Model.PosterPronouns != PreferredPronounTypes.Unspecified)" class="text-body-tertiary col-auto col-md-12" style="line-height: 22px;">@Html.DisplayFor(m => m.PosterPronouns)</small>
 								</row>
 								<div class="ms-2 ms-md-0" style="line-height: 1">
-									<small>@string.Join(", ", Model.PosterRoles.OrderBy(s => s).Append(Model.PosterPlayerRank).Where(s => !string.IsNullOrEmpty(s)).Select(s => s!.Replace(' ', '\u00A0')))
+									<small>@string.Join(", ", Model.CalculatedRoles)
 										<span condition="Model.PosterPlayerPoints >= 5">(@Math.Round(Model.PosterPlayerPoints))</span>
 									</small>
 								</div>

--- a/TASVideos/Pages/Shared/_Profile.cshtml
+++ b/TASVideos/Pages/Shared/_Profile.cshtml
@@ -31,64 +31,56 @@
 				</row>
 			</card-header>
 			<card-body>
-				<img condition="@(!string.IsNullOrWhiteSpace(Model.Avatar))" src="@Model.Avatar" class="float-end" />
+				<danger-alert condition="Model.IsBanned">
+					<span condition="Model.BanIsIndefinite">User is banned indefinitely</span>
+					<span condition="!Model.BanIsIndefinite">User is banned until <timezone-convert relative-time="false" asp-for="BannedUntil"/></span>
+				</danger-alert>
+				<img condition="@(!string.IsNullOrWhiteSpace(Model.Avatar))" src="@Model.Avatar" class="float-end"/>
 				<div class="card-text">
 					<a condition="Model.HasHomePage" href="/HomePages/@Model.UserName">Homepage</a>
 					<small condition="!Model.HasHomePage">(No Home Page)</small>
-					<br />
+					<br/>
 					<label asp-for="JoinDate"></label>
-					<label><timezone-convert asp-for="@Model.JoinDate" date-only="true" /></label>
-					<br />
+					<label><timezone-convert asp-for="@Model.JoinDate" date-only="true"/></label>
+					<br/>
 					<label asp-for="LastLoggedInTimeStamp"></label>
-					<label condition="Model.LastLoggedInTimeStamp.HasValue"><timezone-convert asp-for="@lastLoggedIn" date-only="true" /></label>
+					<label condition="Model.LastLoggedInTimeStamp.HasValue"><timezone-convert asp-for="@lastLoggedIn" date-only="true"/></label>
 					<label condition="!Model.LastLoggedInTimeStamp.HasValue">Never</label>
-					<br />
+					<br/>
 					<label asp-for="PreferredPronouns"></label>
 					<label>@Html.DisplayFor(m => m.PreferredPronouns)</label>
-					<br />
+					<br/>
 					<label asp-for="Location"></label>
 					<label>@Html.DisplayFor(m => m.Location)</label>
-					<br />
+					<br/>
 					<label asp-for="PostCount"></label>
 					<label>
 						<a asp-page="/Forum/Posts/User" asp-route-username="@Model.UserName">
 							@Html.DisplayFor(m => m.PostCount)
 						</a>
 					</label>
-					<br />
+					<br/>
 					<a condition="canViewPrivateData" class="btn btn-warning btn-sm mt-1 mb-2" data-bs-toggle="collapse" href="#pii">Private Data</a>
 					<div class="collapse" id="pii">
 						<div class="alert alert-info" condition="canViewPrivateData">
 							<label asp-for="Id"></label>
 							<label>@Model.Id</label>
-							<br />
+							<br/>
 							<label asp-for="TimeZone"></label>
 							<label>@Model.TimeZone</label>
-							<br />
+							<br/>
 							<div permission="SeeEmails">
 								<label asp-for="Email"></label>
 								<label>@Model.Email</label>
 							</div>
-							<br />
+							<br/>
 							<label asp-for="EmailConfirmed"></label>
-							@if (Model.EmailConfirmed)
-							{
-								<span class="fa fa-check-square text-success"></span><span> Yes</span>
-							}
-							else
-							{
-								<div><span class="fa fa-exclamation-triangle text-danger"></span> No</div>
-							}
-							<br />
+							<span condition="Model.EmailConfirmed" class="fa fa-check-square text-success"></span><span> Yes</span>
+							<div><span condition="!Model.EmailConfirmed" class="fa fa-exclamation-triangle text-danger"></span> No</div>
+							<br/>
 							<label asp-for="IsLockedOut"></label>
-							@if (Model.IsLockedOut)
-							{
-								<span class="fa fa-exclamation-triangle text-danger"></span><span> Locked out</span>
-							}
-							else
-							{
-								<span class="fa fa-check-square text-success"></span><span> Not locked</span>
-							}
+							<span condition="Model.IsLockedOut" class="fa fa-exclamation-triangle text-danger"></span><span> Locked out</span>
+							<span condition="!Model.IsLockedOut" class="fa fa-check-square text-success"></span><span> Not locked</span>
 							<div>
 								<a permission="ViewPrivateUserData" asp-page="/Users/Ips" asp-route-username="@Model.UserName" class="btn btn-warning btn-sm">IP Addresses used</a>
 							</div>
@@ -100,7 +92,7 @@
 					<div class="float-end mt-2">
 						@foreach (var award in Model.Awards.OrderByDescending(a => a.Year))
 						{
-							<partial name="_Award" model="award" />
+							<partial name="_Award" model="award"/>
 						}
 					</div>
 				</div>

--- a/TASVideos/Pages/Users/Edit.cshtml
+++ b/TASVideos/Pages/Users/Edit.cshtml
@@ -12,36 +12,50 @@
 </top-button-bar>
 
 <form asp-route="Edit">
-	<fullrow>
-		<fieldset condition="Model.UserToEdit.IsLockedOut">
-			<label asp-for="UserToEdit.IsLockedOut"></label>
-			<div>
-				<label class="text-danger"><span class="fa fa-exclamation-triangle"></span> This user is currently locked out</label>
-				<a class="btn btn-secondary" asp-page="Edit" asp-page-handler="Unlock" asp-route-returnurl="@HttpContext.CurrentPathToReturnUrl()" asp-route-id="@Model.Id">Unlock</a>
-			</div>
-		</fieldset>
-		<fieldset condition="!Model.UserToEdit.IsLockedOut">
-			<label asp-for="UserToEdit.IsLockedOut"></label>
-			<div>
-				<span class="fa fa-check-square text-success"></span> Not locked
-			</div>
-		</fieldset>
-	</fullrow>
 	<row>
-		<div class="col-md-6">
+		<column md="6">
 			<fieldset>
 				<label asp-for="UserToEdit.CreateTimestamp"></label>
 				<div><timezone-convert asp-for="@Model.UserToEdit.CreateTimestamp"/></div>
 			</fieldset>
+			<fieldset condition="Model.UserToEdit.IsLockedOut">
+				<label asp-for="UserToEdit.IsLockedOut"></label>
+				<div>
+					<label class="text-danger"><span class="fa fa-exclamation-triangle"></span> This user is currently locked out</label>
+					<a class="btn btn-secondary" asp-page="Edit" asp-page-handler="Unlock" asp-route-returnurl="@HttpContext.CurrentPathToReturnUrl()" asp-route-id="@Model.Id">Unlock</a>
+				</div>
+			</fieldset>
+			<fieldset condition="!Model.UserToEdit.IsLockedOut">
+				<label asp-for="UserToEdit.IsLockedOut"></label>
+				<div>
+					<span class="fa fa-check-square text-success"></span> Not locked
+				</div>
+			</fieldset>
+		</column>
+		<column md="6">
+			<fieldset>
+				<label asp-for="UserToEdit.LastLoggedInTimeStamp"></label>
+				<div>@Html.DisplayFor(m => m.UserToEdit.LastLoggedInTimeStamp)</div>
+			</fieldset>
+			<fieldset>
+				<input type="checkbox" class="forum-check-input" asp-for="UserToEdit.UseRatings" />
+				<label class="form-check-label" asp-for="UserToEdit.UseRatings"></label>
+				<br />
+				(@Html.DescriptionFor(m => m.UserToEdit.UseRatings))
+			</fieldset>
+		</column>
+	</row>
+	<row>
+		<column md="6">
 			<fieldset>
 				<label asp-for="UserToEdit.UserName"></label>
 				@if (User.Has(PermissionTo.EditUsersUserName))
 				{
-					<input asp-for="UserToEdit.OriginalUserName" type="hidden" />
+					<input asp-for="UserToEdit.OriginalUserName" type="hidden"/>
 					<row>
 						<div id="user-name-div" class="col-sm-12">
 							<div class="input-group">
-								<input asp-for="UserToEdit.UserName" class="form-control" autocomplete="off" />
+								<input asp-for="UserToEdit.UserName" class="form-control" autocomplete="off"/>
 								<div class="input-group-text" aria-hidden="true">
 									<span id="user-name-status" class="fa fa-check-square text-success"></span>
 								</div>
@@ -137,21 +151,17 @@
 				{
 					<div>
 						<label>@Model.UserToEdit.UserName</label>
-						<input type="hidden" asp-for="UserToEdit.UserName" />
+						<input type="hidden" asp-for="UserToEdit.UserName"/>
 					</div>
 				}
 			</fieldset>
 			<fieldset>
 				<label asp-for="UserToEdit.From"></label>
-				<input asp-for="UserToEdit.From" type="text" class="form-control" />
+				<input asp-for="UserToEdit.From" type="text" class="form-control"/>
 				<span asp-validation-for="UserToEdit.From" class="text-danger"></span>
 			</fieldset>
-		</div>
-		<div class="col-md-6">
-			<fieldset>
-				<label asp-for="UserToEdit.LastLoggedInTimeStamp"></label>
-				<div>@Html.DisplayFor(m => m.UserToEdit.LastLoggedInTimeStamp)</div>
-			</fieldset>
+		</column>
+		<column md="6">
 			<fieldset>
 				<label asp-for="UserToEdit.TimezoneId"></label>
 				<timezone-picker asp-for="UserToEdit.TimezoneId" class="form-control" />
@@ -168,15 +178,13 @@
 				<a asp-page="EditEmail" asp-route-id="@Model.Id" class="btn btn-danger mt-2">Edit</a>
 				<label>(also allows manually setting the email confirmed value)</label>
 			</fieldset>
-		</div>
+		</column>
 	</row>
 	<row>
 		<column md="6">
 			<fieldset>
-				<input type="checkbox" class="forum-check-input" asp-for="UserToEdit.UseRatings" />
-				<label class="form-check-label" asp-for="UserToEdit.UseRatings"></label>
-				<br />
-				(@Html.DescriptionFor(m => m.UserToEdit.UseRatings))
+				<label asp-for="UserToEdit.BannedUntil">Banned Until</label>
+				<input asp-for="UserToEdit.BannedUntil" class="form-control"/>
 			</fieldset>
 		</column>
 	</row>

--- a/TASVideos/Pages/Users/Edit.cshtml.cs
+++ b/TASVideos/Pages/Users/Edit.cshtml.cs
@@ -45,6 +45,7 @@ public class EditModel(
 				Avatar = u.Avatar,
 				MoodAvatarUrlBase = u.MoodAvatarUrlBase,
 				UseRatings = u.UseRatings,
+				BannedUntil = u.BannedUntil,
 				ModeratorComments = u.ModeratorComments
 			})
 			.SingleOrDefaultAsync();
@@ -97,6 +98,7 @@ public class EditModel(
 		user.Avatar = UserToEdit.Avatar;
 		user.MoodAvatarUrlBase = UserToEdit.MoodAvatarUrlBase;
 		user.UseRatings = UserToEdit.UseRatings;
+		user.BannedUntil = UserToEdit.BannedUntil;
 		user.ModeratorComments = UserToEdit.ModeratorComments;
 
 		var currentRoles = await db.UserRoles
@@ -231,6 +233,8 @@ public class EditModel(
 
 		[Display(Name = "Use Ratings", Description = "If unchecked, the user's publication ratings will not be used when calculating average rating")]
 		public bool UseRatings { get; init; }
+
+		public DateTime? BannedUntil { get; init; }
 
 		[Display(Name = "Moderator Comments")]
 		public string? ModeratorComments { get; init; }

--- a/TASVideos/TagHelpers/TimeZoneConvert.cs
+++ b/TASVideos/TagHelpers/TimeZoneConvert.cs
@@ -20,15 +20,19 @@ public class TimeZoneConvert(
 	public bool RelativeTime { get; set; } = true;
 	public bool InLine { get; set; }
 
-	public DateTime ConvertedDateTime => (DateTime)AspFor.Model;
+	private DateTime? ConvertedDateTime => (DateTime?)AspFor.Model;
 
 	public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
 	{
 		ValidateExpression();
 
 		var user = await userManager.GetUserAsync(claimsPrincipal);
+		if (ConvertedDateTime is null)
+		{
+			return;
+		}
 
-		var dateTime = ConvertedDateTime;
+		var dateTime = ConvertedDateTime.Value;
 
 		TimeZoneInfo? userTimeZone = null;
 		if (user is not null)
@@ -81,7 +85,7 @@ public class TimeZoneConvert(
 	private void ValidateExpression()
 	{
 		var type = AspFor.ModelExplorer.ModelType;
-		if (!typeof(DateTime).IsAssignableFrom(type))
+		if (!typeof(DateTime).IsAssignableFrom(type) && !typeof(DateTime?).IsAssignableFrom(type))
 		{
 			throw new ArgumentException($"Invalid property type {type}, {nameof(AspFor)} must be a {nameof(DateTime)}");
 		}


### PR DESCRIPTION
Resolves the immediate problem in #1701 
The full rollout will require more iterations, this PR adds a "Banned Until" datetime on user.  If set, the user cannot log in and effectively has no permissions, so long as the current time is before the ban.  

If a user is banned this way, their role on the forum will display as "Banned User"

Important note that this ties banning to the EditUser permisisons where before it was the AssignUser (due to needing to remove a Login permission).

In future commits and migrations, we will deprecate the Login permission, and remove the Banned User role


Examples of how it would display on the User profile (no Spikes were harmed in the making of these images, was purely from test data):
![image](https://github.com/TASVideos/tasvideos/assets/1679846/b94bf008-023e-40cb-8a95-6e91c3b36a89)

![image](https://github.com/TASVideos/tasvideos/assets/7092625/4927ef73-5be4-4a32-935f-11556991feee)

