### PR TITLE
Fix Submission List Paging

### DIFF
--- a/TASVideos/Pages/Submissions/Index.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Index.cshtml.cs
@@ -49,7 +49,7 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 		Submissions = new SubmissionPageOf<SubmissionEntry>(entries)
 		{
 			Years = Search.Years,
-			StatusFilter = Search.Statuses,
+			Statuses = Search.Statuses,
 			System = Search.System,
 			GameId = Search.GameId,
 			User = Search.User
@@ -100,7 +100,7 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 	public class SubmissionPageOf<T>(IEnumerable<T> items) : PageOf<T>(items)
 	{
 		public IEnumerable<int> Years { get; set; } = [];
-		public IEnumerable<SubmissionStatus> StatusFilter { get; set; } = [];
+		public IEnumerable<SubmissionStatus> Statuses { get; set; } = [];
 		public string? System { get; set; }
 		public string? User { get; set; }
 		public string? GameId { get; set; }


### PR DESCRIPTION
Submission List Paging was broken. Your search fields were lost on page 2.

The reason for this was the `StatusFilter` was refactored into `Statuses` 2 months ago, but it seems the Pager is only loosely coupled to the Search. By which I mean not coupled at all except for both incidentally having the same property names.

Isn't this bad?

I've noticed this same non-coupling on /Games/List, where your "Starts With" search is lost on page 2.