### PR TITLE
Enable extra sanity checks on service provider

### DIFF
--- a/TASVideos/Program.cs
+++ b/TASVideos/Program.cs
@@ -9,6 +9,11 @@ using TASVideos.Middleware;
 using TASVideos.MovieParsers;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Host.UseDefaultServiceProvider(config =>
+{
+	config.ValidateOnBuild = true;
+	config.ValidateScopes = true;
+});
 
 // We use <GenerateAssemblyInfo>false</GenerateAssemblyInfo> to support GitVersionTask.
 // This also suppresses the creation of [assembly: UserSecretsId("...")], so builder.Configuration.AddUserSecrets<T>() will not work.


### PR DESCRIPTION
My understanding is that these are checks for services initialised out of order, and out-of-the-box those would silently fail. In any case the checks currently pass on my machine.