### PR TITLE
Improve search pager look

### DIFF
--- a/TASVideos/Pages/Search/Advanced.cshtml
+++ b/TASVideos/Pages/Search/Advanced.cshtml
@@ -42,36 +42,43 @@
 				</div>
 			</fieldset>
 			<submit-button>Search</submit-button>
-			<a condition="Model.EnablePrev"
-			   class="btn btn-secondary"
-			   asp-route-SearchTerms="@Model.SearchTerms"
-			   asp-route-PageNumber="@(Model.PageNumber - 1)"
-			   asp-route-SearchWiki="@Model.SearchWiki"
-			   asp-route-SearchForumTopics="@Model.SearchForumTopics"
-			   asp-route-SearchForumPosts="@Model.SearchForumPosts"
-			   asp-route-SearchPublications="@Model.SearchPublications"
-			   asp-route-SearchGames="@Model.SearchGames"
-			   asp-route-SearchUsers="@Model.SearchUsers">
-				Prev
-			</a>
-			<a condition="!Model.EnablePrev" disable class="btn btn-secondary">Prev</a>
-			<a condition="Model.EnableNext"
-			   class="btn btn-secondary"
-			   asp-route-SearchTerms="@Model.SearchTerms"
-			   asp-route-PageNumber="@(Model.PageNumber + 1)"
-			   asp-route-SearchWiki="@Model.SearchWiki"
-			   asp-route-SearchForumTopics="@Model.SearchForumTopics"
-			   asp-route-SearchForumPosts="@Model.SearchForumPosts"
-			   asp-route-SearchPublications="@Model.SearchPublications"
-			   asp-route-SearchGames="@Model.SearchGames"
-			   asp-route-SearchUsers="@Model.SearchUsers">
-				Next
-			</a>
-			<a condition="!Model.EnableNext" disable class="btn btn-secondary">Next</a>
 		</column>
 	</row>
 </form>
-<br />
+
+@{
+	const string pagerClass = "btn btn-secondary border-dark flex-grow-0";
+	const string pagerDisabledClass = "btn btn-silver border-dark flex-grow-0";
+}
+
+<fullrow class="my-2 text-center">
+	<div class="btn-group flex-wrap" role="group">
+		<a disable="!Model.EnablePrev" class="@(Model.EnablePrev ? pagerClass : pagerDisabledClass)"
+		   asp-route-SearchTerms="@Model.SearchTerms"
+		   asp-route-PageNumber="@(Model.PageNumber - 1)"
+		   asp-route-SearchWiki="@Model.SearchWiki"
+		   asp-route-SearchForumTopics="@Model.SearchForumTopics"
+		   asp-route-SearchForumPosts="@Model.SearchForumPosts"
+		   asp-route-SearchPublications="@Model.SearchPublications"
+		   asp-route-SearchGames="@Model.SearchGames"
+		   asp-route-SearchUsers="@Model.SearchUsers">
+			<i class="fa fa-chevron-left"></i>
+		</a>
+		<a condition="Model.EnablePrev" disable="true" class="btn btn-outline-silver border-dark flex-grow-0">...</a>
+		<a disable="true" class="@pagerDisabledClass">@Model.PageNumber</a>
+		<a condition="Model.EnableNext" disable="true" class="btn btn-outline-silver border-dark flex-grow-0">...</a>
+		<a disable="!Model.EnableNext" class="@(Model.EnableNext ? pagerClass : pagerDisabledClass)" asp-route-SearchTerms="@Model.SearchTerms"
+		   asp-route-PageNumber="@(Model.PageNumber + 1)"
+		   asp-route-SearchWiki="@Model.SearchWiki"
+		   asp-route-SearchForumTopics="@Model.SearchForumTopics"
+		   asp-route-SearchForumPosts="@Model.SearchForumPosts"
+		   asp-route-SearchPublications="@Model.SearchPublications"
+		   asp-route-SearchGames="@Model.SearchGames"
+		   asp-route-SearchUsers="@Model.SearchUsers">
+			<i class="fa fa-chevron-right"></i>
+		</a>
+	</div>
+</fullrow>
 
 <div condition="Model.GameResults.Any()">
 	<h4>Game Results:</h4>
@@ -176,3 +183,32 @@
 		}
 	</standard-table>
 </div>
+
+<fullrow class="my-2 text-center">
+	<div class="btn-group flex-wrap" role="group">
+		<a disable="!Model.EnablePrev" class="@(Model.EnablePrev ? pagerClass : pagerDisabledClass)"
+		   asp-route-SearchTerms="@Model.SearchTerms"
+		   asp-route-PageNumber="@(Model.PageNumber - 1)"
+		   asp-route-SearchWiki="@Model.SearchWiki"
+		   asp-route-SearchForumTopics="@Model.SearchForumTopics"
+		   asp-route-SearchForumPosts="@Model.SearchForumPosts"
+		   asp-route-SearchPublications="@Model.SearchPublications"
+		   asp-route-SearchGames="@Model.SearchGames"
+		   asp-route-SearchUsers="@Model.SearchUsers">
+			<i class="fa fa-chevron-left"></i>
+		</a>
+		<a condition="Model.EnablePrev" disable="true" class="btn btn-outline-silver border-dark flex-grow-0">...</a>
+		<a disable="true" class="@pagerDisabledClass">@Model.PageNumber</a>
+		<a condition="Model.EnableNext" disable="true" class="btn btn-outline-silver border-dark flex-grow-0">...</a>
+		<a disable="!Model.EnableNext" class="@(Model.EnableNext ? pagerClass : pagerDisabledClass)" asp-route-SearchTerms="@Model.SearchTerms"
+		   asp-route-PageNumber="@(Model.PageNumber + 1)"
+		   asp-route-SearchWiki="@Model.SearchWiki"
+		   asp-route-SearchForumTopics="@Model.SearchForumTopics"
+		   asp-route-SearchForumPosts="@Model.SearchForumPosts"
+		   asp-route-SearchPublications="@Model.SearchPublications"
+		   asp-route-SearchGames="@Model.SearchGames"
+		   asp-route-SearchUsers="@Model.SearchUsers">
+			<i class="fa fa-chevron-right"></i>
+		</a>
+	</div>
+</fullrow>

--- a/TASVideos/Pages/Search/Index.cshtml
+++ b/TASVideos/Pages/Search/Index.cshtml
@@ -16,14 +16,28 @@
 				<span condition="PageContext.HttpContext.Request.QueryString.HasValue" asp-validation-for="SearchTerms"></span>
 			</fieldset>
 			<submit-button>Search</submit-button>
-			<a condition="Model.PageNumber > 1" asp-page="/Search/Index" class="btn btn-secondary" asp-route-searchterms="@Model.SearchTerms" asp-route-pagenumber="@(Model.PageNumber - 1)">Prev</a>
-			<a condition="Model.PageResults.Count > IndexModel.PageSize || Model.PostResults.Count > IndexModel.PageSize || Model.GameResults.Count > IndexModel.PageSize" asp-page="/Search/Index" class="btn btn-secondary" asp-route-searchterms="@Model.SearchTerms" asp-route-pagenumber="@(Model.PageNumber + 1)">Next</a>
 		</column>
 	</row>
 </form>
 
+@{
+	const string pagerClass = "btn btn-secondary border-dark flex-grow-0";
+	const string pagerDisabledClass = "btn btn-silver border-dark flex-grow-0";
+	bool prevDisabled = Model.PageNumber <= 1;
+	bool nextDisabled = Model.PageResults.Count <= IndexModel.PageSize && Model.PostResults.Count <= IndexModel.PageSize && Model.GameResults.Count <= IndexModel.PageSize;
+}
+
+<fullrow class="my-2 text-center">
+	<div class="btn-group flex-wrap" role="group">
+		<a disable="prevDisabled" asp-page="/Search/Index" class="@(prevDisabled ? pagerDisabledClass : pagerClass)" asp-route-SearchTerms="@Model.SearchTerms" asp-route-PageNumber="@(Model.PageNumber - 1)"><i class="fa fa-chevron-left"></i></a>
+		<a condition="!prevDisabled" disable="true" class="btn btn-outline-silver border-dark flex-grow-0">...</a>
+		<a disable="true" class="@pagerDisabledClass">@Model.PageNumber</a>
+		<a condition="!nextDisabled" disable="true" class="btn btn-outline-silver border-dark flex-grow-0">...</a>
+		<a disable="nextDisabled" asp-page="/Search/Index" class="@(nextDisabled ? pagerDisabledClass : pagerClass)" asp-route-SearchTerms="@Model.SearchTerms" asp-route-PageNumber="@(Model.PageNumber + 1)"><i class="fa fa-chevron-right"></i></a>
+	</div>
+</fullrow>
+
 <div condition="Model.GameResults.Any()">
-	<hr />
 	<h4>Game Results:</h4>
 	<standard-table>
 		<table-head columns="Game,System,Groups"></table-head>
@@ -46,7 +60,6 @@
 </div>
 
 <div condition="Model.PageResults.Any()">
-	<hr />
 	<h4>Wiki Results:</h4>
 	<standard-table>
 		<table-head columns="Page,Content"></table-head>
@@ -65,7 +78,6 @@
 </div>
 
 <div condition="Model.PostResults.Any()">
-	<hr />
 	<h4>Post Results:</h4>
 	<standard-table>
 		<table-head columns="Post,Content"></table-head>
@@ -82,3 +94,13 @@
 		}
 	</standard-table>
 </div>
+
+<fullrow class="my-2 text-center">
+	<div class="btn-group flex-wrap" role="group">
+		<a disable="prevDisabled" asp-page="/Search/Index" class="@(prevDisabled ? pagerDisabledClass : pagerClass)" asp-route-SearchTerms="@Model.SearchTerms" asp-route-PageNumber="@(Model.PageNumber - 1)"><i class="fa fa-chevron-left"></i></a>
+		<a condition="!prevDisabled" disable="true" class="btn btn-outline-silver border-dark flex-grow-0">...</a>
+		<a disable="true" class="@pagerDisabledClass">@Model.PageNumber</a>
+		<a condition="!nextDisabled" disable="true" class="btn btn-outline-silver border-dark flex-grow-0">...</a>
+		<a disable="nextDisabled" asp-page="/Search/Index" class="@(nextDisabled ? pagerDisabledClass : pagerClass)" asp-route-SearchTerms="@Model.SearchTerms" asp-route-PageNumber="@(Model.PageNumber + 1)"><i class="fa fa-chevron-right"></i></a>
+	</div>
+</fullrow>


### PR DESCRIPTION
The reason we don't simply use the other pager is because we don't have the total page count for the search.
The search itself is already very heavy on our DB. I didn't test it, and maybe it's not that bad, but a total page count would mean adding an entire query just for the count.

So that's why I didn't touch the data loading, and instead only redesigned the pager to look like our usual pager.
I also added a pager at the bottom.

Resolves #1954 .
Resolves #1820 well enough.

Before:
![image](https://github.com/user-attachments/assets/294b653c-7dba-4ea3-b9f0-203e267ec89a)

After:
![image](https://github.com/user-attachments/assets/d7007cbb-22df-4fc7-9e17-2d968cba70d0)
