### PR TITLE
Allow middle-clicking the search button with progressive enhancement

### DIFF
--- a/TASVideos/wwwroot/js/site-head.js
+++ b/TASVideos/wwwroot/js/site-head.js
@@ -64,6 +64,22 @@ window.addEventListener("DOMContentLoaded", function () {
             rate(btn.dataset.pubId, true);
         };
     });
+
+    // allow middle-clicking the search button to open in new tab
+    const searchBtnElem = document.querySelector(/*ul.navbar-nav */'form[action="/Search/Index"] button[type="submit"]');
+    // is there a function for this? reverse Element.querySelector?
+    let searchFormElem = searchBtnElem.parentElement;
+    while (!(searchFormElem instanceof HTMLFormElement)) searchFormElem = searchFormElem.parentElement;
+    const linkElem = document.createElement("a");
+    Array.from(searchBtnElem.attributes).forEach(attr => linkElem.setAttribute(attr.name, attr.value));
+    linkElem.onclick = e => {
+        e.preventDefault();
+        searchFormElem.requestSubmit();
+    };
+    linkElem.removeAttribute("type");
+    linkElem.setAttribute("href", "/Search/Index");
+    Array.from(searchBtnElem.children).forEach(e => linkElem.appendChild(e));
+    searchBtnElem.replaceWith(linkElem);
 });
 
 function rate(pubId, unrated) {

--- a/TASVideos/wwwroot/js/site-head.js
+++ b/TASVideos/wwwroot/js/site-head.js
@@ -67,14 +67,11 @@ window.addEventListener("DOMContentLoaded", function () {
 
     // allow middle-clicking the search button to open in new tab
     const searchBtnElem = document.querySelector(/*ul.navbar-nav */'form[action="/Search/Index"] button[type="submit"]');
-    // is there a function for this? reverse Element.querySelector?
-    let searchFormElem = searchBtnElem.parentElement;
-    while (!(searchFormElem instanceof HTMLFormElement)) searchFormElem = searchFormElem.parentElement;
     const linkElem = document.createElement("a");
     Array.from(searchBtnElem.attributes).forEach(attr => linkElem.setAttribute(attr.name, attr.value));
     linkElem.onclick = e => {
         e.preventDefault();
-        searchFormElem.requestSubmit();
+        e.target.closest("form").requestSubmit();
     };
     linkElem.removeAttribute("type");
     linkElem.setAttribute("href", "/Search/Index");


### PR DESCRIPTION
Implements #1878.
RetroEdit's earlier draft used JS to add an event handler specifically for MMB. I feel that's the wrong approach, and it should instead use the browser's built-in handling for `<a/>`.
This changeset uses JS to replace the `<button/>` with an `<a/>`, then adds an event handler for `onclick` (which [is a misnomer](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event) and is not specific to LMB) which restores the `<button/>`-like submit behaviour.