### PR TITLE
Add Flag Weight, Remove PublicationClass Weight

### DIFF
--- a/TASVideos.Core/Services/ClassService.cs
+++ b/TASVideos.Core/Services/ClassService.cs
@@ -46,7 +46,6 @@ internal class ClassService(ApplicationDbContext db, ICacheService cache) : ICla
 			Name = publicationClass.Name,
 			IconPath = publicationClass.IconPath,
 			Link = publicationClass.Link,
-			Weight = publicationClass.Weight
 		});
 
 		try
@@ -81,7 +80,6 @@ internal class ClassService(ApplicationDbContext db, ICacheService cache) : ICla
 		existingClass.Name = publicationClass.Name;
 		existingClass.Link = publicationClass.Link;
 		existingClass.IconPath = publicationClass.IconPath;
-		existingClass.Weight = publicationClass.Weight;
 
 		try
 		{

--- a/TASVideos.Core/Services/FlagsService.cs
+++ b/TASVideos.Core/Services/FlagsService.cs
@@ -62,7 +62,8 @@ internal class FlagService(ApplicationDbContext db, ICacheService cache) : IFlag
 			IconPath = flag.IconPath,
 			LinkPath = flag.LinkPath,
 			Token = flag.Token,
-			PermissionRestriction = flag.PermissionRestriction
+			PermissionRestriction = flag.PermissionRestriction,
+			Weight = flag.Weight
 		});
 
 		try
@@ -99,6 +100,7 @@ internal class FlagService(ApplicationDbContext db, ICacheService cache) : IFlag
 		existingFlag.LinkPath = flag.LinkPath;
 		existingFlag.Token = flag.Token;
 		existingFlag.PermissionRestriction = flag.PermissionRestriction;
+		existingFlag.Weight = flag.Weight;
 
 		try
 		{

--- a/TASVideos.Core/Services/PointsService/PointsService.cs
+++ b/TASVideos.Core/Services/PointsService/PointsService.cs
@@ -95,7 +95,7 @@ internal static class PointsEntityExtensions
 			p.ObsoletedById.HasValue,
 			p.PublicationRatings.Count,
 			p.Authors.Count,
-			p.PublicationClass!.Weight,
+			p.PublicationFlags.Any() ? p.PublicationFlags.Max(pf => pf.Flag!.Weight) : 1,
 			p.PublicationRatings.Count > 0 ? p.PublicationRatings
 				.Where(pr => !pr.Publication!.Authors.Select(a => a.UserId).Contains(pr.UserId))
 				.Where(pr => pr.User!.UseRatings)

--- a/TASVideos.Data/Entity/Flag.cs
+++ b/TASVideos.Data/Entity/Flag.cs
@@ -17,4 +17,6 @@ public class Flag
 	public string Token { get; set; } = "";
 
 	public PermissionTo? PermissionRestriction { get; set; }
+
+	public double Weight { get; set; }
 }

--- a/TASVideos.Data/Entity/PublicationClass.cs
+++ b/TASVideos.Data/Entity/PublicationClass.cs
@@ -7,7 +7,6 @@ public class PublicationClass
 
 	[StringLength(20)]
 	public string Name { get; set; } = "";
-	public double Weight { get; set; }
 
 	[StringLength(100)]
 	public string? IconPath { get; set; }

--- a/TASVideos.Data/Migrations/20240627005453_TransferWeightToFlags.Designer.cs
+++ b/TASVideos.Data/Migrations/20240627005453_TransferWeightToFlags.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using TASVideos.Data;
 namespace TASVideos.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240627005453_TransferWeightToFlags")]
+    partial class TransferWeightToFlags
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TASVideos.Data/Migrations/20240627005453_TransferWeightToFlags.cs
+++ b/TASVideos.Data/Migrations/20240627005453_TransferWeightToFlags.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TASVideos.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class TransferWeightToFlags : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "weight",
+                table: "publication_classes");
+
+            migrationBuilder.AddColumn<double>(
+                name: "weight",
+                table: "flags",
+                type: "double precision",
+                nullable: false,
+                defaultValue: 0.0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "weight",
+                table: "flags");
+
+            migrationBuilder.AddColumn<double>(
+                name: "weight",
+                table: "publication_classes",
+                type: "double precision",
+                nullable: false,
+                defaultValue: 0.0);
+        }
+    }
+}

--- a/TASVideos.Data/Migrations/20240627005453_TransferWeightToFlags.cs
+++ b/TASVideos.Data/Migrations/20240627005453_TransferWeightToFlags.cs
@@ -2,39 +2,38 @@
 
 #nullable disable
 
-namespace TASVideos.Data.Migrations
+namespace TASVideos.Data.Migrations;
+
+/// <inheritdoc />
+public partial class TransferWeightToFlags : Migration
 {
-    /// <inheritdoc />
-    public partial class TransferWeightToFlags : Migration
-    {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropColumn(
-                name: "weight",
-                table: "publication_classes");
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropColumn(
+			name: "weight",
+			table: "publication_classes");
 
-            migrationBuilder.AddColumn<double>(
-                name: "weight",
-                table: "flags",
-                type: "double precision",
-                nullable: false,
-                defaultValue: 0.0);
-        }
+		migrationBuilder.AddColumn<double>(
+			name: "weight",
+			table: "flags",
+			type: "double precision",
+			nullable: false,
+			defaultValue: 0.0);
+	}
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropColumn(
-                name: "weight",
-                table: "flags");
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropColumn(
+			name: "weight",
+			table: "flags");
 
-            migrationBuilder.AddColumn<double>(
-                name: "weight",
-                table: "publication_classes",
-                type: "double precision",
-                nullable: false,
-                defaultValue: 0.0);
-        }
-    }
+		migrationBuilder.AddColumn<double>(
+			name: "weight",
+			table: "publication_classes",
+			type: "double precision",
+			nullable: false,
+			defaultValue: 0.0);
+	}
 }

--- a/TASVideos/Pages/Flags/Create.cshtml
+++ b/TASVideos/Pages/Flags/Create.cshtml
@@ -34,6 +34,11 @@
 				<select asp-for="Flag.PermissionRestriction" asp-items="Model.AvailablePermissions.WithDefaultEntry()"></select>
 				<span asp-validation-for="Flag.PermissionRestriction"></span>
 			</fieldset>
+			<fieldset>
+				<label asp-for="Flag.Weight"></label>
+				<input asp-for="Flag.Weight" />
+				<span asp-validation-for="Flag.Weight"></span>
+			</fieldset>
 		</column>
 	</row>
 	<form-button-bar>

--- a/TASVideos/Pages/Flags/Edit.cshtml
+++ b/TASVideos/Pages/Flags/Edit.cshtml
@@ -43,6 +43,11 @@
 				<select asp-for="Flag.PermissionRestriction" asp-items="Model.AvailablePermissions.WithDefaultEntry()"></select>
 				<span asp-validation-for="Flag.PermissionRestriction"></span>
 			</fieldset>
+			<fieldset>
+				<label asp-for="Flag.Weight"></label>
+				<input asp-for="Flag.Weight" />
+				<span asp-validation-for="Flag.Weight"></span>
+			</fieldset>
 		</column>
 	</row>
 	<form-button-bar>

--- a/TASVideos/Pages/Flags/Index.cshtml
+++ b/TASVideos/Pages/Flags/Index.cshtml
@@ -8,7 +8,7 @@
 	<add-link asp-page="Create"></add-link>
 </top-button-bar>
 <standard-table>
-	<table-head columns="Name,Icon Path,Link Path,Token,Permission Restriction,"></table-head>
+	<table-head columns="Name,Icon Path,Link Path,Token,Permission Restriction,Weight,"></table-head>
 	@foreach (var flag in Model.Flags.OrderBy(f => f.Token))
 	{
 		<tr>
@@ -17,6 +17,7 @@
 			<td>@flag.LinkPath</td>
 			<td>@flag.Token</td>
 			<td>@flag.PermissionRestriction</td>
+			<td>@flag.Weight</td>
 			<td-action-column>
 				<edit-link asp-page="Edit" asp-route-id="@flag.Id"></edit-link>
 			</td-action-column>

--- a/TASVideos/Pages/PublicationClasses/Create.cshtml
+++ b/TASVideos/Pages/PublicationClasses/Create.cshtml
@@ -20,11 +20,6 @@
 		</column>
 		<column lg="6">
 			<fieldset>
-				<label asp-for="PublicationClass.Weight"></label>
-				<input asp-for="PublicationClass.Weight" />
-				<span asp-validation-for="PublicationClass.Weight"></span>
-			</fieldset>
-			<fieldset>
 				<label asp-for="PublicationClass.IconPath"></label>
 				<input asp-for="PublicationClass.IconPath" />
 				<span asp-validation-for="PublicationClass.IconPath"></span>

--- a/TASVideos/Pages/PublicationClasses/Edit.cshtml
+++ b/TASVideos/Pages/PublicationClasses/Edit.cshtml
@@ -28,11 +28,6 @@
 		</column>
 		<column lg="6">
 			<fieldset>
-				<label asp-for="PublicationClass.Weight"></label>
-				<input asp-for="PublicationClass.Weight" />
-				<span asp-validation-for="PublicationClass.Weight"></span>
-			</fieldset>
-			<fieldset>
 				<label asp-for="PublicationClass.IconPath"></label>
 				<input asp-for="PublicationClass.IconPath" />
 				<span asp-validation-for="PublicationClass.IconPath"></span>

--- a/TASVideos/Pages/PublicationClasses/Index.cshtml
+++ b/TASVideos/Pages/PublicationClasses/Index.cshtml
@@ -8,7 +8,7 @@
 	<add-link asp-page="Create"></add-link>
 </top-button-bar>
 <standard-table>
-	<table-head columns="Id,Name,Link,Weight,"></table-head>
+	<table-head columns="Id,Name,Link,"></table-head>
 	@foreach (var pubClass in Model.Classes.OrderBy(t => t.Id))
 	{
 		<tr>
@@ -21,9 +21,6 @@
 			</td>
 			<td>
 				<a href="/@pubClass.Link">@pubClass.Link</a>
-			</td>
-			<td>
-				@pubClass.Weight
 			</td>
 			<td-action-column>
 				<edit-link asp-page="/PublicationClasses/Edit" asp-route-id="@pubClass.Id"></edit-link>

--- a/TASVideos/WikiModules/FirstEditionTas.cshtml.cs
+++ b/TASVideos/WikiModules/FirstEditionTas.cshtml.cs
@@ -46,7 +46,6 @@ public class FirstEditionTas(ApplicationDbContext db) : WikiViewComponent
 		}
 
 		var query = db.Publications
-			.Where(p => p.PublicationClass!.Weight >= 1) // Exclude Vault
 			.Where(p => p.CreateTimestamp >= afterYear)
 			.Where(p => p.CreateTimestamp < beforeYear);
 

--- a/tests/TASVideos.Core.Tests/Services/ClassServiceTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/ClassServiceTests.cs
@@ -92,7 +92,6 @@ public class ClassServiceTests
 			Name = "Name",
 			IconPath = "IconPath",
 			Link = "Link",
-			Weight = 1
 		};
 
 		var (id, result) = await _classService.Add(publicationClass);
@@ -105,7 +104,6 @@ public class ClassServiceTests
 		Assert.AreEqual(publicationClass.Name, savedClass.Name);
 		Assert.AreEqual(publicationClass.IconPath, savedClass.IconPath);
 		Assert.AreEqual(publicationClass.Link, savedClass.Link);
-		Assert.AreEqual(publicationClass.Weight, savedClass.Weight);
 		Assert.IsFalse(_cache.ContainsKey(ClassService.ClassesKey));
 	}
 

--- a/tests/TASVideos.Core.Tests/Services/PointsServiceTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/PointsServiceTests.cs
@@ -36,11 +36,10 @@ public class PointsServiceTests
 	{
 		const int numMovies = 2;
 		var user = _db.AddUser(1, Author);
-		var publicationClass = new PublicationClass { Weight = 1, Name = "Test" };
-		_db.PublicationClasses.Add(publicationClass);
+
 		for (int i = 0; i < numMovies; i++)
 		{
-			_db.Publications.Add(new Publication { PublicationClass = publicationClass });
+			_db.Publications.Add(new Publication());
 		}
 
 		await _db.SaveChangesAsync();
@@ -65,16 +64,12 @@ public class PointsServiceTests
 	public async Task PlayerPoints_OnlyObsoletedPublications_NearZero()
 	{
 		var user = _db.AddUser(1, Author);
-		var publicationClass = new PublicationClass { Weight = 1, Name = "Test" };
-		_db.PublicationClasses.Add(publicationClass);
-		await _db.SaveChangesAsync();
 
 		var newPub = new Publication();
 		var oldPub = new Publication
 		{
 			Authors = [new PublicationAuthor { UserId = user.Entity.Id }],
-			ObsoletedBy = newPub,
-			PublicationClass = publicationClass
+			ObsoletedBy = newPub
 		};
 		_db.Publications.Add(oldPub);
 		_db.Publications.Add(newPub);
@@ -91,19 +86,19 @@ public class PointsServiceTests
 		// 2 authors, 1 for a non-weighted pub and 1 for a weighted pub
 		var author1 = _db.AddUser(1, Author);
 		var author2 = _db.AddUser(2, Author);
-		var nonWeightedClass = new PublicationClass { Id = 1, Weight = 1, Name = "Regular" };
-		var weightedClass = new PublicationClass { Id = 2, Weight = 100, Name = "Weighted" };
-		_db.PublicationClasses.Add(nonWeightedClass);
-		_db.PublicationClasses.Add(weightedClass);
+		var nonWeightedFlag = new Flag { Id = 1, Name = "Regular", Weight = 1 };
+		var weightedFlag = new Flag { Id = 2, Name = "Weighted", Weight = 100 };
+		_db.Flags.Add(nonWeightedFlag);
+		_db.Flags.Add(weightedFlag);
 		var pubNonWeighted = _db.Publications.Add(new Publication
 		{
 			Authors = [new PublicationAuthor { UserId = author1.Entity.Id }],
-			PublicationClass = nonWeightedClass
+			PublicationFlags = [new PublicationFlag { Flag = nonWeightedFlag }]
 		});
 		var pubWeighted = _db.Publications.Add(new Publication
 		{
 			Authors = [new PublicationAuthor { UserId = author2.Entity.Id }],
-			PublicationClass = weightedClass
+			PublicationFlags = [new PublicationFlag { Flag = weightedFlag }]
 		});
 		await _db.SaveChangesAsync();
 


### PR DESCRIPTION
In preparation for turning stars into a flag, flags need a player point weight value.  It has been decided that publication classes will no longer have this.  For points calculation, if there are multiple flags with weight, the highest value will be used.