### PR TITLE
Fix the Hide button of the show-more feature

### DIFF
--- a/TASVideos/wwwroot/js/show-more.js
+++ b/TASVideos/wwwroot/js/show-more.js
@@ -36,5 +36,5 @@ function registerShowMore(content) {
     };
 
     show.querySelector('a').onclick = () => false;
-    show.querySelector('a').onclick = () => false;
+    hide.querySelector('a').onclick = () => false;
 }


### PR DESCRIPTION
It accidentally scrolled you to the top of the page due to the anchor not returning false.