### PR TITLE
Fix activity posts not being marked as read

### DIFF
--- a/TASVideos.Core/Services/ForumService.cs
+++ b/TASVideos.Core/Services/ForumService.cs
@@ -254,7 +254,7 @@ internal class ForumService(
 			return forumActivity;
 		}
 
-		DateTime minimumDate = DateTime.UtcNow.AddDays(-ForumConstants.DaysPostsCountAsActive);
+		DateTime minimumDate = DateTime.UtcNow.AddDays(-(ForumConstants.DaysPostsCountAsActive - 1)); // we subtract 1 day here because we cache activity for 1 day
 
 		var fullrow = await db.ForumPosts
 			.Where(fp => fp.CreateTimestamp > minimumDate || fp.PostEditedTimestamp > minimumDate)
@@ -306,7 +306,7 @@ internal class ForumService(
 			return subforumActivity;
 		}
 
-		DateTime minimumDate = DateTime.UtcNow.AddDays(-ForumConstants.DaysPostsCountAsActive);
+		DateTime minimumDate = DateTime.UtcNow.AddDays(-(ForumConstants.DaysPostsCountAsActive - 1)); // we subtract 1 day here because we cache activity for 1 day
 
 		var fullrow = await db.ForumPosts
 			.Where(fp => fp.CreateTimestamp > minimumDate || fp.PostEditedTimestamp > minimumDate)


### PR DESCRIPTION
Resolves #2007 .

We cache post activity for 1 day, so we have to account for that by making sure that in 1 day none of the timestamps of the posts we cached exceed the active-days constant. Otherwise they don't get marked as read.