### PR TITLE
Set up `Content-Security-Policy` "reporting" (monitoring)

### DIFF
--- a/TASVideos/Pages/Diagnostics/UserAgentInterventionReports.cshtml
+++ b/TASVideos/Pages/Diagnostics/UserAgentInterventionReports.cshtml
@@ -1,0 +1,14 @@
+﻿@model UserAgentInterventionReportsModel
+@{
+	ViewData.SetTitle("User agent intervention reports");
+}
+
+This is the endpoint for reports automatically submitted by user agents, which can happen for several reasons:<ul>
+<li>CSP violations;</li>
+<li><code>Permissions-Policy</code> violations;</li>
+<li>use of deprecated features;</li>
+<li>crashes; or</li>
+<li>pther miscellaneous user-agent interventions.</li>
+</ul>
+(Paraphrased from <a href="https://developer.mozilla.org/en-US/docs/Web/API/Reporting_API">MDN</a>.)
+A JSON payload will be POST'd to one of <code>Reporting-Endpoints</code> (should all be pointing at this page) if any of these are encountered by a conformant browser.

--- a/TASVideos/Pages/Diagnostics/UserAgentInterventionReports.cshtml.cs
+++ b/TASVideos/Pages/Diagnostics/UserAgentInterventionReports.cshtml.cs
@@ -1,0 +1,10 @@
+﻿namespace TASVideos.Pages.Diagnostics;
+
+[RequirePermission(PermissionTo.SeeDiagnostics)]
+public class UserAgentInterventionReportsModel(ILogger<ILogger> logger) : BasePageModel
+{
+	public void OnPost()
+	{
+		logger.LogInformation("got POST payload maybe?");
+	}
+}


### PR DESCRIPTION
Follow-up to #2003. For an overview of reporting, see [Google's web.dev](https://web.dev/articles/csp#report-policy-violations) and [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP#violation_reporting).

What's missing at the moment is all the handling for POST requests to `/Diagnostics/UserAgentInterventionReports`.