### PR TITLE
Disable User from AutoHistory

### DIFF
--- a/TASVideos.Data/Entity/User.cs
+++ b/TASVideos.Data/Entity/User.cs
@@ -7,6 +7,7 @@ public enum UserPreference
 	Auto = 0, Always, Never
 }
 
+[ExcludeFromHistory]
 public class User : IdentityUser<int>, ITrackable
 {
 	[StringLength(50)]


### PR DESCRIPTION
The Asp Net Core IdentityUser doesn't play nice with autohistory. Many IdentityUser properties are set to "Modified", causing autohistory to log them every time the user is changed. Which happens on every claim verification.

After merging and deploying, we should remove old data by executing:
```sql
DELETE FROM auto_history
WHERE table_name = 'users'
```