### PR TITLE
Rewrite Paging system a bit

### DIFF
--- a/TASVideos.Core/Paging/PageOf.cs
+++ b/TASVideos.Core/Paging/PageOf.cs
@@ -6,14 +6,14 @@ public class PageOf<T>(IEnumerable<T> items, PagingModel request) : PageOf<T, Pa
 {
 }
 
-public class PageOf<T, T2>(IEnumerable<T> items, T2 request) : IPaged<T2>, IEnumerable<T>
-	where T2 : IRequest
+public class PageOf<TItem, TRequest>(IEnumerable<TItem> items, TRequest request) : IPaged<TRequest>, IEnumerable<TItem>
+	where TRequest : IRequest
 {
-	public T2 Request { get; init; } = request;
+	public TRequest Request { get; init; } = request;
 
 	public int RowCount { get; init; }
 
-	public IEnumerator<T> GetEnumerator() => items.GetEnumerator();
+	public IEnumerator<TItem> GetEnumerator() => items.GetEnumerator();
 	IEnumerator IEnumerable.GetEnumerator() => items.GetEnumerator();
 }
 

--- a/TASVideos.Core/Paging/PageOf.cs
+++ b/TASVideos.Core/Paging/PageOf.cs
@@ -2,35 +2,25 @@
 
 namespace TASVideos.Core;
 
-public class PageOf<T> : IPaged, IEnumerable<T>
+public class PageOf<T>(IEnumerable<T> items, PagingModel request) : PageOf<T, PagingModel>(items, request)
 {
-	private readonly IEnumerable<T> _items;
+}
 
-	public PageOf(IEnumerable<T> items)
-	{
-		_items = items;
-		if (_items is PageOf<T> pageOf)
-		{
-			RowCount = pageOf.RowCount;
-			Sort = pageOf.Sort;
-			PageSize = pageOf.PageSize;
-			CurrentPage = pageOf.CurrentPage;
-		}
-	}
+public class PageOf<T, T2>(IEnumerable<T> items, T2 request) : IPaged<T2>, IEnumerable<T>
+	where T2 : IRequest
+{
+	public T2 Request { get; init; } = request;
 
 	public int RowCount { get; init; }
-	public string? Sort { get; init; }
-	public int? PageSize { get; init; }
-	public int? CurrentPage { get; init; }
 
-	public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
-	IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+	public IEnumerator<T> GetEnumerator() => items.GetEnumerator();
+	IEnumerator IEnumerable.GetEnumerator() => items.GetEnumerator();
 }
 
 /// <summary>
 /// Represents all the data necessary to create a paged query.
 /// </summary>
-public class PagingModel : ISortable, IPageable
+public class PagingModel : IRequest
 {
 	public string? Sort { get; set; }
 	public int? PageSize { get; set; } = 25;

--- a/TASVideos.Core/Paging/Paginator.cs
+++ b/TASVideos.Core/Paging/Paginator.cs
@@ -11,28 +11,28 @@ public static class Paginator
 	/// </summary>
 	/// <param name="query">The query to paginate and run.</param>
 	/// <param name="paging">The paging data to use.</param>
-	/// <typeparam name="T">The result type of the query.</typeparam>
-	public static async Task<PageOf<T>> SortedPageOf<T>(this IQueryable<T> query, PagingModel paging)
-		where T : class
+	/// <typeparam name="TItem">The result type of the query.</typeparam>
+	public static async Task<PageOf<TItem>> SortedPageOf<TItem>(this IQueryable<TItem> query, PagingModel paging)
+		where TItem : class
 	{
 		return await query
 			.SortBy(paging)
 			.PageOf(paging);
 	}
 
-	public static async Task<PageOf<T, T2>> SortedPageOf<T, T2>(this IQueryable<T> query, T2 paging)
-		where T : class
-		where T2 : PagingModel
+	public static async Task<PageOf<TItem, TRequest>> SortedPageOf<TItem, TRequest>(this IQueryable<TItem> query, TRequest paging)
+		where TItem : class
+		where TRequest : PagingModel
 	{
 		return await query
 			.SortBy(paging)
 			.PageOf(paging);
 	}
 
-	public static async Task<PageOf<T>> PageOf<T>(
-		this IQueryable<T> query,
+	public static async Task<PageOf<TItem>> PageOf<TItem>(
+		this IQueryable<TItem> query,
 		PagingModel paging)
-		where T : class
+		where TItem : class
 	{
 		int rowsToSkip = paging.Offset();
 
@@ -46,10 +46,10 @@ public static class Paginator
 			newQuery = newQuery.Take(pageSize);
 		}
 
-		IEnumerable<T> results = await newQuery
+		IEnumerable<TItem> results = await newQuery
 			.ToListAsync();
 
-		var pageOf = new PageOf<T>(results, paging)
+		var pageOf = new PageOf<TItem>(results, paging)
 		{
 			RowCount = rowCount,
 		};
@@ -57,11 +57,11 @@ public static class Paginator
 		return pageOf;
 	}
 
-	public static async Task<PageOf<T, T2>> PageOf<T, T2>(
-		this IQueryable<T> query,
-		T2 paging)
-		where T : class
-		where T2 : PagingModel
+	public static async Task<PageOf<TItem, TRequest>> PageOf<TItem, TRequest>(
+		this IQueryable<TItem> query,
+		TRequest paging)
+		where TItem : class
+		where TRequest : PagingModel
 	{
 		int rowsToSkip = paging.Offset();
 
@@ -75,10 +75,10 @@ public static class Paginator
 			newQuery = newQuery.Take(pageSize);
 		}
 
-		IEnumerable<T> results = await newQuery
+		IEnumerable<TItem> results = await newQuery
 			.ToListAsync();
 
-		var pageOf = new PageOf<T, T2>(results, paging)
+		var pageOf = new PageOf<TItem, TRequest>(results, paging)
 		{
 			RowCount = rowCount,
 		};

--- a/TASVideos.Core/Services/RatingService.cs
+++ b/TASVideos.Core/Services/RatingService.cs
@@ -103,7 +103,7 @@ internal class RatingService(ApplicationDbContext db) : IRatingService
 			return dto;
 		}
 
-		var ratings = await db.PublicationRatings
+		dto.Ratings = await db.PublicationRatings
 			.ForUser(dto.Id)
 			.IncludeObsolete(paging.IncludeObsolete)
 			.Select(pr => new UserRatings.Rating
@@ -114,11 +114,6 @@ internal class RatingService(ApplicationDbContext db) : IRatingService
 				Value = pr.Value
 			})
 			.SortedPageOf(paging);
-
-		dto.Ratings = new RatingPageOf<UserRatings.Rating>(ratings)
-		{
-			IncludeObsolete = paging.IncludeObsolete,
-		};
 
 		return dto;
 	}
@@ -132,7 +127,7 @@ public class UserRatings
 	public string UserName { get; init; } = "";
 	public bool PublicRatings { get; init; }
 
-	public RatingPageOf<Rating> Ratings { get; set; } = new([]);
+	public PageOf<Rating, RatingRequest> Ratings { get; set; } = new([], new());
 
 	public class Rating
 	{
@@ -159,9 +154,4 @@ public class RatingRequest : PagingModel
 	}
 
 	public bool IncludeObsolete { get; set; }
-}
-
-public class RatingPageOf<T>(IEnumerable<T> items) : PageOf<T>(items)
-{
-	public bool IncludeObsolete { get; init; }
 }

--- a/TASVideos/Pages/Forum/Posts/Latest.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Latest.cshtml.cs
@@ -8,7 +8,7 @@ public class LatestModel(ApplicationDbContext db) : BasePageModel
 	[FromQuery]
 	public PagingModel Search { get; set; } = new();
 
-	public PageOf<LatestPost> Posts { get; set; } = new([]);
+	public PageOf<LatestPost> Posts { get; set; } = new([], new());
 
 	public async Task OnGet()
 	{

--- a/TASVideos/Pages/Forum/Posts/New.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/New.cshtml.cs
@@ -9,7 +9,7 @@ public class NewModel(ApplicationDbContext db, UserManager userManager) : BasePa
 	[FromQuery]
 	public PagingModel Search { get; set; } = new();
 
-	public PageOf<LatestModel.LatestPost> Posts { get; set; } = new([]);
+	public PageOf<LatestModel.LatestPost> Posts { get; set; } = new([], new());
 
 	public async Task OnGet()
 	{

--- a/TASVideos/Pages/Forum/Posts/Unanswered.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Unanswered.cshtml.cs
@@ -8,7 +8,7 @@ public class UnansweredModel(ApplicationDbContext db) : BasePageModel
 	[FromQuery]
 	public PagingModel Search { get; set; } = new();
 
-	public PageOf<UnansweredPosts> Posts { get; set; } = new([]);
+	public PageOf<UnansweredPosts> Posts { get; set; } = new([], new());
 
 	public async Task OnGet()
 	{

--- a/TASVideos/Pages/Forum/Posts/User.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/User.cshtml.cs
@@ -11,7 +11,7 @@ public class UserModel(ApplicationDbContext db, IAwards awards, IPointsService p
 	[FromQuery]
 	public TopicRequest Search { get; set; } = new();
 
-	public PageOf<UserPagePost> Posts { get; set; } = new([]);
+	public PageOf<UserPagePost, TopicRequest> Posts { get; set; } = new([], new());
 
 	public async Task<IActionResult> OnGet()
 	{

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
@@ -13,7 +13,7 @@ public class IndexModel(ApplicationDbContext db, IForumService forumService) : B
 	public int Id { get; set; }
 
 	public ForumDisplay Forum { get; set; } = null!;
-	public PageOf<ForumTopicEntry> Topics { get; set; } = new([]);
+	public PageOf<ForumTopicEntry> Topics { get; set; } = new([], new());
 	public Dictionary<int, (string PostsCreated, string PostsEdited)> ActivityTopics { get; set; } = [];
 
 	public async Task<IActionResult> OnGet()

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
@@ -315,7 +315,7 @@ public class IndexModel(
 		public int ForumId { get; init; }
 		public string ForumName { get; init; } = "";
 		public int? SubmissionId { get; init; }
-		public PageOf<PostEntry> Posts { get; set; } = new([]);
+		public PageOf<PostEntry, TopicRequest> Posts { get; set; } = new([], new());
 		public PollModel? Poll { get; init; }
 		public int? GameId { get; init; }
 		public string? GameName { get; init; }

--- a/TASVideos/Pages/Games/List.cshtml
+++ b/TASVideos/Pages/Games/List.cshtml
@@ -2,9 +2,9 @@
 @model ListModel
 @{
 	ViewData.SetTitle("Game List" +
-		(!string.IsNullOrWhiteSpace(Model.Games.System) ? " - " + Model.Games.System : "") +
-		(!string.IsNullOrWhiteSpace(Model.Games.StartsWith) ? " - " + Model.Games.StartsWith : "") +
-		(!string.IsNullOrWhiteSpace(Model.Games.SearchTerms) ? " - " + $@"""{Model.Games.SearchTerms}""" : ""));
+		(!string.IsNullOrWhiteSpace(Model.Search.System) ? " - " + Model.Search.System : "") +
+		(!string.IsNullOrWhiteSpace(Model.Search.StartsWith) ? " - " + Model.Search.StartsWith : "") +
+		(!string.IsNullOrWhiteSpace(Model.Search.SearchTerms) ? " - " + $@"""{Model.Search.SearchTerms}""" : ""));
 }
 
 <div class="row">
@@ -25,28 +25,28 @@
 			<div class="row mb-1">
 				<div class="col-5 mb-1">
 					<div class="input-group">
-						<label asp-for="@Model.Games.System" class="input-group-text"></label>
-						<select asp-items="@Model.SystemList" asp-for="@Model.Games.System" name="System"></select>
+						<label asp-for="@Model.Search.System" class="input-group-text"></label>
+						<select asp-items="@Model.SystemList" asp-for="@Model.Search.System" name="System"></select>
 					</div>
 				</div>
 				<div class="col-5 mb-1">
 					<div class="input-group">
-						<label asp-for="@Model.Games.StartsWith" class="input-group-text"></label>
-						<select asp-items="@Model.LetterList" asp-for="@Model.Games.StartsWith" name="Letter"></select>
+						<label asp-for="@Model.Search.StartsWith" class="input-group-text"></label>
+						<select asp-items="@Model.LetterList" asp-for="@Model.Search.StartsWith" name="StartsWith"></select>
 					</div>
 				</div>
 			</div>
 			<div class="row mb-1">
 				<div class="col-5 mb-1">
 					<div class="input-group">
-						<label asp-for="@Model.Games.Genre" class="input-group-text"></label>
-						<select asp-for="@Model.Games.Genre" asp-items="@Model.GenreList" name="Genre"></select>
+						<label asp-for="@Model.Search.Genre" class="input-group-text"></label>
+						<select asp-for="@Model.Search.Genre" asp-items="@Model.GenreList" name="GenreList"></select>
 					</div>
 				</div>
 				<div class="col-5 mb-1">
 					<div class="input-group">
-						<label asp-for="@Model.Games.Group" class="input-group-text"></label>
-						<select asp-for="@Model.Games.Group" asp-items="@Model.GroupList" name="Group"></select>
+						<label asp-for="@Model.Search.Group" class="input-group-text"></label>
+						<select asp-for="@Model.Search.Group" asp-items="@Model.GroupList" name="GroupList"></select>
 					</div>
 				</div>
 			</div>

--- a/TASVideos/Pages/Logs/Index.cshtml.cs
+++ b/TASVideos/Pages/Logs/Index.cshtml.cs
@@ -8,7 +8,7 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 	[FromQuery]
 	public LogPaging Search { get; set; } = new();
 
-	public PageOf<LogEntry> History { get; set; } = new([]);
+	public PageOf<LogEntry, LogPaging> History { get; set; } = new([], new());
 
 	[FromRoute]
 	public string Table { get; set; } = "";

--- a/TASVideos/Pages/Messages/Inbox.cshtml.cs
+++ b/TASVideos/Pages/Messages/Inbox.cshtml.cs
@@ -10,7 +10,7 @@ public class InboxModel(IPrivateMessageService privateMessageService) : BasePage
 	[FromRoute]
 	public int? Id { get; set; }
 
-	public PageOf<InboxEntry> Messages { get; set; } = new([]);
+	public PageOf<InboxEntry> Messages { get; set; } = new([], new());
 
 	public async Task OnGet()
 	{

--- a/TASVideos/Pages/Messages/SentBox.cshtml.cs
+++ b/TASVideos/Pages/Messages/SentBox.cshtml.cs
@@ -9,7 +9,7 @@ public class SentboxModel(IPrivateMessageService privateMessageService) : BasePa
 	[FromRoute]
 	public int? Id { get; set; }
 
-	public PageOf<SentboxEntry> SentBox { get; set; } = new([]);
+	public PageOf<SentboxEntry> SentBox { get; set; } = new([], new());
 
 	public async Task OnGet()
 	{

--- a/TASVideos/Pages/Profile/Unrated.cshtml.cs
+++ b/TASVideos/Pages/Profile/Unrated.cshtml.cs
@@ -6,7 +6,7 @@ public class UnratedModel(ApplicationDbContext db) : BasePageModel
 	[FromQuery]
 	public UnratedRequest Search { get; set; } = new();
 
-	public PageOf<UnratedMovie> UnratedMovies { get; set; } = new([]);
+	public PageOf<UnratedMovie, UnratedRequest> UnratedMovies { get; set; } = new([], new());
 
 	public async Task OnGet()
 	{

--- a/TASVideos/Pages/Profile/UserFiles.cshtml.cs
+++ b/TASVideos/Pages/Profile/UserFiles.cshtml.cs
@@ -6,7 +6,7 @@ public class UserFilesModel(ApplicationDbContext db) : BasePageModel
 	[FromQuery]
 	public PagingModel Search { get; set; } = new();
 
-	public PageOf<UserFiles.InfoModel.UserFileModel> Files { get; set; } = new([]);
+	public PageOf<UserFiles.InfoModel.UserFileModel> Files { get; set; } = new([], new());
 
 	public async Task OnGet()
 	{

--- a/TASVideos/Pages/Profile/WatchedTopics.cshtml.cs
+++ b/TASVideos/Pages/Profile/WatchedTopics.cshtml.cs
@@ -6,7 +6,7 @@ public class WatchedTopicsModel(ITopicWatcher topicWatcher) : BasePageModel
 	[FromQuery]
 	public PagingModel Search { get; set; } = new();
 
-	public PageOf<WatchedTopic> Watches { get; set; } = new([]);
+	public PageOf<WatchedTopic> Watches { get; set; } = new([], new());
 
 	public async Task OnGet()
 	{

--- a/TASVideos/Pages/Publications/Index.cshtml.cs
+++ b/TASVideos/Pages/Publications/Index.cshtml.cs
@@ -11,7 +11,7 @@ public class IndexModel(ApplicationDbContext db, IMovieSearchTokens movieTokens)
 	[FromRoute]
 	public string Query { get; set; } = "";
 
-	public PageOf<PublicationDisplay> Movies { get; set; } = new([]);
+	public PageOf<PublicationDisplay, PublicationRequest> Movies { get; set; } = new([], new());
 
 	public async Task<IActionResult> OnGet()
 	{

--- a/TASVideos/Pages/Shared/_Pager.cshtml
+++ b/TASVideos/Pages/Shared/_Pager.cshtml
@@ -1,9 +1,9 @@
 @using TASVideos.Core
-@model IPaged
+@model IPaged<IRequest>
 
 <row class="my-2 align-items-center">
 	<div class="col-12 text-end">
-		<small><label class="text-body-tertiary me-4"> Showing items [@(Model.Offset() + 1) - @Model.LastRow()] of @Model.RowCount</label></small>
+		<small><label class="text-body-tertiary me-4"> Showing items [@(Model.Request.Offset() + 1) - @Model.LastRow()] of @Model.RowCount</label></small>
 		<a asp-page="@ViewContext.Page()" class="btn btn-outline-silver">
 			<i class="fa fa-sort"> <i class="fa fa-times-circle"></i></i>
 		</a>
@@ -14,21 +14,21 @@
 				const string pagerClass = "btn btn-secondary border-dark flex-grow-0";
 				const string pagerDisabledClass = "btn btn-silver border-dark flex-grow-0";
 				const string ellipsisClass = "btn btn-outline-secondary border-dark flex-grow-0";
-				var additionalProperties = Model.AdditionalProperties();
+				var additionalProperties = Model.Request.AdditionalProperties();
 			}
-			<a disable="@Model.CurrentPage == 1"
+			<a disable="@Model.Request.CurrentPage == 1"
 			   asp-page="@ViewContext.Page()"
 			   asp-all-route-data="@additionalProperties"
-			   asp-route-CurrentPage="@(Model.CurrentPage - 1)"
-			   asp-route-PageSize="@Model.PageSize"
-			   asp-route-Sort="@Model.Sort"
-			   type="button" class="@(Model.CurrentPage == 1 ? pagerDisabledClass : pagerClass)">
+			   asp-route-CurrentPage="@(Model.Request.CurrentPage - 1)"
+			   asp-route-PageSize="@Model.Request.PageSize"
+			   asp-route-Sort="@Model.Request.Sort"
+			   type="button" class="@(Model.Request.CurrentPage == 1 ? pagerDisabledClass : pagerClass)">
 				<span class="fa fa-chevron-left"></span>
 			</a>
 
 			@{
 				var totalPages = Model.LastPage();
-				var currentPage = Model.CurrentPage ?? 0;
+				var currentPage = Model.Request.CurrentPage ?? 0;
 				var pageList = Enumerable.Range(1, totalPages).ToList();
 				var leftShown = pageList.Where(p => p <= 2);
 				var leftHidden = pageList.Where(p => 2 < p && p < currentPage - 1).ToList();
@@ -40,8 +40,8 @@
 					<a asp-page="@ViewContext.Page()"
 					   asp-all-route-data="@additionalProperties"
 					   asp-route-CurrentPage="@iteratorPage"
-					   asp-route-PageSize="@Model.PageSize"
-					   asp-route-Sort="@Model.Sort"
+					   asp-route-PageSize="@Model.Request.PageSize"
+					   asp-route-Sort="@Model.Request.Sort"
 					   type="button" class="@pagerClass @(iteratorPage == currentPage ? "active" : "")">@iteratorPage</a>
 				}
 				if (leftHidden.Count == 1)
@@ -49,8 +49,8 @@
 					<a asp-page="@ViewContext.Page()"
 					   asp-all-route-data="@additionalProperties"
 					   asp-route-CurrentPage="@leftHidden.First()"
-					   asp-route-PageSize="@Model.PageSize"
-					   asp-route-Sort="@Model.Sort"
+					   asp-route-PageSize="@Model.Request.PageSize"
+					   asp-route-Sort="@Model.Request.Sort"
 					   type="button" class="@pagerClass">@leftHidden.First()</a>
 
 				}
@@ -63,8 +63,8 @@
 								<a asp-page="@ViewContext.Page()"
 								   asp-all-route-data="@additionalProperties"
 								   asp-route-CurrentPage="@iteratorPage"
-								   asp-route-PageSize="@Model.PageSize"
-								   asp-route-Sort="@Model.Sort"
+								   asp-route-PageSize="@Model.Request.PageSize"
+								   asp-route-Sort="@Model.Request.Sort"
 								   class="dropdown-item">@iteratorPage</a>
 							</li>
 						}
@@ -75,8 +75,8 @@
 					<a asp-page="@ViewContext.Page()"
 					   asp-all-route-data="@additionalProperties"
 					   asp-route-CurrentPage="@iteratorPage"
-					   asp-route-PageSize="@Model.PageSize"
-					   asp-route-Sort="@Model.Sort"
+					   asp-route-PageSize="@Model.Request.PageSize"
+					   asp-route-Sort="@Model.Request.Sort"
 					   type="button" class="@pagerClass @(iteratorPage == currentPage ? "active" : "")">@iteratorPage</a>
 				}
 				if (rightHidden.Count == 1)
@@ -84,8 +84,8 @@
 					<a asp-page="@ViewContext.Page()"
 					   asp-all-route-data="@additionalProperties"
 					   asp-route-CurrentPage="@rightHidden.First()"
-					   asp-route-PageSize="@Model.PageSize"
-					   asp-route-Sort="@Model.Sort"
+					   asp-route-PageSize="@Model.Request.PageSize"
+					   asp-route-Sort="@Model.Request.Sort"
 					   type="button" class="@pagerClass">@rightHidden.First()</a>
 				}
 				<div condition="rightHidden.Count > 1" class="btn-group" role="group">
@@ -97,8 +97,8 @@
 								<a asp-page="@ViewContext.Page()"
 								   asp-all-route-data="@additionalProperties"
 								   asp-route-CurrentPage="@iteratorPage"
-								   asp-route-PageSize="@Model.PageSize"
-								   asp-route-Sort="@Model.Sort"
+								   asp-route-PageSize="@Model.Request.PageSize"
+								   asp-route-Sort="@Model.Request.Sort"
 								   class="dropdown-item">@iteratorPage</a>
 							</li>
 						}
@@ -109,18 +109,18 @@
 					<a asp-page="@ViewContext.Page()"
 					   asp-all-route-data="@additionalProperties"
 					   asp-route-CurrentPage="@iteratorPage"
-					   asp-route-PageSize="@Model.PageSize"
-					   asp-route-Sort="@Model.Sort"
+					   asp-route-PageSize="@Model.Request.PageSize"
+					   asp-route-Sort="@Model.Request.Sort"
 					   type="button" class="@pagerClass @(iteratorPage == currentPage ? "active" : "")">@iteratorPage</a>
 				}
 			}
-			<a disable="@Model.CurrentPage == Model.LastPage()"
+			<a disable="@Model.Request.CurrentPage == Model.LastPage()"
 			   asp-page="@ViewContext.Page()"
 			   asp-all-route-data="@additionalProperties"
-			   asp-route-CurrentPage="@(Model.CurrentPage + 1)"
-			   asp-route-PageSize="@Model.PageSize"
-			   asp-route-Sort="@Model.Sort"
-			   type="button" class="@(Model.CurrentPage == Model.LastPage() ? pagerDisabledClass : pagerClass)">
+			   asp-route-CurrentPage="@(Model.Request.CurrentPage + 1)"
+			   asp-route-PageSize="@Model.Request.PageSize"
+			   asp-route-Sort="@Model.Request.Sort"
+			   type="button" class="@(Model.Request.CurrentPage == Model.LastPage() ? pagerDisabledClass : pagerClass)">
 				<span class="fa fa-chevron-right"></span>
 			</a>
 		</div>

--- a/TASVideos/Pages/Shared/_Ratings.cshtml
+++ b/TASVideos/Pages/Shared/_Ratings.cshtml
@@ -17,7 +17,7 @@
 	</warning-alert>
 	<form id="obsolete-form">
 		<div class="d-flex justify-content-end" style="gap: 8px;">
-			<label style="margin: auto 0" for="include-obsolete">Include Obsolete <input id="include-obsolete" name="IncludeObsolete" checked="@Model.Ratings.IncludeObsolete" type="checkbox" asp-for="Ratings.IncludeObsolete"/></label>
+			<label style="margin: auto 0" for="include-obsolete">Include Obsolete <input id="include-obsolete" name="IncludeObsolete" checked="@(Model.Ratings.Request.IncludeObsolete)" type="checkbox" asp-for="Ratings.Request.IncludeObsolete"/></label>
 			<noscript>
 				<submit-button btn-class-override="ml-2 btn-secondary btn-sm" class="float-center">Go</submit-button>
 			</noscript>
@@ -25,7 +25,7 @@
 	</form>
 	<partial name="_Pager" model="Model.Ratings" />
 	<standard-table>
-		<sortable-table-head sorting="@Model.Ratings" model-type="typeof(UserRatings.Rating)" />
+		<sortable-table-head sorting="@Model.Ratings.Request" model-type="typeof(UserRatings.Rating)" />
 		@foreach (var rating in Model.Ratings)
 		{
 			<tr style="@(rating.IsObsolete ? "opacity: 0.6" : "")">

--- a/TASVideos/Pages/Submissions/Index.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Index.cshtml.cs
@@ -14,7 +14,7 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 	[FromQuery]
 	public SubmissionSearchRequest Search { get; set; } = new();
 
-	public SubmissionPageOf<SubmissionEntry> Submissions { get; set; } = new([]);
+	public PageOf<SubmissionEntry, SubmissionSearchRequest> Submissions { get; set; } = new([], new());
 
 	public List<SelectListItem> AvailableStatuses => Statuses;
 
@@ -41,19 +41,10 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 				: SubmissionSearchRequest.Default;
 		}
 
-		var entries = await db.Submissions
+		Submissions = await db.Submissions
 			.FilterBy(Search)
 			.ToSubListEntry()
 			.SortedPageOf(Search);
-
-		Submissions = new SubmissionPageOf<SubmissionEntry>(entries)
-		{
-			Years = Search.Years,
-			Statuses = Search.Statuses,
-			System = Search.System,
-			GameId = Search.GameId,
-			User = Search.User
-		};
 	}
 
 	public class SubmissionEntry : ITimeable, ISubmissionDisplay
@@ -95,15 +86,6 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 
 		[TableIgnore]
 		public string? IntendedClass { get; init; }
-	}
-
-	public class SubmissionPageOf<T>(IEnumerable<T> items) : PageOf<T>(items)
-	{
-		public IEnumerable<int> Years { get; set; } = [];
-		public IEnumerable<SubmissionStatus> Statuses { get; set; } = [];
-		public string? System { get; set; }
-		public string? User { get; set; }
-		public string? GameId { get; set; }
 	}
 
 	public class SubmissionSearchRequest : PagingModel, ISubmissionFilter

--- a/TASVideos/Pages/UserFiles/ForUser.cshtml.cs
+++ b/TASVideos/Pages/UserFiles/ForUser.cshtml.cs
@@ -9,7 +9,7 @@ public class ForUserModel(ApplicationDbContext db) : BasePageModel
 	[FromRoute]
 	public string UserName { get; set; } = "";
 
-	public PageOf<InfoModel.UserFileModel> Files { get; set; } = new([]);
+	public PageOf<InfoModel.UserFileModel> Files { get; set; } = new([], new());
 
 	public async Task OnGet()
 	{

--- a/TASVideos/Pages/UserFiles/List.cshtml.cs
+++ b/TASVideos/Pages/UserFiles/List.cshtml.cs
@@ -5,7 +5,7 @@ public class ListModel(ApplicationDbContext db) : BasePageModel
 	[FromQuery]
 	public UserFileListRequest Search { get; set; } = new();
 
-	public PageOf<UserFileEntry> UserFiles { get; set; } = new([]);
+	public PageOf<UserFileEntry, UserFileListRequest> UserFiles { get; set; } = new([], new());
 	public async Task OnGet()
 	{
 		UserFiles = await db.UserFiles

--- a/TASVideos/Pages/Users/List.cshtml.cs
+++ b/TASVideos/Pages/Users/List.cshtml.cs
@@ -6,7 +6,7 @@ public class ListModel(ApplicationDbContext db, ICacheService cache) : BasePageM
 	[FromQuery]
 	public PagingModel Search { get; set; } = new();
 
-	public PageOf<UserEntry> Users { get; set; } = new([]);
+	public PageOf<UserEntry> Users { get; set; } = new([], new());
 
 	public async Task OnGet()
 	{

--- a/TASVideos/Pages/Wiki/EditHistory.cshtml.cs
+++ b/TASVideos/Pages/Wiki/EditHistory.cshtml.cs
@@ -9,7 +9,7 @@ public class EditHistoryModel(ApplicationDbContext db) : BasePageModel
 	[FromRoute]
 	public string UserName { get; set; } = "";
 
-	public PageOf<HistoryEntry> History { get; set; } = new([]);
+	public PageOf<HistoryEntry> History { get; set; } = new([], new());
 
 	public async Task OnGet()
 	{

--- a/TASVideos/WikiModules/MediaPosts.cshtml.cs
+++ b/TASVideos/WikiModules/MediaPosts.cshtml.cs
@@ -6,7 +6,7 @@ namespace TASVideos.WikiModules;
 [WikiModule(ModuleNames.MediaPosts)]
 public class MediaPosts(ApplicationDbContext db) : WikiViewComponent
 {
-	public PageOf<MediaPost> Posts { get; set; } = new([]);
+	public PageOf<MediaPost> Posts { get; set; } = new([], new());
 
 	public async Task<IViewComponentResult> InvokeAsync()
 	{

--- a/TASVideos/WikiModules/MovieChangeLog.cshtml.cs
+++ b/TASVideos/WikiModules/MovieChangeLog.cshtml.cs
@@ -5,7 +5,7 @@ namespace TASVideos.WikiModules;
 [WikiModule(ModuleNames.MovieChangeLog)]
 public class MovieChangeLog(ApplicationDbContext db) : WikiViewComponent
 {
-	public PageOf<HistoryEntry> Logs { get; set; } = new([]);
+	public PageOf<HistoryEntry> Logs { get; set; } = new([], new());
 
 	public async Task<IViewComponentResult> InvokeAsync(string pubClass)
 	{

--- a/TASVideos/WikiModules/Screenshots.cshtml
+++ b/TASVideos/WikiModules/Screenshots.cshtml
@@ -3,13 +3,13 @@
 @using TASVideos.TagHelpers
 @model Screenshots
 @{
-	var additionalProperties = Model.List.AdditionalProperties();
+	var additionalProperties = Model.List.Request.AdditionalProperties();
 }
 <a asp-page="@ViewContext.Page()"
 	asp-all-route-data="@additionalProperties"
-	asp-route-CurrentPage="@Model.List.CurrentPage"
-	asp-route-PageSize="@Model.List.PageSize"
-	asp-route-Sort="@Model.List.Sort"
+	asp-route-CurrentPage="@Model.List.Request.CurrentPage"
+	asp-route-PageSize="@Model.List.Request.PageSize"
+	asp-route-Sort="@Model.List.Request.Sort"
 	asp-route-OnlyDescriptions=""
 	type="button" class="btn btn-secondary border-dark flex-grow-0">
 	All
@@ -17,18 +17,18 @@
 <a
 	asp-page="@ViewContext.Page()"
 	asp-all-route-data="@additionalProperties"
-	asp-route-CurrentPage="@Model.List.CurrentPage"
-	asp-route-PageSize="@Model.List.PageSize"
-	asp-route-Sort="@Model.List.Sort"
+	asp-route-CurrentPage="@Model.List.Request.CurrentPage"
+	asp-route-PageSize="@Model.List.Request.PageSize"
+	asp-route-Sort="@Model.List.Request.Sort"
 	asp-route-OnlyDescriptions="True"
 	type="button" class="btn btn-secondary border-dark flex-grow-0">
 	Only Descriptions
 </a>
 <a asp-page="@ViewContext.Page()"
    asp-all-route-data="@additionalProperties"
-   asp-route-CurrentPage="@Model.List.CurrentPage"
-   asp-route-PageSize="@Model.List.PageSize"
-   asp-route-Sort="@Model.List.Sort"
+   asp-route-CurrentPage="@Model.List.Request.CurrentPage"
+   asp-route-PageSize="@Model.List.Request.PageSize"
+   asp-route-Sort="@Model.List.Request.Sort"
    asp-route-OnlyDescriptions="False"
    type="button" class="btn btn-secondary border-dark flex-grow-0">
 	Missing Descriptions

--- a/TASVideos/WikiModules/Screenshots.cshtml.cs
+++ b/TASVideos/WikiModules/Screenshots.cshtml.cs
@@ -5,7 +5,7 @@ namespace TASVideos.WikiModules;
 [WikiModule(ModuleNames.Screenshots)]
 public class Screenshots(ApplicationDbContext db) : WikiViewComponent
 {
-	public ScreenshotPageOf<ScreenshotEntry> List { get; set; } = null!;
+	public PageOf<ScreenshotEntry> List { get; set; } = null!;
 
 	public async Task<IViewComponentResult> InvokeAsync()
 	{
@@ -23,7 +23,7 @@ public class Screenshots(ApplicationDbContext db) : WikiViewComponent
 			query = query.Where(pf => string.IsNullOrEmpty(pf.Description));
 		}
 
-		var screenshots = await query
+		List = await query
 			.Select(p => new ScreenshotEntry
 			{
 				Id = p.PublicationId,
@@ -32,11 +32,6 @@ public class Screenshots(ApplicationDbContext db) : WikiViewComponent
 				Screenshot = p.Path
 			})
 			.SortedPageOf(GetPaging());
-
-		List = new ScreenshotPageOf<ScreenshotEntry>(screenshots)
-		{
-			OnlyDescriptions = onlyDescriptions
-		};
 
 		return View();
 	}
@@ -53,10 +48,5 @@ public class Screenshots(ApplicationDbContext db) : WikiViewComponent
 
 		[Sortable]
 		public string Description { get; init; } = "";
-	}
-
-	public class ScreenshotPageOf<T>(IEnumerable<T> items) : PageOf<T>(items)
-	{
-		public bool? OnlyDescriptions { get; set; }
 	}
 }

--- a/TASVideos/WikiModules/UserMaintenanceLogs.cshtml.cs
+++ b/TASVideos/WikiModules/UserMaintenanceLogs.cshtml.cs
@@ -5,7 +5,7 @@ namespace TASVideos.WikiModules;
 [WikiModule(ModuleNames.UserMaintenanceLogs)]
 public class UserMaintenanceLogs(ApplicationDbContext db) : WikiViewComponent
 {
-	public PageOf<LogEntry> Logs { get; set; } = new([]);
+	public PageOf<LogEntry> Logs { get; set; } = new([], new());
 
 	public async Task<IViewComponentResult> InvokeAsync()
 	{

--- a/TASVideos/WikiModules/WikiTextChangeLog.cshtml.cs
+++ b/TASVideos/WikiModules/WikiTextChangeLog.cshtml.cs
@@ -5,7 +5,7 @@ namespace TASVideos.WikiModules;
 [WikiModule(ModuleNames.WikiTextChangeLog)]
 public class WikiTextChangeLog(ApplicationDbContext db) : WikiViewComponent
 {
-	public PageOf<Log> Logs { get; set; } = new([]);
+	public PageOf<Log> Logs { get; set; } = new([], new());
 
 	public async Task<IViewComponentResult> InvokeAsync(bool includeMinors)
 	{


### PR DESCRIPTION
Okay, this PR has quite a few things to talk about.

First of all, what is the purpose of this PR? It's about solving the duplicate properties problem we had with our previous paging code.
- The problem:
Pages like the Games List or the Subs List allow **Custom Filtering** like "Starts With Letter" that needs to apply before paging. The query is bound using a custom Request class. However, the paging system itself needs to know about those queries as well, otherwise it can't make the page buttons link to the proper url with the proper query parameters.
- The previous solution: 
Make a custom PageOf implementation like SubmissionPageOf that has all the same properties of SubmissionRequest. The issue being that refactorings will miss this and break paging, along with the usual problems of unnecessarily duplicating code.
- This new solution in this PR:
Always include the Request in the PageOf itself. So instead of making a `SubmissionPageOf<SubmissionEntry>` we instead make a `PageOf<SubmissionEntry, SubmissionRequest>`. Inside the PageOf there is a .Request property that contains the original request data. The pager then uses this to make the pager buttons.

This PR implements this change.
But it does a bit more. Every PageOf now needs an additional type, so this would require a lot of additional code refactorings everywhere we use a page. But most of our pages don't even use **Custom Filtering**! They just use the default implementation of a request: the `PagingModel`.
So this PR not only changes the `PageOf<T>` into a `PageOf<T, T2>`, it also implements a "fallback" `PageOf<T>` which is just a `PageOf<T, PagingModel>`, so that most places don't need to deal with the additional type.

I also had the idea of renaming our PagingModel class into something like `DefaultPagingRequest`, since it's now an IRequest and every custom Request implementation inherits it. But I wanted a somewhat minimal solution first, and renaming can come after.

I have two things left that irk me about this PR:
1. In the Paginator.cs, the PageOf method (not the class) that turns a query into a PageOf along with the SortedPageOf method are now duplicated. This too is for the purpose of giving a "fallback" implementation. I wasn't able to combine their codes.
2. The Request object has a reference in two places on Custom Filtering pages. First it needs to be in a Search property with a [FromQuery] attribute so that binding works. And once the paging is queried and generated, it's now also in the PageOf object in the .Request property. This Search and PageOf.Request are the same objects. I tried to come up with a way to only have a single reference always, so that developers aren't confused whether to use Search or PageOf.Request. But I wasn't able to, because the [FromQuery] needs to be somewhere.

I separated this PR into commits to look at in an isolated way.
- The first commit is the functional change. The actual meat of this PR.
- The second commit are the results that we can now do. The commit is mostly deleted code. It allows removing things like SubmissionPageOf and SystemPageOf.
- The rest are minor commits.

That's all.