### PR TITLE
Content Security Policy: allow Google reCAPTCHA

### DIFF
--- a/TASVideos/Extensions/ApplicationBuilderExtensions.cs
+++ b/TASVideos/Extensions/ApplicationBuilderExtensions.cs
@@ -65,7 +65,7 @@ public static class ApplicationBuilderExtensions
 			context.Response.Headers.XContentTypeOptions = "nosniff";
 			context.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
 			context.Response.Headers.XPoweredBy = "";
-			context.Response.Headers.ContentSecurityPolicy = "upgrade-insecure-requests; script-src 'self' https://code.jquery.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://www.youtube.com";
+			context.Response.Headers.ContentSecurityPolicy = "upgrade-insecure-requests; script-src 'self' https://code.jquery.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://www.youtube.com https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/";
 			await next();
 		});
 


### PR DESCRIPTION
So according to Google, it suggests actually using the nonce-based approach to CSP for the captchas.
But as a workaround, it also supplies the values needed for the header. Maybe we should look into using nonces for google captcha (and also youtube embeds, since they have the same nonce-based thing in their script.)

Reference: https://developers.google.com/recaptcha/docs/faq#im-using-content-security-policy-csp-on-my-website.-how-can-i-configure-it-to-work-with-recaptcha