### PR TITLE
Add various UI stuff

### DIFF
--- a/TASVideos.Common/VoteCounts.cs
+++ b/TASVideos.Common/VoteCounts.cs
@@ -1,0 +1,11 @@
+﻿namespace TASVideos.Common;
+
+public class VoteCounts
+{
+	public int VotesYes { get; init; }
+	public int VotesMeh { get; init; }
+	public int VotesNo { get; init; }
+	public bool UserVotedYes { get; init; }
+	public bool UserVotedMeh { get; init; }
+	public bool UserVotedNo { get; init; }
+}

--- a/TASVideos/Extensions/EntityExtensions.cs
+++ b/TASVideos/Extensions/EntityExtensions.cs
@@ -1,4 +1,5 @@
-﻿using TASVideos.Data.Entity.Awards;
+﻿using TASVideos.Common;
+using TASVideos.Data.Entity.Awards;
 using TASVideos.Data.Entity.Forum;
 using TASVideos.Data.Entity.Game;
 using TASVideos.Pages.Forum.Posts;
@@ -345,7 +346,7 @@ public static class EntityExtensions
 		return [.. UiDefaults.AnyEntry, .. items];
 	}
 
-	public static IQueryable<Pages.Submissions.IndexModel.SubmissionEntry> ToSubListEntry(this IQueryable<Submission> query)
+	public static IQueryable<Pages.Submissions.IndexModel.SubmissionEntry> ToSubListEntry(this IQueryable<Submission> query, int? userIdForVotes = null)
 	{
 		return query
 			.Select(s => new Pages.Submissions.IndexModel.SubmissionEntry
@@ -362,7 +363,17 @@ public static class EntityExtensions
 				Status = s.Status,
 				Judge = s.Judge != null ? s.Judge.UserName : null,
 				Publisher = s.Publisher != null ? s.Publisher.UserName : null,
-				IntendedClass = s.IntendedClass != null ? s.IntendedClass.Name : null
+				IntendedClass = s.IntendedClass != null ? s.IntendedClass.Name : null,
+				Votes = s.Topic != null ? s.Topic.Poll != null ? new VoteCounts
+				{
+					VotesYes = s.Topic.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionYes).Votes.Count,
+					VotesMeh = s.Topic.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionsMeh).Votes.Count,
+					VotesNo = s.Topic.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionNo).Votes.Count,
+					UserVotedYes = s.Topic.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionYes).Votes.Any(v => v.UserId == userIdForVotes),
+					UserVotedMeh = s.Topic.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionsMeh).Votes.Any(v => v.UserId == userIdForVotes),
+					UserVotedNo = s.Topic.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionNo).Votes.Any(v => v.UserId == userIdForVotes),
+				}
+				: null : null,
 			});
 	}
 

--- a/TASVideos/Extensions/EntityExtensions.cs
+++ b/TASVideos/Extensions/EntityExtensions.cs
@@ -364,7 +364,11 @@ public static class EntityExtensions
 				Judge = s.Judge != null ? s.Judge.UserName : null,
 				Publisher = s.Publisher != null ? s.Publisher.UserName : null,
 				IntendedClass = s.IntendedClass != null ? s.IntendedClass.Name : null,
-				Votes = s.Topic != null ? s.Topic.Poll != null ? new VoteCounts
+				Votes = s.Topic != null && s.Topic.Poll != null
+					&& s.Topic.Poll.PollOptions.Any(o => o.Text == SiteGlobalConstants.PollOptionYes)
+					&& s.Topic.Poll.PollOptions.Any(o => o.Text == SiteGlobalConstants.PollOptionsMeh)
+					&& s.Topic.Poll.PollOptions.Any(o => o.Text == SiteGlobalConstants.PollOptionNo)
+					? new VoteCounts
 				{
 					VotesYes = s.Topic.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionYes).Votes.Count,
 					VotesMeh = s.Topic.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionsMeh).Votes.Count,
@@ -373,7 +377,7 @@ public static class EntityExtensions
 					UserVotedMeh = s.Topic.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionsMeh).Votes.Any(v => v.UserId == userIdForVotes),
 					UserVotedNo = s.Topic.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionNo).Votes.Any(v => v.UserId == userIdForVotes),
 				}
-				: null : null,
+				: null,
 			});
 	}
 

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml
@@ -44,6 +44,7 @@
 					</a>
 				}
 				<a asp-page="/Forum/Topics/Index" asp-route-id="@topic.Id" class="fw-bold">@topic.Topics</a>
+				<div condition="topic.Votes is not null" class="text-body-tertiary float-end"><partial name="_VoteCounts" model="topic.Votes" /></div>
 				<div class="ms-2">
 					@{
 						var totalPages = (topic.Replies - 1) / ForumConstants.PostsPerPage + 1;

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml
@@ -77,8 +77,7 @@
 				@if (topic.LastPost is not null)
 				{
 					<timezone-convert asp-for="@topic.LastPost.CreateTimestamp" /> <br />
-					<profile-link username="@topic.LastPost.PosterName"></profile-link>
-					<a href="/Forum/Posts/@topic.LastPost.Id" class="fa fa-arrow-circle-right"></a>
+					<a href="/Forum/Posts/@topic.LastPost.Id">@topic.LastPost.PosterName <i class="fa fa-arrow-circle-right"></i></a>
 				}
 			</td>
 		</tr>

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
@@ -63,7 +63,6 @@ public class IndexModel(ApplicationDbContext db, IForumService forumService) : B
 					UserVotedNo = ft.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionNo).Votes.Any(v => v.UserId == userIdForVotes),
 				}
 				: null : null,
-
 			})
 			.OrderByDescending(ft => ft.Type)
 			.ThenByDescending(ft => ft.LastPost!.Id) // The database does not enforce it, but we can assume a topic will always have at least one post

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using TASVideos.Data.Entity.Forum;
+﻿using TASVideos.Common;
+using TASVideos.Data.Entity.Forum;
 
 namespace TASVideos.Pages.Forum.Subforum;
 
@@ -30,6 +31,8 @@ public class IndexModel(ApplicationDbContext db, IForumService forumService) : B
 			return NotFound();
 		}
 
+		int userIdForVotes = User.GetUserId();
+
 		Forum = forum;
 		Topics = await db.ForumTopics
 			.ForForum(Id)
@@ -49,7 +52,18 @@ public class IndexModel(ApplicationDbContext db, IForumService forumService) : B
 						PosterName = fp.Poster!.UserName,
 						CreateTimestamp = fp.CreateTimestamp
 					})
-					.FirstOrDefault()
+					.FirstOrDefault(),
+				Votes = ft.Submission != null ? ft.Poll != null ? new VoteCounts
+				{
+					VotesYes = ft.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionYes).Votes.Count,
+					VotesMeh = ft.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionsMeh).Votes.Count,
+					VotesNo = ft.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionNo).Votes.Count,
+					UserVotedYes = ft.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionYes).Votes.Any(v => v.UserId == userIdForVotes),
+					UserVotedMeh = ft.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionsMeh).Votes.Any(v => v.UserId == userIdForVotes),
+					UserVotedNo = ft.Poll.PollOptions.Single(o => o.Text == SiteGlobalConstants.PollOptionNo).Votes.Any(v => v.UserId == userIdForVotes),
+				}
+				: null : null,
+
 			})
 			.OrderByDescending(ft => ft.Type)
 			.ThenByDescending(ft => ft.LastPost!.Id) // The database does not enforce it, but we can assume a topic will always have at least one post
@@ -80,6 +94,9 @@ public class IndexModel(ApplicationDbContext db, IForumService forumService) : B
 
 		[TableIgnore]
 		public bool IsLocked { get; init; }
+
+		[TableIgnore]
+		public VoteCounts? Votes { get; init; }
 
 		[TableIgnore]
 		public LastPostEntry? LastPost { get; init; }

--- a/TASVideos/Pages/Forum/_Category.cshtml
+++ b/TASVideos/Pages/Forum/_Category.cshtml
@@ -42,8 +42,7 @@
 			{
 				<div class="col-4 align-items-center">
 					<timezone-convert asp-for="@forum.LastPost.Timestamp" /> <br />
-					<profile-link username="@forum.LastPost.PosterName"></profile-link>
-					<a href="/Forum/Posts/@forum.LastPost.Id" class="fa fa-arrow-circle-right"></a>
+					<a href="/Forum/Posts/@forum.LastPost.Id">@forum.LastPost.PosterName <i class="fa fa-arrow-circle-right"></i></a>
 				</div>
 			}
 			</row>

--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -129,8 +129,9 @@
 					@{
 						var (version, sha) = Versioning.GetVersion();
 					}
-					&copy; @DateTime.UtcNow.Year - TASVideos <a href="https://github.com/TASVideos/tasvideos/commit/@(sha)">v@(version)</a>
-					- <a href="/SiteRules">Terms</a> - <a href="/api">API</a>
+					<a class="btn btn-silver btn-sm mb-2" href="https://github.com/TASVideos/tasvideos/commit/@(sha)">&copy; @DateTime.UtcNow.Year - TASVideos v@(version)</a>
+					<a class="btn btn-info btn-sm mb-2" href="/SiteRules">Terms</a>
+					<a class="btn btn-info btn-sm mb-2" href="/api">API</a>
 					@{
 						string? path = null;
 						if (ViewData.GetWikiPage() is null && this.Model is not (Publications.ViewModel or Submissions.ViewModel))
@@ -138,7 +139,7 @@
 							path = this.Model.HttpContext.Request.Path.ToString().TrimStart('/');
 						}
 					}
-				<a condition="path is not null" class="btn btn-info btn-sm" asp-page="/Wiki/Referrers" asp-route-path="@path">List referrers</a>
+				<a condition="path is not null" class="btn btn-info btn-sm mb-2" asp-page="/Wiki/Referrers" asp-route-path="@path">List referrers</a>
 			</p>
 		</row>
 	</footer>

--- a/TASVideos/Pages/Shared/_VoteCounts.cshtml
+++ b/TASVideos/Pages/Shared/_VoteCounts.cshtml
@@ -1,0 +1,20 @@
+﻿@model VoteCounts?
+
+<span condition="Model is not null">
+	@{
+		int totalCount = Model!.VotesYes + Model.VotesMeh + Model.VotesNo;
+		if (totalCount == 0)
+		{
+			<text>No votes</text>
+		}
+		else
+		{
+			var support = Math.Ceiling(100 * ((Model.VotesYes + (Model.VotesMeh / 2d)) / totalCount));
+			<text>@support%</text>
+		}
+
+		if (totalCount != 0){
+			<text> (<span class="@(Model.UserVotedYes ? "fw-bold" : "")">@Model.VotesYes</span>/<span class="@(Model.UserVotedMeh ? "fw-bold" : "")">@Model.VotesMeh</span>/<span class="@(Model.UserVotedNo ? "fw-bold" : "")">@Model.VotesNo</span>)</text>
+		}
+	}
+</span>

--- a/TASVideos/Pages/Submissions/Index.cshtml
+++ b/TASVideos/Pages/Submissions/Index.cshtml
@@ -63,6 +63,7 @@
 					<br />(Available for judging in @hoursRemaining hours)
 				</small>
 			</td>
+			<td><partial name="_VoteCounts" model="item.Votes" /></td>
 		</tr>
 	}
 </standard-table>

--- a/TASVideos/Pages/Submissions/Index.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Index.cshtml.cs
@@ -43,7 +43,7 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 
 		Submissions = await db.Submissions
 			.FilterBy(Search)
-			.ToSubListEntry()
+			.ToSubListEntry(User.GetUserId())
 			.SortedPageOf(Search);
 	}
 
@@ -68,6 +68,8 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 
 		[Sortable]
 		public SubmissionStatus Status { get; init; }
+
+		public VoteCounts? Votes { get; init; }
 
 		[TableIgnore]
 		public int Id { get; init; }

--- a/TASVideos/Pages/Submissions/View.cshtml
+++ b/TASVideos/Pages/Submissions/View.cshtml
@@ -200,8 +200,8 @@
 		</div>
 
 		<div class="btn-toolbar mt-2">
-			<a condition="@canClaimAsJudge" asp-page="Edit" asp-route-id="@Model.Id" asp-page-handler="ClaimForJudging" class="btn btn-success">Claim</a>
-			<a condition="@canClaimAsPublisher" asp-page="Edit" asp-route-id="@Model.Id" asp-page-handler="ClaimForPublishing" class="btn btn-success">Claim</a>
+			<a condition="@canClaimAsJudge" asp-page="Edit" asp-route-id="@Model.Id" asp-page-handler="ClaimForJudging" class="btn btn-success"><i class="fa fa-hand"></i> Claim</a>
+			<a condition="@canClaimAsPublisher" asp-page="Edit" asp-route-id="@Model.Id" asp-page-handler="ClaimForPublishing" class="btn btn-success"><i class="fa fa-hand"></i> Claim</a>
 			<edit-link condition="@canEdit" asp-page="Edit" asp-route-id="@Model.Id"></edit-link>
 			<a permission="CatalogMovies" asp-page="Catalog" asp-route-id="@Model.Id" class="btn btn-info"><i class="fa fa-book"></i> Catalog</a>
 			<a condition="@canPublish" asp-page="Publish" asp-route-id="@Model.Id" class="btn btn-warning">Publish</a>

--- a/TASVideos/Pages/Wiki/PageHistory.cshtml
+++ b/TASVideos/Pages/Wiki/PageHistory.cshtml
@@ -8,31 +8,16 @@
 }
 
 @functions {
-	string RowStyles(int revision)
-	{
-		if (revision == Model.FromRevision)
-		{
-			return "table-info";
-		}
-
-		if (revision == Model.ToRevision)
-		{
-			return "table-primary";
-		}
-
-		return "";
-	}
-
 	string DiffBtnStyles(int revision, bool isFrom)
 	{
 		if (isFrom && revision == Model.FromRevision)
 		{
-			return "btn btn-info btn-sm active";
+			return "btn btn-info btn-sm bg-warning";
 		}
 
 		if (!isFrom && revision == Model.ToRevision)
 		{
-			return "btn btn-info btn-sm active";
+			return "btn btn-info btn-sm bg-warning";
 		}
 
 		return "btn btn-info btn-sm";
@@ -55,7 +40,7 @@
 		{
 			var revision = revisions[i];
 			var previousId = i < revisions.Count - 1 ? revisions[i + 1].Revision : (int?)null;
-			<tr data-revision="@revision.Revision" class="@RowStyles(revision.Revision)">
+			<tr data-revision="@revision.Revision">
 				<td><a href="/@(Model.PageName)?revision=@revision.Revision">@revision.Revision</a> (<a asp-page="ViewSource" asp-route-path="@Model.Path" asp-route-revision="@revision.Revision">source</a>)</td>
 				<td><timezone-convert asp-for="@revision.CreateTimestamp" /></td>
 				<td><profile-link username="@revision.CreateUserName"></profile-link></td>

--- a/TASVideos/Pages/Wiki/PageHistory.cshtml
+++ b/TASVideos/Pages/Wiki/PageHistory.cshtml
@@ -56,7 +56,7 @@
 			var revision = revisions[i];
 			var previousId = i < revisions.Count - 1 ? revisions[i + 1].Revision : (int?)null;
 			<tr data-revision="@revision.Revision" class="@RowStyles(revision.Revision)">
-				<td><a href="/@(Model.PageName)?revision=@revision.Revision">@revision.Revision</a></td>
+				<td><a href="/@(Model.PageName)?revision=@revision.Revision">@revision.Revision</a> (<a asp-page="ViewSource" asp-route-path="@Model.Path" asp-route-revision="@revision.Revision">source</a>)</td>
 				<td><timezone-convert asp-for="@revision.CreateTimestamp" /></td>
 				<td><profile-link username="@revision.CreateUserName"></profile-link></td>
 				<td>@revision.MinorEdit</td>

--- a/TASVideos/Pages/Wiki/ViewSource.cshtml
+++ b/TASVideos/Pages/Wiki/ViewSource.cshtml
@@ -8,7 +8,7 @@
 	<back-link href="/@Model.WikiPage.PageName" name-override="Back to Page"></back-link>
 </top-button-bar>
 <div class="mb-2">
-	Revision @Model.Revision (current) <br />
-	Last Updated by @(Model.WikiPage.AuthorName ?? "Unknown") <timezone-convert asp-for="@Model.WikiPage.CreateTimestamp" in-line="true" />
+	Revision @Model.WikiPage.Revision @(Model.WikiPage.IsCurrent() ? "(current)" : "(old)") <br />
+	Edited by @(Model.WikiPage.AuthorName ?? "Unknown") <timezone-convert asp-for="@Model.WikiPage.CreateTimestamp" in-line="true" />
 </div>
 <pre>@Model.WikiPage.Markup.ReplaceLineEndings("\n")</pre>

--- a/TASVideos/wwwroot/js/wiki-page-history.js
+++ b/TASVideos/wwwroot/js/wiki-page-history.js
@@ -47,21 +47,17 @@ function diffBtnClicked(from, to) {
 function updateTableStyling() {
 	Array.from(document.querySelectorAll('tbody[data-hasrevisions] tr'))
 		.forEach(function (elem) {
-			elem.classList.remove('table-primary');
-			elem.classList.remove('table-info');
-			elem.querySelector("button[data-from]").classList.remove("active");
-			elem.querySelector("button[data-to]").classList.remove("active");
+			elem.querySelector("button[data-from]").classList.remove("bg-warning");
+			elem.querySelector("button[data-to]").classList.remove("bg-warning");
 		});
 
 	const cur = document.querySelector(`tr[data-revision="${toRevision}"]`);
 	if (cur) {
-		cur.classList.add('table-primary');
-		cur.querySelector("button[data-to]").classList.add("active");
+		cur.querySelector("button[data-to]").classList.add("bg-warning");
 	}
 
 	const prev = document.querySelector(`tr[data-revision="${fromRevision}"]`);
 	if (prev) {
-		prev.classList.add('table-info');
-		prev.querySelector("button[data-from]").classList.add("active");
+		prev.querySelector("button[data-from]").classList.add("bg-warning");
 	}
 }


### PR DESCRIPTION
"Biggest" part of this PR is adding the submission topic vote count that we had on the old site `75% (9/3/2)` (9 Yes, 3 Meh, 2 No).
I made a VoteCounts class for this. But I didn't know where to put it because it's both Forum Topic stuff and also Submission stuff. So I put it in Common. This can be moved wherever anyway.

So basically the PR adds this to the submission list,
![image](https://github.com/user-attachments/assets/dfd154f7-f4cc-41d1-b7b7-cc12edec2767)
and also to the forum topics.
![image](https://github.com/user-attachments/assets/c1bd53ea-4c28-4150-8310-a62de4c6c137)
<hr>

The entire username now leads to the "last post". No need for the username to lead to the user profile. This can be done in a second click because you're about to go to the user's post which has the profile link there.
![image](https://github.com/user-attachments/assets/87e0d39a-64d5-4279-ad88-de52bcdd733a)

<hr>
Claim now has an icon.

![image](https://github.com/user-attachments/assets/d67f6e6c-0bce-4648-8de1-eed803a66ca8)
<hr>
Fixed some bugs on the Wiki ViewSource page. On current revisions it was missing the number. And it always said "current" even on non-current revisions.

![image](https://github.com/user-attachments/assets/ae135cf1-a813-4460-b41d-aa3415fa7697)
<hr>
Added source links to revisions on Wiki PageHistory page, and also changed the coloring, because in dark mode this was not good:

![image](https://github.com/user-attachments/assets/8bad7ffa-8d8e-4b9d-9f1d-ba9e824cf5c5)
<hr>
Changed footer to button links, because those fit more with our other buttons:

![image](https://github.com/user-attachments/assets/aa429a0d-3f41-450a-986a-4cdefad66766)
