### PR TITLE
Dispose of Transactions in a Sync instead of Async manner

### DIFF
--- a/TASVideos.Core/Data/DbInitializer.cs
+++ b/TASVideos.Core/Data/DbInitializer.cs
@@ -56,7 +56,7 @@ public static class DbInitializer
 	private static async Task GenerateDevSampleData(DbContext context)
 	{
 		var sql = await GetSampleDataScript();
-		await using (await context.Database.BeginTransactionAsync())
+		using (await context.Database.BeginTransactionAsync())
 		{
 			var commands = new[] { sql };
 

--- a/TASVideos/Pages/Forum/Topics/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Create.cshtml.cs
@@ -118,7 +118,7 @@ public class CreateModel(
 			ForumId = ForumId
 		};
 
-		await using var dbTransaction = await db.Database.BeginTransactionAsync();
+		using var dbTransaction = await db.Database.BeginTransactionAsync();
 		db.ForumTopics.Add(topic);
 		await db.SaveChangesAsync();
 

--- a/TASVideos/Pages/Submissions/Submit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Submit.cshtml.cs
@@ -113,7 +113,7 @@ public class SubmitModel(
 			return Page();
 		}
 
-		await using var dbTransaction = await db.Database.BeginTransactionAsync();
+		using var dbTransaction = await db.Database.BeginTransactionAsync();
 		var submission = new Submission
 		{
 			SubmittedGameVersion = GameVersion,


### PR DESCRIPTION
The Transaction needs to be disposed before the DbContext.
This might fix the 30s timeout problem we were having with transient db errors.