### PR TITLE
Use Transactions when Publishing

### DIFF
--- a/TASVideos/Pages/Submissions/Publish.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Publish.cshtml.cs
@@ -104,6 +104,8 @@ public class PublishModel(
 			return Page();
 		}
 
+		using var dbTransaction = await db.Database.BeginTransactionAsync();
+
 		var publication = new Publication
 		{
 			PublicationClassId = submission.IntendedClass!.Id,
@@ -153,6 +155,7 @@ public class PublishModel(
 
 		await userManager.AssignAutoAssignableRolesByPublication(publication.Authors.Select(pa => pa.UserId), publication.Title);
 		await tasVideoAgent.PostSubmissionPublished(Id, publication.Id);
+		await dbTransaction.CommitAsync();
 		await publisher.AnnounceNewPublication(publication);
 
 		if (youtubeSync.IsYoutubeUrl(Submission.OnlineWatchingUrl))


### PR DESCRIPTION
When publishing, sometimes our wiki runs into timeouts, and we also had once instance where the HttpClient of the YouTube Sync timed out causing an exception.
This has caused e.g. the submission thread to not be moved to Published Movies, and the TVA post was also missing.

So with this PR the publishing will either fail completely or succeed completely. No half-publication state.