### PR TITLE
Add missing tooltip to pub classes in history

### DIFF
--- a/TASVideos.Core/Services/PublicationHistory.cs
+++ b/TASVideos.Core/Services/PublicationHistory.cs
@@ -35,6 +35,7 @@ internal class PublicationHistory(ApplicationDbContext db) : IPublicationHistory
 				Goal = p.GameGoal!.DisplayName,
 				CreateTimestamp = p.CreateTimestamp,
 				ObsoletedById = p.ObsoletedById,
+				Class = p.PublicationClass!.Name,
 				ClassIconPath = p.PublicationClass!.IconPath,
 				Flags = p.PublicationFlags
 					.Select(pf => new PublicationHistoryNode.FlagEntry(
@@ -89,6 +90,8 @@ public class PublicationHistoryNode
 	public string Title { get; init; } = "";
 	public string? Goal { get; init; }
 	public DateTime CreateTimestamp { get; init; }
+
+	public string Class { get; init; } = "";
 
 	public string? ClassIconPath { get; init; }
 

--- a/TASVideos/Pages/Shared/_HistoryEntry.cshtml
+++ b/TASVideos/Pages/Shared/_HistoryEntry.cshtml
@@ -3,7 +3,7 @@
 	var highlight = Model.Id == ViewData.Int("Highlight") ? "fw-bold fst-italic border border-info p-1" : "";
 	var strikethrough = Model.ObsoletedById is null ? "" : "text-decoration-line-through";
 }
-<icon path="@Model.ClassIconPath" />
+<icon path="@Model.ClassIconPath" title="@Model.Class" />
 @foreach (var flag in Model.Flags.Where(f => !string.IsNullOrWhiteSpace(f.IconPath)))
 {
 	<a href="/@flag.LinkPath">


### PR DESCRIPTION
Namely, the Alternative note block.

I simply copied what the pub display card does.