### PR TITLE
Make Catalogs keep selections when creating Games or Versions or Goals

### DIFF
--- a/TASVideos/Pages/Games/Goals/List.cshtml.cs
+++ b/TASVideos/Pages/Games/Goals/List.cshtml.cs
@@ -54,14 +54,18 @@ public class ListModel(ApplicationDbContext db) : BasePageModel
 			return BackToList();
 		}
 
-		db.GameGoals.Add(new GameGoal
+		var gameGoal = new GameGoal
 		{
 			GameId = GameId,
 			DisplayName = goalToCreate
-		});
+		};
+
+		db.GameGoals.Add(gameGoal);
 
 		SetMessage(await db.TrySaveChanges(), $"Goal {goalToCreate} created successfully", $"Unable to create goal {goalToCreate}");
-		return BackToList();
+		return string.IsNullOrWhiteSpace(Request.ReturnUrl())
+			? RedirectToPage("List", new { GameId })
+			: BaseReturnUrlRedirect(new() { ["GameGoalId"] = gameGoal.Id.ToString() });
 	}
 
 	public async Task<IActionResult> OnPostEdit(int gameGoalId, string? newGoalName)

--- a/TASVideos/Pages/Games/Versions/Edit.cshtml.cs
+++ b/TASVideos/Pages/Games/Versions/Edit.cshtml.cs
@@ -154,7 +154,7 @@ public class EditModel(ApplicationDbContext db) : BasePageModel
 		SuccessStatusMessage($"Game Version {Id} updated");
 		return string.IsNullOrWhiteSpace(HttpContext.Request.ReturnUrl())
 			? RedirectToPage("List", new { gameId = GameId })
-			: BaseReturnUrlRedirect(new() { ["GameId"] = GameId.ToString(), ["GameVersionId"] = version.Id.ToString() });
+			: BaseReturnUrlRedirect(new() { ["SystemId"] = system.Id.ToString(), ["GameId"] = GameId.ToString(), ["GameVersionId"] = version.Id.ToString() });
 	}
 
 	public async Task<IActionResult> OnPostDelete()

--- a/TASVideos/Pages/Publications/Catalog.cshtml.cs
+++ b/TASVideos/Pages/Publications/Catalog.cshtml.cs
@@ -9,10 +9,16 @@ public class CatalogModel(ApplicationDbContext db, ExternalMediaPublisher publis
 	public int Id { get; set; }
 
 	[FromQuery]
+	public int? SystemId { get; set; }
+
+	[FromQuery]
 	public int? GameId { get; set; }
 
 	[FromQuery]
 	public int? GameVersionId { get; set; }
+
+	[FromQuery]
+	public int? GameGoalId { get; set; }
 
 	[BindProperty]
 	public PublicationCatalog Catalog { get; set; } = new();
@@ -45,6 +51,16 @@ public class CatalogModel(ApplicationDbContext db, ExternalMediaPublisher publis
 		}
 
 		Catalog = catalog;
+
+		if (SystemId.HasValue)
+		{
+			var system = await db.GameSystems.FindAsync(SystemId);
+			if (system is not null)
+			{
+				Catalog.System = system.Id;
+			}
+		}
+
 		if (GameId.HasValue)
 		{
 			var game = await db.Games.FindAsync(GameId);
@@ -59,6 +75,15 @@ public class CatalogModel(ApplicationDbContext db, ExternalMediaPublisher publis
 					if (gameVersion is not null)
 					{
 						Catalog.GameVersion = gameVersion.Id;
+					}
+				}
+
+				if (GameGoalId.HasValue)
+				{
+					var gameGoal = await db.GameGoals.SingleOrDefaultAsync(gg => gg.GameId == game.Id && gg.Id == GameGoalId);
+					if (gameGoal is not null)
+					{
+						Catalog.Goal = gameGoal.Id;
 					}
 				}
 			}
@@ -202,9 +227,9 @@ public class CatalogModel(ApplicationDbContext db, ExternalMediaPublisher publis
 	{
 		public string Title { get; init; } = "";
 		public int GameVersion { get; set; }
-		public int Goal { get; init; }
+		public int Goal { get; set; }
 		public int Game { get; set; }
-		public int System { get; init; }
+		public int System { get; set; }
 		public int SystemFramerate { get; init; }
 
 		[StringLength(50)]

--- a/TASVideos/Pages/Submissions/Catalog.cshtml
+++ b/TASVideos/Pages/Submissions/Catalog.cshtml
@@ -62,7 +62,11 @@
 						<span asp-validation-for="Catalog.Goal"></span>
 					</div>
 					<div class="col-2">
-						<button id="create-goal" type="button" class="btn btn-primary">Manage</button>
+						<button
+							disable="Model.Catalog.Game is null or -1"
+							id="create-goal"
+							type="button"
+							class="btn btn-primary">Manage</button>
 					</div>
 				</row>
 			</fieldset>

--- a/TASVideos/Pages/Submissions/Catalog.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Catalog.cshtml.cs
@@ -9,10 +9,16 @@ public class CatalogModel(ApplicationDbContext db, ExternalMediaPublisher publis
 	public int Id { get; set; }
 
 	[FromQuery]
+	public int? SystemId { get; set; }
+
+	[FromQuery]
 	public int? GameId { get; set; }
 
 	[FromQuery]
 	public int? GameVersionId { get; set; }
+
+	[FromQuery]
+	public int? GameGoalId { get; set; }
 
 	[BindProperty]
 	public SubmissionCatalog Catalog { get; set; } = new();
@@ -45,6 +51,16 @@ public class CatalogModel(ApplicationDbContext db, ExternalMediaPublisher publis
 		}
 
 		Catalog = catalog;
+
+		if (SystemId.HasValue)
+		{
+			var system = await db.GameSystems.FindAsync(SystemId);
+			if (system is not null)
+			{
+				Catalog.System = system.Id;
+			}
+		}
+
 		if (GameId.HasValue)
 		{
 			var game = await db.Games.FindAsync(GameId);
@@ -59,6 +75,15 @@ public class CatalogModel(ApplicationDbContext db, ExternalMediaPublisher publis
 					if (version is not null)
 					{
 						Catalog.GameVersion = version.Id;
+					}
+				}
+
+				if (GameGoalId.HasValue)
+				{
+					var gameGoal = await db.GameGoals.SingleOrDefaultAsync(gg => gg.GameId == game.Id && gg.Id == GameGoalId);
+					if (gameGoal is not null)
+					{
+						Catalog.Goal = gameGoal.Id;
 					}
 				}
 			}
@@ -238,12 +263,12 @@ public class CatalogModel(ApplicationDbContext db, ExternalMediaPublisher publis
 		public int? Game { get; set; }
 
 		[Required]
-		public int? System { get; init; }
+		public int? System { get; set; }
 
 		[Required]
 		public int? SystemFramerate { get; init; }
 
-		public int? Goal { get; init; }
+		public int? Goal { get; set; }
 
 		[StringLength(50)]
 		public string? Emulator { get; init; }

--- a/TASVideos/wwwroot/js/catalog.js
+++ b/TASVideos/wwwroot/js/catalog.js
@@ -68,31 +68,32 @@ function enableCataloging() {
 	}
 
 	document.getElementById('create-version')?.addEventListener('click', function () {
-		const returnUrlQueryModified = new URLSearchParams();
-		returnUrlQueryModified.set('SystemId', systemModel.value);
-		returnUrlQueryModified.set('GameId', gameModel.value);
-		document.location = `/Games/${gameModel.value}/Versions/Edit?SystemId=${systemModel.value}&returnUrl=${encodeURIComponent(returnUrlPath + '?' + returnUrlQueryModified.toString())}`;
+		document.location = `/Games/${gameModel.value}/Versions/Edit?SystemId=${systemModel.value}&returnUrl=${generateCurrentReturnUrl() }`;
 	});
 
 	document.getElementById('create-game')?.addEventListener('click', function () {
-		const returnUrlQueryModified = new URLSearchParams();
-		returnUrlQueryModified.set('SystemId', systemModel.value);
-		if (gameModel.value) {
-			returnUrlQueryModified.set('GameId', gameModel.value);
-		}
-		document.location = `/Games/Edit?returnUrl=${encodeURIComponent(returnUrlPath + '?' + returnUrlQueryModified.toString())}`;
+		document.location = `/Games/Edit?returnUrl=${generateCurrentReturnUrl() }`;
 	});
 
 	gameGoalBtn?.addEventListener('click', function () {
+		document.location = `/Games/${gameModel.value}/Goals/List?returnUrl=${generateCurrentReturnUrl()}`;
+	});
+
+	function generateCurrentReturnUrl() {
 		const returnUrlQueryModified = new URLSearchParams();
-		returnUrlQueryModified.set('SystemId', systemModel.value);
-		returnUrlQueryModified.set('GameId', gameModel.value);
+		if (systemModel.value) {
+			returnUrlQueryModified.set('SystemId', systemModel.value);
+		}
+		if (gameModel.value) {
+			returnUrlQueryModified.set('GameId', gameModel.value);
+		}
 		if (versionModel.value) {
 			returnUrlQueryModified.set('GameVersionId', versionModel.value);
 		}
 		if (gameGoalModel.value) {
 			returnUrlQueryModified.set('GameGoalId', gameGoalModel.value);
 		}
-		document.location = `/Games/${gameModel.value}/Goals/List?returnUrl=${encodeURIComponent(returnUrlPath + '?' + returnUrlQueryModified.toString())}`;
-	});
+
+		return encodeURIComponent(returnUrlPath + '?' + returnUrlQueryModified.toString());
+	}
 }

--- a/TASVideos/wwwroot/js/catalog.js
+++ b/TASVideos/wwwroot/js/catalog.js
@@ -10,7 +10,9 @@ function enableCataloging() {
 	const createVersionBtn = document.getElementById('create-version');
 	const gameGoalModel = document.querySelector('[data-id="goal"]');
 	const gameGoalBtn = document.getElementById('create-goal');
-	const returnUrl = encodeURIComponent(systemModel.dataset.returnUrl);
+	const returnUrlPathAndQuery = systemModel.dataset.returnUrl.split(/\?(.*)/s) // splits string at the first question mark (?)
+	const returnUrlPath = returnUrlPathAndQuery[0];
+	const returnUrlQuery = returnUrlPathAndQuery[1] ?? "";
 
 	systemModel.onchange = function () {
 		if (this.value) {
@@ -58,20 +60,39 @@ function enableCataloging() {
 		} else {
 			createVersionBtn.classList.add('disabled');
 			createVersionBtn.setAttribute('disabled', 'disabled');
+			gameGoalBtn.classList.add('disabled');
+			gameGoalBtn.setAttribute('disabled', 'disabled');
 			clearDropdown(versionElemId);
 			clearDropdown(gameGoalElemId);
 		}
 	}
 
 	document.getElementById('create-version')?.addEventListener('click', function () {
-		document.location = `/Games/${gameModel.value}/Versions/Edit?returnUrl=${returnUrl}&systemId=${systemModel.value}`;
+		const returnUrlQueryModified = new URLSearchParams();
+		returnUrlQueryModified.set('SystemId', systemModel.value);
+		returnUrlQueryModified.set('GameId', gameModel.value);
+		document.location = `/Games/${gameModel.value}/Versions/Edit?SystemId=${systemModel.value}&returnUrl=${encodeURIComponent(returnUrlPath + '?' + returnUrlQueryModified.toString())}`;
 	});
 
 	document.getElementById('create-game')?.addEventListener('click', function () {
-		document.location = `/Games/Edit?returnUrl=${returnUrl}`;
+		const returnUrlQueryModified = new URLSearchParams();
+		returnUrlQueryModified.set('SystemId', systemModel.value);
+		if (gameModel.value) {
+			returnUrlQueryModified.set('GameId', gameModel.value);
+		}
+		document.location = `/Games/Edit?returnUrl=${encodeURIComponent(returnUrlPath + '?' + returnUrlQueryModified.toString())}`;
 	});
 
 	gameGoalBtn?.addEventListener('click', function () {
-		document.location = `/Games/${gameModel.value}/Goals/List?returnUrl=${returnUrl}`;
+		const returnUrlQueryModified = new URLSearchParams();
+		returnUrlQueryModified.set('SystemId', systemModel.value);
+		returnUrlQueryModified.set('GameId', gameModel.value);
+		if (versionModel.value) {
+			returnUrlQueryModified.set('GameVersionId', versionModel.value);
+		}
+		if (gameGoalModel.value) {
+			returnUrlQueryModified.set('GameGoalId', gameGoalModel.value);
+		}
+		document.location = `/Games/${gameModel.value}/Goals/List?returnUrl=${encodeURIComponent(returnUrlPath + '?' + returnUrlQueryModified.toString())}`;
 	});
 }


### PR DESCRIPTION
This PR uses the very useful JavaScript `URLSearchParams` class to edit and set URL query parameters.
Resolves #1963 .

Whenever the user clicks on one of the buttons to navigate away, we send all the selections with it, and then when the new page returns, it will selectively override with new data it just created.

This will result in some inconsistent data in the URL, e.g. if you create a new Game, the Version and Goal IDs of the old Game will still be there. However, we validate the Goal and Versions fit to the Game in the OnGet anyway. If they don't fit, we just keep them empty. So this works out perfectly.
The inconsistency in the URL won't propagate to anywhere else, because we never use the query parameters after the page loaded. (And we shouldn't, because users change dropdowns, so the query is quickly outdated.)

Oh, the advantage with sending the entire data is that the "Cancel" or "Back" buttons on the new page work very well this way. So even if you planned to create a new Game (clearing Goal and Version on the way), and then click Cancel, you will keep the previously entered data!