### PR TITLE
Fix the bug where the text backup functionality wasn't working

### DIFF
--- a/TASVideos/TagHelpers/Attributes/BackupContentTagHelper.cs
+++ b/TASVideos/TagHelpers/Attributes/BackupContentTagHelper.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace TASVideos.TagHelpers;
 
-[HtmlTargetElement("textarea", Attributes = "backup-content")]
+[HtmlTargetElement(Attributes = "backup-content")]
 public class BackupContentTagHelper : TagHelper
 {
 	[HtmlAttributeName("backup-content")]


### PR DESCRIPTION
The BackupContentTagHelper only called when it had attributes on a "textarea". But if you look at where it's used, it's not a "textarea" but a "forum-textarea" or "wiki-textarea", which are yet more taghelpers. So this one never started.