### PR TITLE
Add fm2 binary parser

### DIFF
--- a/TASVideos.Parsers/Parsers/Fm2.cs
+++ b/TASVideos.Parsers/Parsers/Fm2.cs
@@ -11,7 +11,24 @@ internal class Fm2 : Parser, IParser
 			SystemCode = SystemCodes.Nes
 		};
 
-		(var header, result.Frames) = await file.PipeBasedMovieHeaderAndFrameCount();
+		(var header, int initialFrameCount) = await file.PipeBasedMovieHeaderAndFrameCount();
+
+		if (header.GetBoolFor(Keys.Binary))
+		{
+			int? frameCount = header.GetPositiveIntFor(Keys.Length);
+			if (frameCount.HasValue)
+			{
+				result.Frames = frameCount.Value;
+			}
+			else
+			{
+				return Error("No frame count found for binary format");
+			}
+		}
+		else
+		{
+			result.Frames = initialFrameCount;
+		}
 
 		if (header.GetBoolFor(Keys.Fds))
 		{
@@ -45,6 +62,8 @@ internal class Fm2 : Parser, IParser
 	{
 		public const string RerecordCount = "rerecordcount";
 		public const string Pal = "palFlag";
+		public const string Binary = "binary";
+		public const string Length = "length";
 		public const string Fds = "fds";
 		public const string StartsFromSavestate = "savestate";
 	}

--- a/tests/TASVideos.MovieParsers.Tests/Fm2ParserTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/Fm2ParserTests.cs
@@ -15,7 +15,7 @@ public class Fm2ParserTests : BaseParserTests
 		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
 		Assert.AreEqual(RegionType.Ntsc, result.Region);
 		Assert.AreEqual(21, result.RerecordCount);
-		Assert.AreEqual(SystemCodes.Nes, result.SystemCode, "System chould be NES");
+		Assert.AreEqual(SystemCodes.Nes, result.SystemCode, "System should be NES");
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
 		AssertNoWarningsOrErrors(result);
 	}
@@ -28,7 +28,7 @@ public class Fm2ParserTests : BaseParserTests
 		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
 		Assert.AreEqual(RegionType.Pal, result.Region);
 		Assert.AreEqual(21, result.RerecordCount);
-		Assert.AreEqual(SystemCodes.Nes, result.SystemCode, "System chould be NES");
+		Assert.AreEqual(SystemCodes.Nes, result.SystemCode, "System should be NES");
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
 		AssertNoWarningsOrErrors(result);
 	}
@@ -54,7 +54,7 @@ public class Fm2ParserTests : BaseParserTests
 		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
 		Assert.AreEqual(RegionType.Ntsc, result.Region);
 		Assert.AreEqual(21, result.RerecordCount);
-		Assert.AreEqual(SystemCodes.Nes, result.SystemCode, "System chould be NES");
+		Assert.AreEqual(SystemCodes.Nes, result.SystemCode, "System should be NES");
 		Assert.AreEqual(MovieStartType.Savestate, result.StartType);
 		AssertNoWarningsOrErrors(result);
 	}
@@ -78,5 +78,23 @@ public class Fm2ParserTests : BaseParserTests
 		Assert.AreEqual(0, result.RerecordCount, "Rerecord count assumed to be 0");
 		AssertNoErrors(result);
 		Assert.AreEqual(1, result.Warnings.Count());
+	}
+
+	[TestMethod]
+	public async Task Binary()
+	{
+		var result = await _fm2Parser.Parse(Embedded("binary.fm2"), EmbeddedLength("binary.fm2"));
+		Assert.IsTrue(result.Success, "Result is successful");
+		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
+		AssertNoWarningsOrErrors(result);
+	}
+
+	[TestMethod]
+	public async Task BinaryWithoutFrameCount()
+	{
+		var result = await _fm2Parser.Parse(Embedded("binarynolength.fm2"), EmbeddedLength("binarynolength.fm2"));
+		Assert.IsFalse(result.Success);
+		AssertNoWarnings(result);
+		Assert.AreEqual(1, result.Errors.Count());
 	}
 }

--- a/tests/TASVideos.MovieParsers.Tests/Fm2SampleFiles/binary.fm2
+++ b/tests/TASVideos.MovieParsers.Tests/Fm2SampleFiles/binary.fm2
@@ -1,0 +1,6 @@
+rerecordCount 21
+palFlag 0
+FDS 0
+binary 1
+length 2
+|              A  I  S  r  z  …  MARKERX BOOKMARKX GREENZONX    	   xœc       HISTORX PIANO_ROLX SELECTIOX 

--- a/tests/TASVideos.MovieParsers.Tests/Fm2SampleFiles/binarynolength.fm2
+++ b/tests/TASVideos.MovieParsers.Tests/Fm2SampleFiles/binarynolength.fm2
@@ -1,0 +1,5 @@
+rerecordCount 21
+palFlag 0
+FDS 0
+binary 1
+|              A  I  S  r  z  …  MARKERX BOOKMARKX GREENZONX    	   xœc       HISTORX PIANO_ROLX SELECTIOX 

--- a/tests/TASVideos.MovieParsers.Tests/TASVideos.MovieParsers.Tests.csproj
+++ b/tests/TASVideos.MovieParsers.Tests/TASVideos.MovieParsers.Tests.csproj
@@ -13,6 +13,8 @@
 	  <None Remove="Bk2SampleFiles\System-Nds.bk2" />
 	  <None Remove="Bk2SampleFiles\System-Ndsi.bk2" />
 	  <None Remove="FbmSampleFiles\savestate.fbm" />
+	  <None Remove="Fm2SampleFiles\binary.fm2" />
+	  <None Remove="Fm2SampleFiles\binarynolength.fm2" />
 	  <None Remove="LmpSampleFiles\doesnotendin80.lmp" />
 	  <None Remove="LmpSampleFiles\doom.lmp" />
 	  <None Remove="LtmSampleFiles\annotations.ltm" />


### PR DESCRIPTION
FM2 format officially supports binary format, even though the only way you would probably end up with such a movie is by renaming an FM3.

Does this need a test?