### PR TITLE
Select Improver: Remove inital flashing of old select

### DIFF
--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -164,6 +164,7 @@
 		</script>
 	}
 	<script condition="ViewData.UsesSelectImprover()" src="/js/select-improver.js"></script>
+	<noscript condition="ViewData.UsesSelectImprover()"><style>.d-none-js { display: block !important; }</style></noscript>
 	<script condition="ViewData.UsesUserSearch()" src="/js/user-search.js"></script>
 	<script condition="ViewData.UsesBackupText()" src="/js/backup-text.js"></script>
 	<script condition="ViewData.UsesStringList()" src="/js/string-list.js"></script>

--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -164,7 +164,7 @@
 		</script>
 	}
 	<script condition="ViewData.UsesSelectImprover()" src="/js/select-improver.js"></script>
-	<noscript condition="ViewData.UsesSelectImprover()"><style>.d-none-js { display: block !important; }</style></noscript>
+	<noscript condition="ViewData.UsesSelectImprover()"><style>.d-none-except-noscript { display: block !important; }</style></noscript>
 	<script condition="ViewData.UsesUserSearch()" src="/js/user-search.js"></script>
 	<script condition="ViewData.UsesBackupText()" src="/js/backup-text.js"></script>
 	<script condition="ViewData.UsesStringList()" src="/js/string-list.js"></script>

--- a/TASVideos/TagHelpers/Attributes/MultiSelectTagHelper.cs
+++ b/TASVideos/TagHelpers/Attributes/MultiSelectTagHelper.cs
@@ -18,7 +18,7 @@ public class MultiselectTagHelper : TagHelper
 		if (Multiselect)
 		{
 			output.Attributes.Add("data-multiselect", "true");
-			output.AddCssClass("d-none-js");
+			output.AddCssClass("d-none-except-noscript");
 			ViewContext.ViewData.UseSelectImprover();
 		}
 	}

--- a/TASVideos/TagHelpers/Attributes/MultiSelectTagHelper.cs
+++ b/TASVideos/TagHelpers/Attributes/MultiSelectTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
+﻿using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace TASVideos.TagHelpers;
@@ -13,11 +14,30 @@ public class MultiselectTagHelper : TagHelper
 	[ViewContext]
 	public ViewContext ViewContext { get; set; } = new();
 
+	public override int Order => 1; // needs to be executed after other TagHelpers
+
 	public override void Process(TagHelperContext context, TagHelperOutput output)
 	{
 		if (Multiselect)
 		{
-			output.Attributes.Add("data-multiselect", "true");
+			TagBuilder selectTag = new("select");
+			selectTag.MergeAttributes(output.Attributes.ToDictionary(a => a.Name, a => a.Value.ToString()));
+			HtmlContentBuilder tempContentBuilder = new();
+			output.PostContent.MoveTo(tempContentBuilder);
+			selectTag.InnerHtml.AppendHtml(tempContentBuilder);
+
+			TagBuilder noscriptTag = new("noscript");
+			noscriptTag.InnerHtml.AppendHtml(selectTag);
+
+			TagBuilder templateTag = new("template");
+			templateTag.Attributes.Add("data-multiselect", "true");
+			templateTag.InnerHtml.AppendHtml(selectTag);
+
+			output.TagName = "div";
+			output.Attributes.Clear();
+			output.Content.SetHtmlContent(noscriptTag);
+			output.Content.AppendHtml(templateTag);
+
 			ViewContext.ViewData.UseSelectImprover();
 		}
 	}

--- a/TASVideos/TagHelpers/Attributes/MultiSelectTagHelper.cs
+++ b/TASVideos/TagHelpers/Attributes/MultiSelectTagHelper.cs
@@ -18,6 +18,7 @@ public class MultiselectTagHelper : TagHelper
 		if (Multiselect)
 		{
 			output.Attributes.Add("data-multiselect", "true");
+			output.AddCssClass("d-none-js");
 			ViewContext.ViewData.UseSelectImprover();
 		}
 	}

--- a/TASVideos/TagHelpers/Attributes/MultiSelectTagHelper.cs
+++ b/TASVideos/TagHelpers/Attributes/MultiSelectTagHelper.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
+﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace TASVideos.TagHelpers;
@@ -14,30 +13,11 @@ public class MultiselectTagHelper : TagHelper
 	[ViewContext]
 	public ViewContext ViewContext { get; set; } = new();
 
-	public override int Order => 1; // needs to be executed after other TagHelpers
-
 	public override void Process(TagHelperContext context, TagHelperOutput output)
 	{
 		if (Multiselect)
 		{
-			TagBuilder selectTag = new("select");
-			selectTag.MergeAttributes(output.Attributes.ToDictionary(a => a.Name, a => a.Value.ToString()));
-			HtmlContentBuilder tempContentBuilder = new();
-			output.PostContent.MoveTo(tempContentBuilder);
-			selectTag.InnerHtml.AppendHtml(tempContentBuilder);
-
-			TagBuilder noscriptTag = new("noscript");
-			noscriptTag.InnerHtml.AppendHtml(selectTag);
-
-			TagBuilder templateTag = new("template");
-			templateTag.Attributes.Add("data-multiselect", "true");
-			templateTag.InnerHtml.AppendHtml(selectTag);
-
-			output.TagName = "div";
-			output.Attributes.Clear();
-			output.Content.SetHtmlContent(noscriptTag);
-			output.Content.AppendHtml(templateTag);
-
+			output.Attributes.Add("data-multiselect", "true");
 			ViewContext.ViewData.UseSelectImprover();
 		}
 	}

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -718,6 +718,6 @@ top-button-bar {
 	}
 }
 
-.d-none-js {
+.d-none-except-noscript {
 	display: none !important;
 }

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -717,3 +717,7 @@ top-button-bar {
 		}
 	}
 }
+
+.d-none-js {
+	display: none !important;
+}

--- a/TASVideos/wwwroot/js/select-improver.js
+++ b/TASVideos/wwwroot/js/select-improver.js
@@ -103,7 +103,6 @@ function engageSelectImprover(multiSelectId, maxHeight = 250) {
 </div>
 `;
 	let multiSelect = document.getElementById(multiSelectId);
-	multiSelect.classList.add('d-none');
 	let div = document.getElementById(multiSelectId + '_div');
 	div?.remove();
 	multiSelect.insertAdjacentHTML('afterend', initialHtmlToAdd);

--- a/TASVideos/wwwroot/js/select-improver.js
+++ b/TASVideos/wwwroot/js/select-improver.js
@@ -3,10 +3,7 @@
 function findAndEngageMultiselects() {
 	const selects = Array.from(document.querySelectorAll('[data-multiselect="true"]'));
 	selects.forEach(select => {
-		const selectFromTemplate = select.content.cloneNode(true).firstElementChild;
-		selectFromTemplate.classList.add('d-none');
-		select.insertAdjacentElement('afterend', selectFromTemplate);
-		engageSelectImprover(selectFromTemplate.id);
+		engageSelectImprover(select.id);
 	});
 }
 

--- a/TASVideos/wwwroot/js/select-improver.js
+++ b/TASVideos/wwwroot/js/select-improver.js
@@ -3,7 +3,10 @@
 function findAndEngageMultiselects() {
 	const selects = Array.from(document.querySelectorAll('[data-multiselect="true"]'));
 	selects.forEach(select => {
-		engageSelectImprover(select.id);
+		const selectFromTemplate = select.content.cloneNode(true).firstElementChild;
+		selectFromTemplate.classList.add('d-none');
+		select.insertAdjacentElement('afterend', selectFromTemplate);
+		engageSelectImprover(selectFromTemplate.id);
 	});
 }
 


### PR DESCRIPTION
This PR hides the original select by default, and uses the `<noscript>` tag to set the style back to visible, for noscripters.
This PR also improves performance, because the intial render doesn't render the select, as it is already hidden when the html comes from the server.