### PR TITLE
Add Pub and Sub counts to Platform Framerates module

### DIFF
--- a/TASVideos.Data/Entity/Game/GameSystemFrameRate.cs
+++ b/TASVideos.Data/Entity/Game/GameSystemFrameRate.cs
@@ -15,6 +15,9 @@ public class GameSystemFrameRate : BaseEntity
 	public bool Preliminary { get; set; }
 
 	public bool Obsolete { get; set; }
+
+	public virtual ICollection<Submission> Submissions { get; set; } = [];
+	public virtual ICollection<Publication> Publications { get; set; } = [];
 }
 
 public static class GameSystemFrameRateExtensions

--- a/TASVideos/WikiModules/PlatformFramerates.cshtml
+++ b/TASVideos/WikiModules/PlatformFramerates.cshtml
@@ -1,6 +1,6 @@
 ﻿@model PlatformFramerates
 <standard-table>
-	<table-head columns="System,Region,Framerate,Preliminary or approximate"></table-head>
+	<table-head columns="System,Region,Framerate,Preliminary or approximate,Publications,Submissions"></table-head>
 	@foreach (var item in Model.Framerates)
 	{
 		<tr class="@(item.Preliminary ? "alert-warning" : "")">
@@ -8,6 +8,8 @@
 			<td>@item.RegionCode</td>
 			<td>@item.FrameRate</td>
 			<td>@item.Preliminary.ToYesNo()</td>
+			<td>@item.PublicationCount</td>
+			<td>@item.SubmissionCount</td>
 		</tr>
 	}
 </standard-table>

--- a/TASVideos/WikiModules/PlatformFramerates.cshtml.cs
+++ b/TASVideos/WikiModules/PlatformFramerates.cshtml.cs
@@ -12,12 +12,13 @@ public class PlatformFramerates(ApplicationDbContext db) : WikiViewComponent
 		Framerates = await db.GameSystemFrameRates
 			.Where(sf => !sf.Obsolete)
 			.OrderBy(sf => sf.System!.Code)
+			.ThenByDescending(sf => sf.Publications.Count + sf.Submissions.Count)
 			.ThenBy(sf => sf.RegionCode)
 			.Select(sf => new Framerate(
-				sf.System!.Code, sf.RegionCode, sf.FrameRate, sf.Preliminary))
+				sf.System!.Code, sf.RegionCode, sf.FrameRate, sf.Preliminary, sf.Publications.Count, sf.Submissions.Count))
 			.ToListAsync();
 		return View();
 	}
 
-	public record Framerate(string SystemCode, string RegionCode, double FrameRate, bool Preliminary);
+	public record Framerate(string SystemCode, string RegionCode, double FrameRate, bool Preliminary, int PublicationCount, int SubmissionCount);
 }


### PR DESCRIPTION
For the page https://tasvideos.org/PlatformFramerates .
We have many single-use framerates. Having the counts make the table more useful as a resource to see which are the "correct" framerates.

Example image:

![image](https://github.com/TASVideos/tasvideos/assets/22375320/3557b241-3901-4f0b-91fe-1a81a08029e1)
