### PR TITLE
Add/Merge additional params on return urls

### DIFF
--- a/TASVideos/Pages/BasePageModel.cs
+++ b/TASVideos/Pages/BasePageModel.cs
@@ -83,14 +83,27 @@ public class BasePageModel : PageModel
 			? BaseReturnUrlRedirect()
 			: Redirect(page);
 
-	protected IActionResult BaseReturnUrlRedirect(NameValueCollection? additionalParam = null)
+	protected IActionResult BaseReturnUrlRedirect(NameValueCollection? additionalParams = null)
 	{
 		var returnUrl = Request.ReturnUrl();
-		if (additionalParam is not null)
+
+		if (additionalParams is not null)
 		{
-			var returnUrlParams = HttpUtility.ParseQueryString(returnUrl);
-			returnUrlParams.Add(additionalParam);
-			returnUrl = returnUrlParams.ToString();
+			try
+			{
+				var uri = new UriBuilder($"https://localhost/{returnUrl.TrimStart('/')}");
+				var returnQuery = HttpUtility.ParseQueryString(uri.Query);
+				foreach (string? key in additionalParams.AllKeys)
+				{
+					returnQuery[key] = additionalParams[key];
+				}
+
+				uri.Query = returnQuery.ToString();
+				returnUrl = uri.Path + uri.Query;
+			}
+			catch // fall through, because return urls can be messed with by malicious users
+			{
+			}
 		}
 
 		if (!string.IsNullOrWhiteSpace(returnUrl))

--- a/TASVideos/Pages/BasePageModel.cs
+++ b/TASVideos/Pages/BasePageModel.cs
@@ -1,4 +1,6 @@
-﻿using System.Net.Mime;
+﻿using System.Collections.Specialized;
+using System.Net.Mime;
+using System.Web;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -81,9 +83,16 @@ public class BasePageModel : PageModel
 			? BaseReturnUrlRedirect()
 			: Redirect(page);
 
-	protected IActionResult BaseReturnUrlRedirect(string? additionalParam = null)
+	protected IActionResult BaseReturnUrlRedirect(NameValueCollection? additionalParam = null)
 	{
-		var returnUrl = Request.ReturnUrl() + additionalParam;
+		var returnUrl = Request.ReturnUrl();
+		if (additionalParam is not null)
+		{
+			var returnUrlParams = HttpUtility.ParseQueryString(returnUrl);
+			returnUrlParams.Add(additionalParam);
+			returnUrl = returnUrlParams.ToString();
+		}
+
 		if (!string.IsNullOrWhiteSpace(returnUrl))
 		{
 			return Url.IsLocalUrl(returnUrl)

--- a/TASVideos/Pages/BasePageModel.cs
+++ b/TASVideos/Pages/BasePageModel.cs
@@ -87,24 +87,7 @@ public class BasePageModel : PageModel
 	{
 		var returnUrl = Request.ReturnUrl();
 
-		if (additionalParams is not null)
-		{
-			try
-			{
-				var uri = new UriBuilder($"https://localhost/{returnUrl.TrimStart('/')}");
-				var returnQuery = HttpUtility.ParseQueryString(uri.Query);
-				foreach (string? key in additionalParams.AllKeys)
-				{
-					returnQuery[key] = additionalParams[key];
-				}
-
-				uri.Query = returnQuery.ToString();
-				returnUrl = uri.Path + uri.Query;
-			}
-			catch // fall through, because return urls can be messed with by malicious users
-			{
-			}
-		}
+		returnUrl = AddAdditionalParams(returnUrl, additionalParams);
 
 		if (!string.IsNullOrWhiteSpace(returnUrl))
 		{
@@ -114,6 +97,32 @@ public class BasePageModel : PageModel
 		}
 
 		return Home();
+	}
+
+	internal static string AddAdditionalParams(string relativeUrl, NameValueCollection? additionalParams = null)
+	{
+		if (additionalParams is null)
+		{
+			return relativeUrl;
+		}
+
+		try
+		{
+			var uri = new UriBuilder($"https://localhost/{relativeUrl.TrimStart('/')}");
+			var returnQuery = HttpUtility.ParseQueryString(uri.Query);
+			foreach (string? key in additionalParams.AllKeys)
+			{
+				returnQuery[key] = additionalParams[key];
+			}
+
+			uri.Query = returnQuery.ToString();
+			relativeUrl = uri.Path + uri.Query;
+		}
+		catch
+		{
+		}
+
+		return relativeUrl;
 	}
 
 	protected void AddErrors(IdentityResult result)

--- a/TASVideos/Pages/Flags/Edit.cshtml.cs
+++ b/TASVideos/Pages/Flags/Edit.cshtml.cs
@@ -70,6 +70,6 @@ public class EditModel(IFlagService flagService) : BasePageModel
 				break;
 		}
 
-		return BaseReturnUrlRedirect("Index");
+		return BasePageRedirect("Index");
 	}
 }

--- a/TASVideos/Pages/Games/Edit.cshtml.cs
+++ b/TASVideos/Pages/Games/Edit.cshtml.cs
@@ -130,7 +130,7 @@ public class EditModel(
 
 		return string.IsNullOrWhiteSpace(HttpContext.Request.ReturnUrl())
 			? RedirectToPage("Index", new { game.Id })
-			: BaseReturnUrlRedirect($"?GameId={game.Id}");
+			: BaseReturnUrlRedirect(new() { ["GameId"] = game.Id.ToString() });
 	}
 
 	public async Task<IActionResult> OnPostDelete()

--- a/TASVideos/Pages/Games/Versions/Edit.cshtml.cs
+++ b/TASVideos/Pages/Games/Versions/Edit.cshtml.cs
@@ -149,7 +149,7 @@ public class EditModel(ApplicationDbContext db) : BasePageModel
 		SuccessStatusMessage($"Game Version {Id} updated");
 		return string.IsNullOrWhiteSpace(HttpContext.Request.ReturnUrl())
 			? RedirectToPage("List", new { gameId = GameId })
-			: BaseReturnUrlRedirect($"?GameId={GameId}&GameVersionId={version.Id}");
+			: BaseReturnUrlRedirect(new() { ["GameId"] = GameId.ToString(), ["GameVersionId"] = version.Id.ToString() });
 	}
 
 	public async Task<IActionResult> OnPostDelete()

--- a/TASVideos/wwwroot/js/catalog.js
+++ b/TASVideos/wwwroot/js/catalog.js
@@ -64,14 +64,14 @@ function enableCataloging() {
 	}
 
 	document.getElementById('create-version')?.addEventListener('click', function () {
-		document.location = `/Games/${gameModel.value}/Versions/Edit?returnUrl=${returnUrl}&systemId=${systemModel.value}`;
+		document.location = `/Games/${gameModel.value}/Versions/Edit?returnUrl=${encodeURIComponent(returnUrl)}&systemId=${systemModel.value}`;
 	});
 
 	document.getElementById('create-game')?.addEventListener('click', function () {
 		if (returnUrl) {
 			// we do not want to pass query params
 			const split = returnUrl.split('?')[0];
-			document.location = `/Games/Edit?returnUrl=${split}`;
+			document.location = `/Games/Edit?returnUrl=${encodeURIComponent(split)}`;
 		} else {
 			document.location = '/Games/Edit';
 		}
@@ -79,6 +79,6 @@ function enableCataloging() {
 	});
 
 	gameGoalBtn?.addEventListener('click', function () {
-		document.location = `/Games/${gameModel.value}/Goals/List?returnUrl=${returnUrl}`;
+		document.location = `/Games/${gameModel.value}/Goals/List?returnUrl=${encodeURIComponent(returnUrl)}`;
 	});
 }

--- a/TASVideos/wwwroot/js/catalog.js
+++ b/TASVideos/wwwroot/js/catalog.js
@@ -10,7 +10,7 @@ function enableCataloging() {
 	const createVersionBtn = document.getElementById('create-version');
 	const gameGoalModel = document.querySelector('[data-id="goal"]');
 	const gameGoalBtn = document.getElementById('create-goal');
-	const returnUrl = systemModel.dataset.returnUrl;
+	const returnUrl = encodeURIComponent(systemModel.dataset.returnUrl);
 
 	systemModel.onchange = function () {
 		if (this.value) {
@@ -64,21 +64,14 @@ function enableCataloging() {
 	}
 
 	document.getElementById('create-version')?.addEventListener('click', function () {
-		document.location = `/Games/${gameModel.value}/Versions/Edit?returnUrl=${encodeURIComponent(returnUrl)}&systemId=${systemModel.value}`;
+		document.location = `/Games/${gameModel.value}/Versions/Edit?returnUrl=${returnUrl}&systemId=${systemModel.value}`;
 	});
 
 	document.getElementById('create-game')?.addEventListener('click', function () {
-		if (returnUrl) {
-			// we do not want to pass query params
-			const split = returnUrl.split('?')[0];
-			document.location = `/Games/Edit?returnUrl=${encodeURIComponent(split)}`;
-		} else {
-			document.location = '/Games/Edit';
-		}
-
+		document.location = `/Games/Edit?returnUrl=${returnUrl}`;
 	});
 
 	gameGoalBtn?.addEventListener('click', function () {
-		document.location = `/Games/${gameModel.value}/Goals/List?returnUrl=${encodeURIComponent(returnUrl)}`;
+		document.location = `/Games/${gameModel.value}/Goals/List?returnUrl=${returnUrl}`;
 	});
 }

--- a/tests/TASVideos.Test/Pages/BasePageModelTests.cs
+++ b/tests/TASVideos.Test/Pages/BasePageModelTests.cs
@@ -1,12 +1,15 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System.Collections.Specialized;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Routing;
+using TASVideos.Pages;
 
 namespace TASVideos.RazorPages.Tests.Pages;
 
+[TestClass]
 public class BasePageModelTests
 {
 	protected static PageContext TestPageContext()
@@ -20,5 +23,30 @@ public class BasePageModelTests
 		{
 			ViewData = viewData
 		};
+	}
+
+	[TestMethod]
+	[DataRow("", "", new string[0])]
+	[DataRow("/Index", "/Index", new string[0])]
+	[DataRow("/Index", "/Index?GameId=12", new[] { "GameId", "12" })]
+	[DataRow("/Index", "/Index?GameId=12&OtherId=345", new[] { "GameId", "12", "OtherId", "345" })]
+	[DataRow("/Index?Change=67&ChangeToo=890&Unchanged=99", "/Index?Change=444&ChangeToo=555&Unchanged=99&New=11", new[] { "Change", "444", "ChangeToo", "555", "New", "11" })]
+	[DataRow("/", "/?GameId=12", new[] { "GameId", "12" })]
+	public void AddAdditionalParamsTests(string relativeUrl, string expected, string[] additionalParamsStrings)
+	{
+		Assert.IsTrue(additionalParamsStrings.Length % 2 == 0);
+
+		NameValueCollection? additionalParams = null;
+		if (additionalParamsStrings.Length > 0)
+		{
+			additionalParams = [];
+			for (int i = 0; i < additionalParamsStrings.Length; i += 2)
+			{
+				additionalParams[additionalParamsStrings[i]] = additionalParamsStrings[i + 1];
+			}
+		}
+
+		string actual = BasePageModel.AddAdditionalParams(relativeUrl, additionalParams);
+		Assert.AreEqual(expected, actual);
 	}
 }


### PR DESCRIPTION
Resolves the bug where we would redirect to a page with two `?`, breaking the query.

To recreate the bug
- go to Submission Catalog
- click New next to Game to create a new game, enter some stuff, and Save
- you get redirected back, notice you're now on a url like `/Submissions/Catalog/7251?GameId=2356`
- click New next to Game Version to create a new version, enter some stuff, and Save
- you get redirected back again, notice you're now on a url like `/Submissions/Catalog/7251?GameId=2356?GameId=2356&GameVersionId=4820`

That's the bug, there are two `?` in that final link. Only the first `?` counts, so the query sets `GameId` to `2356?GameId=2356`.

~~After this PR the final link will look like `/Submissions/Catalog/7251?GameId=2356&GameId=2356&GameVersionId=4820`.
Notice how there are still two `GameId`s, but it works (and query string expliticly allow multiple settings of the same value).~~

After this PR the final link will look like `/Submissions/Catalog/7251?GameId=2356&GameVersionId=4820`.