### PR TITLE
list playground submissions on game pages

### DIFF
--- a/TASVideos/Pages/Games/Index.cshtml
+++ b/TASVideos/Pages/Games/Index.cshtml
@@ -131,7 +131,7 @@
 		{
 			<div id="tab-goal-@(goal.Id)" class="tab-pane fade@(goal==Model.Game.PlaygroundGoals.First() ? " active show" : "")">
 				<ul>
-					@foreach (var sub in goal.Submissions.OrderByDescending(s => s.Id))
+					@foreach (var sub in goal.Submissions)
 					{
 						<li>
 							<sub-link id="@sub.Id">@sub.Title</sub-link>

--- a/TASVideos/Pages/Games/Index.cshtml
+++ b/TASVideos/Pages/Games/Index.cshtml
@@ -91,7 +91,9 @@
 		@foreach (var movie in Model.Movies)
 		{
 			<li class="nav-item">
-				<a class="nav-link@(movie==Model.Movies.First() ? " active" : "")" href="#tab-@(movie.Movie.Id)M" data-bs-toggle="tab">
+				<a class="nav-link@(movie==Model.Movies.First() ? " active" : "")"
+				   href="#tab-@(movie.Movie.Id)M"
+				   data-bs-toggle="tab">
 					<span condition="!string.IsNullOrEmpty(movie.TabTitleRegular)">@movie.TabTitleRegular</span>
 					<span condition="!string.IsNullOrEmpty(movie.TabTitleBold)" class="fw-bold">"@(movie.TabTitleBold)"</span>
 				</a>
@@ -108,6 +110,39 @@
 	</div>
 	<small condition="@(Model.Movies.Any(m => m.Movie.Goal == "baseline"))" class="text-body-tertiary">The baseline tab shows the default movie beating the game as fast as possible without any special conditions.</small>
 </div>
+<br />
+
+<div condition="Model.Game.PlaygroundGoals.Any()">
+	<h3>Playground</h3>
+	<ul class="nav nav-tabs" role="tablist">
+		@foreach (var goal in Model.Game.PlaygroundGoals)
+		{
+			<li class="nav-item">
+				<a class="nav-link@(goal==Model.Game.PlaygroundGoals.First() ? " active" : "")"
+				   href="#tab-goal-@(goal.Id)"
+				   data-bs-toggle="tab">
+					@goal.Name
+				</a>
+			</li>
+		}
+	</ul>
+	<div class="tab-content">
+		@foreach (var goal in Model.Game.PlaygroundGoals)
+		{
+			<div id="tab-goal-@(goal.Id)" class="tab-pane fade@(goal==Model.Game.PlaygroundGoals.First() ? " active show" : "")">
+				<ul>
+					@foreach (var sub in goal.Submissions.OrderByDescending(s => s.Id))
+					{
+						<li>
+							<sub-link id="@sub.Id">@sub.Title</sub-link>
+						</li>
+					}
+				</ul>
+			</div>
+		}
+	</div>
+</div>
+
 <row class="my-3">
 	<column md="6">
 		<ul>
@@ -130,15 +165,15 @@
 				<a href="/UserFiles/Game/@(Model.Game.Id)">
 					@Model.Game.UserFilesCount User Files
 				</a>
-            </li>
-            <li condition="Model.Game.PublicationCount > 0">
-                <a asp-page="PublicationHistory" asp-route-id="@Model.Game.Id">Publication History</a>
-            </li>
-            <li>
+			</li>
+			<li condition="Model.Game.PublicationCount > 0">
+				<a asp-page="PublicationHistory" asp-route-id="@Model.Game.Id">Publication History</a>
+			</li>
+			<li>
 				<a href="/Games/@(Model.Game.Id)/Goals/List">
-                    Goals
-                </a>
-            </li>
+					Goals
+				</a>
+			</li>
 		</ul>
 	</column>
 	<column md="6" condition="Model.WatchFiles.Any()">

--- a/TASVideos/Pages/Games/Index.cshtml.cs
+++ b/TASVideos/Pages/Games/Index.cshtml.cs
@@ -44,15 +44,15 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 			UserFilesCount = g.UserFiles.Count(uf => !uf.Hidden),
 			PlaygroundGoals = g.Submissions
 				.Where(s => s.Status == SubmissionStatus.Playground)
-				.Select(s => s.GameGoal)
-				.Select(g => new GoalEntry(
-					g.Id,
-					g.DisplayName,
-					g.Submissions
-						.Where(s => s.Status == SubmissionStatus.Playground)
-						.Select(s => new SubmissionEntry(s.Id, s.Title))
+				.GroupBy(s => s.GameGoal)
+				.OrderBy(gg => gg.Key!.DisplayName.Length)
+				.Select(gg => new GoalEntry(
+					gg.Key!.Id,
+					gg.Key!.DisplayName,
+					gg.OrderByDescending(ggs => ggs.Id)
+						.Select(ggs => new SubmissionEntry(ggs.Id, ggs.Title))
 						.ToList()))
-				.ToList()
+				.ToList(),
 		});
 
 		query = ParsedId > 0

--- a/TASVideos/Pages/Games/Index.cshtml.cs
+++ b/TASVideos/Pages/Games/Index.cshtml.cs
@@ -41,7 +41,18 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 			PublicationCount = g.Publications.Count(p => p.ObsoletedById == null),
 			ObsoletePublicationCount = g.Publications.Count(p => p.ObsoletedById != null),
 			SubmissionCount = g.Submissions.Count,
-			UserFilesCount = g.UserFiles.Count(uf => !uf.Hidden)
+			UserFilesCount = g.UserFiles.Count(uf => !uf.Hidden),
+			PlaygroundGoals = g.Submissions
+				.Where(s => s.Status == SubmissionStatus.Playground)
+				.Select(s => s.GameGoal)
+				.Select(g => new GoalEntry(
+					g.Id,
+					g.DisplayName,
+					g.Submissions
+						.Where(s => s.Status == SubmissionStatus.Playground)
+						.Select(s => new SubmissionEntry(s.Id, s.Title))
+						.ToList()))
+				.ToList()
 		});
 
 		query = ParsedId > 0
@@ -116,6 +127,8 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 
 	public record WatchFile(long Id, string FileName);
 	public record TopicEntry(int Id, string Title);
+	public record GoalEntry(int Id, string Name, List<SubmissionEntry> Submissions);
+	public record SubmissionEntry(int Id, string Title);
 
 	public class GameDisplay
 	{
@@ -128,6 +141,7 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 		public List<string> Genres { get; init; } = [];
 		public List<GameVersion> Versions { get; init; } = [];
 		public List<GameGroup> GameGroups { get; init; } = [];
+		public List<GoalEntry> PlaygroundGoals { get; set; } = [];
 		public int PublicationCount { get; init; }
 		public int ObsoletePublicationCount { get; init; }
 		public int SubmissionCount { get; init; }


### PR DESCRIPTION
Meant to close #1239

The query is bad but I failed to understand adelikat's explanations on how to improve it. `Select()` is absolute black magic for me, and I barely ever touched db manip.

The tabs need to be sorted too, but I thought it'd be bad to sort them in the 2 `foreach` places, and they should be sorted on the cs side, but it crashes if I add `.OrderBy(g => g.Name.Length)` to my query.

Whenever we have individual PG entries we may change the listed links to point to them instead, but this should be good for now.