### PR TITLE
Fix Exceeded Submission Limit Page

### DIFF
--- a/TASVideos/Pages/Submissions/ExceededLimit.cshtml
+++ b/TASVideos/Pages/Submissions/ExceededLimit.cshtml
@@ -7,12 +7,17 @@
 		nextWindow = date;
 	}
 }
-<info-alert condition="@nextWindow.HasValue">
-	Sorry, you can not submit at this time.<br />
-	We limit submissions to @Settings.SubmissionRate.Submissions in @Settings.SubmissionRate.Days days per user.<br />
-	You will be able to submit again on <timezone-convert relative-time="false" asp-for="@nextWindow!.Value" />
-</info-alert>
-
-<info-alert condition="!nextWindow.HasValue">
-	You are allowed to submit, you should not be seeing this
-</info-alert>
+@if (nextWindow.HasValue)
+{
+	<info-alert>
+		Sorry, you can not submit at this time.<br />
+		We limit submissions to @Settings.SubmissionRate.Submissions in @Settings.SubmissionRate.Days days per user.<br />
+		You will be able to submit again on <timezone-convert relative-time="false" asp-for="@nextWindow!.Value" />
+	</info-alert>
+}
+else
+{
+	<info-alert>
+		You are allowed to submit, you should not be seeing this
+	</info-alert>
+}


### PR DESCRIPTION
Currently, using `condition` in combination with other TagHelpers is unsafe. The other TagHelpers might load child content anyway.
In this case this then breaks the timezone-convert taghelper, because it expects a non-null value.