### PR TITLE
Fix rating sorts on user ratings page

### DIFF
--- a/TASVideos/Pages/Shared/_Ratings.cshtml
+++ b/TASVideos/Pages/Shared/_Ratings.cshtml
@@ -25,7 +25,7 @@
 	</form>
 	<partial name="_Pager" model="Model.Ratings" />
 	<standard-table>
-		<sortable-table-head sorting="@Model.Ratings.Request" model-type="typeof(UserRatings.Rating)" />
+		<sortable-table-head sorting="@Model.Ratings.Request" model-type="typeof(UserRatings.Rating)" page-override="@Context.Request.Path" />
 		@foreach (var rating in Model.Ratings)
 		{
 			<tr style="@(rating.IsObsolete ? "opacity: 0.6" : "")">


### PR DESCRIPTION
Sorting was broken on pages like `/Users/Ratings/Morimoto` because it calculated the wrong base page.

Resolves #1085 . (Which was technically already implemented, but this PR fixes a final bug in a related sort.)