### PR TITLE
Add script-src to Content-Security-Policy

### DIFF
--- a/TASVideos/Extensions/ApplicationBuilderExtensions.cs
+++ b/TASVideos/Extensions/ApplicationBuilderExtensions.cs
@@ -65,7 +65,7 @@ public static class ApplicationBuilderExtensions
 			context.Response.Headers.XContentTypeOptions = "nosniff";
 			context.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
 			context.Response.Headers.XPoweredBy = "";
-			context.Response.Headers.ContentSecurityPolicy = "upgrade-insecure-requests";
+			context.Response.Headers.ContentSecurityPolicy = "upgrade-insecure-requests; script-src 'self' https://code.jquery.com https://cdn.jsdelivr.net";
 			await next();
 		});
 


### PR DESCRIPTION
By adding the script-src to our Content-Security-Policy (CSP), we limit the places scripts can be executed from. This commit 29a84245f862a112bc71bd86c7173ceacf3f8606 prepared us for this, because we don't want to allow unsafe-inline and unsafe-eval.

However, now come some problems. I think some of our embeds throw weird errors with a CSP like this.
Luckily, browsers' javascript console tells us exactly if something failed due to our CSP, so maybe we just need to go through a bunch of our pages to validate everything works.

~~Anyway, the embed problem is why it's a draft for now.~~
Actually, it was my adblocker using CSP to block things. It's an iframe, so it has its own stuff. If we want to block what iframes can do, we need to use a different part of CSP, `frame-src` or `child-src`. But allowing iframes from everywhere is less of a security risk for now.

So this PR is ready now.