### PR TITLE
Add Metrics (OpenTelemetry with Prometheus Export endpoint)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,8 @@
     <PackageVersion Include="Namotion.Reflection" Version="3.1.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.9.0-beta.2" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageVersion Include="RoslynCodeTaskFactory" Version="2.0.7" />
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageVersion Include="SharpCompress" Version="0.36.0" />

--- a/TASVideos.Core/Settings/AppSettings.cs
+++ b/TASVideos.Core/Settings/AppSettings.cs
@@ -28,6 +28,8 @@ public class AppSettings
 
 	public ReCaptchaSettings ReCaptcha { get; set; } = new();
 
+	public bool EnableMetrics { get; set; }
+
 	// User is only allowed to submit X submissions in Y days
 	public class SubmissionRateLimit
 	{

--- a/TASVideos/Extensions/ApplicationBuilderExtensions.cs
+++ b/TASVideos/Extensions/ApplicationBuilderExtensions.cs
@@ -112,6 +112,10 @@ public static class ApplicationBuilderExtensions
 		return app.UseEndpoints(endpoints =>
 		{
 			endpoints.MapRazorPages();
+			endpoints.MapPrometheusScrapingEndpoint().RequireAuthorization(builder =>
+			{
+				builder.RequireClaim(CustomClaimTypes.Permission, ((int)PermissionTo.SeeDiagnostics).ToString());
+			});
 		});
 	}
 }

--- a/TASVideos/Extensions/ApplicationBuilderExtensions.cs
+++ b/TASVideos/Extensions/ApplicationBuilderExtensions.cs
@@ -112,10 +112,14 @@ public static class ApplicationBuilderExtensions
 		return app.UseEndpoints(endpoints =>
 		{
 			endpoints.MapRazorPages();
-			endpoints.MapPrometheusScrapingEndpoint().RequireAuthorization(builder =>
+
+			if (settings.EnableMetrics)
 			{
-				builder.RequireClaim(CustomClaimTypes.Permission, ((int)PermissionTo.SeeDiagnostics).ToString());
-			});
+				endpoints.MapPrometheusScrapingEndpoint().RequireAuthorization(builder =>
+				{
+					builder.RequireClaim(CustomClaimTypes.Permission, ((int)PermissionTo.SeeDiagnostics).ToString());
+				});
+			}
 		});
 	}
 }

--- a/TASVideos/Pages/Diagnostics/Index.cshtml
+++ b/TASVideos/Pages/Diagnostics/Index.cshtml
@@ -40,6 +40,8 @@
 	<li><a asp-page="Logging">Logging</a></li>
 	<li><a asp-page="SendEmail">Send an Email</a></li>
 	<li><a asp-page="SystemPages">System Wiki Pages</a></li>
+	<li condition="@Settings.EnableMetrics"><a href="/metrics">Metrics</a></li>
+	<li condition="!@Settings.EnableMetrics">Metrics (disabled)</li>
 </ul>
 
 <standard-table>

--- a/TASVideos/Pages/Diagnostics/Index.cshtml
+++ b/TASVideos/Pages/Diagnostics/Index.cshtml
@@ -40,7 +40,7 @@
 	<li><a asp-page="Logging">Logging</a></li>
 	<li><a asp-page="SendEmail">Send an Email</a></li>
 	<li><a asp-page="SystemPages">System Wiki Pages</a></li>
-	<li condition="@Settings.EnableMetrics"><a href="/metrics">Metrics</a></li>
+	<li condition="@Settings.EnableMetrics"><a href="/Metrics">Metrics</a></li>
 	<li condition="!@Settings.EnableMetrics">Metrics (disabled)</li>
 </ul>
 

--- a/TASVideos/Program.cs
+++ b/TASVideos/Program.cs
@@ -1,7 +1,6 @@
 ﻿using AspNetCore.ReCaptcha;
 using JavaScriptEngineSwitcher.Core;
 using JavaScriptEngineSwitcher.V8;
-using OpenTelemetry.Metrics;
 using Serilog;
 using TASVideos.Api;
 using TASVideos.Core.Data;
@@ -50,30 +49,10 @@ builder.Services
 		pipeline.AddScssBundle("/css/site.css", "/css/site.scss");
 		pipeline.AddScssBundle("/css/forum.css", "/css/forum.scss");
 		pipeline.AddFiles("text/javascript", "/js/*");
-	});
+	})
+	.AddMetrics(settings);
 
 builder.Host.UseSerilog();
-
-if (settings.EnableMetrics)
-{
-	builder.Services
-		.AddOpenTelemetry()
-		.WithMetrics(builder =>
-		{
-			builder.AddMeter(
-				"Microsoft.AspNetCore.Hosting",
-				"Microsoft.AspNetCore.Server.Kestrel",
-				"Microsoft.AspNetCore.Routing",
-				"Microsoft.AspNetCore.Diagnostics");
-
-			builder.AddMeter("Npgsql");
-
-			builder.AddPrometheusExporter(options =>
-			{
-				options.ScrapeEndpointPath = "/Metrics";
-			});
-		});
-}
 
 var app = builder.Build();
 

--- a/TASVideos/Program.cs
+++ b/TASVideos/Program.cs
@@ -1,6 +1,7 @@
 ﻿using AspNetCore.ReCaptcha;
 using JavaScriptEngineSwitcher.Core;
 using JavaScriptEngineSwitcher.V8;
+using OpenTelemetry.Metrics;
 using Serilog;
 using TASVideos.Api;
 using TASVideos.Core.Data;
@@ -52,6 +53,23 @@ builder.Services
 	});
 
 builder.Host.UseSerilog();
+
+builder.Services
+	.AddOpenTelemetry()
+	.WithMetrics(builder =>
+	{
+		builder.AddMeter(
+			"Microsoft.AspNetCore.Hosting",
+			"Microsoft.AspNetCore.Server.Kestrel",
+			"Microsoft.AspNetCore.Http.Connections",
+			"Microsoft.AspNetCore.Routing",
+			"Microsoft.AspNetCore.Diagnostics",
+			"Microsoft.AspNetCore.RateLimiting");
+
+		builder.AddMeter("Npgsql");
+
+		builder.AddPrometheusExporter();
+	});
 
 var app = builder.Build();
 

--- a/TASVideos/Program.cs
+++ b/TASVideos/Program.cs
@@ -54,22 +54,23 @@ builder.Services
 
 builder.Host.UseSerilog();
 
-builder.Services
-	.AddOpenTelemetry()
-	.WithMetrics(builder =>
-	{
-		builder.AddMeter(
-			"Microsoft.AspNetCore.Hosting",
-			"Microsoft.AspNetCore.Server.Kestrel",
-			"Microsoft.AspNetCore.Http.Connections",
-			"Microsoft.AspNetCore.Routing",
-			"Microsoft.AspNetCore.Diagnostics",
-			"Microsoft.AspNetCore.RateLimiting");
+if (settings.EnableMetrics)
+{
+	builder.Services
+		.AddOpenTelemetry()
+		.WithMetrics(builder =>
+		{
+			builder.AddMeter(
+				"Microsoft.AspNetCore.Hosting",
+				"Microsoft.AspNetCore.Server.Kestrel",
+				"Microsoft.AspNetCore.Routing",
+				"Microsoft.AspNetCore.Diagnostics");
 
-		builder.AddMeter("Npgsql");
+			builder.AddMeter("Npgsql");
 
-		builder.AddPrometheusExporter();
-	});
+			builder.AddPrometheusExporter();
+		});
+}
 
 var app = builder.Build();
 

--- a/TASVideos/Program.cs
+++ b/TASVideos/Program.cs
@@ -68,7 +68,10 @@ if (settings.EnableMetrics)
 
 			builder.AddMeter("Npgsql");
 
-			builder.AddPrometheusExporter();
+			builder.AddPrometheusExporter(options =>
+			{
+				options.ScrapeEndpointPath = "/Metrics";
+			});
 		});
 }
 

--- a/TASVideos/TASVideos.csproj
+++ b/TASVideos/TASVideos.csproj
@@ -42,6 +42,8 @@
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
 		<PackageReference Include="Microsoft.Web.LibraryManager.Build" />
 		<PackageReference Include="Namotion.Reflection" />
+		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" />
 		<PackageReference Include="RoslynCodeTaskFactory" />
 		<PackageReference Include="Serilog.AspNetCore" />
 	</ItemGroup>

--- a/TASVideos/appsettings.json
+++ b/TASVideos/appsettings.json
@@ -13,5 +13,6 @@
   "webOptimizer": {
     "enableCaching": true,
     "enableTagHelperBundling": true
-  }
+  },
+  "EnableMetrics": true
 }


### PR DESCRIPTION
Ever since .NET 8.0, there are built-in metrics for both [ASP.NET Core](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-aspnetcore) and also our PostgreSQL [Npgsql](https://www.npgsql.org/doc/diagnostics/metrics.html).

With the OpenTelemetry nuget package, we collect these metrics. And with the Prometheus Export nuget package we can expose them on an endpoint `/Metrics`, which I guarded behind the SeeDiagnostics permission.

If you access that endpoint you will see all live metric data in Prometheus format, which is a very big text file of stuff like
```
db_client_commands_bytes_written_bytes_total{otel_scope_name="Npgsql",otel_scope_version="0.1.0",pool_name="Host=127.0.0.1;Port=5432;Database=TASVideos;Username=postgres;Include Error Detail=True"} 90222 1729267870852
http_server_active_requests{otel_scope_name="Microsoft.AspNetCore.Hosting",http_request_method="GET",url_scheme="https"} 1 1729267870852
aspnetcore_routing_match_attempts_total{otel_scope_name="Microsoft.AspNetCore.Routing",aspnetcore_routing_is_fallback="false",aspnetcore_routing_match_status="success",http_route=""} 2 1729267870852
aspnetcore_routing_match_attempts_total{otel_scope_name="Microsoft.AspNetCore.Routing",aspnetcore_routing_is_fallback="false",aspnetcore_routing_match_status="success",http_route="{*url}"} 10 1729267870852
aspnetcore_routing_match_attempts_total{otel_scope_name="Microsoft.AspNetCore.Routing",aspnetcore_routing_is_fallback="false",aspnetcore_routing_match_status="success",http_route="Wiki/PageNotFound"} 10 1729267870852
aspnetcore_routing_match_attempts_total{otel_scope_name="Microsoft.AspNetCore.Routing",aspnetcore_routing_is_fallback="false",aspnetcore_routing_match_status="success",http_route="/Metrics"} 3 1729267870852
aspnetcore_routing_match_attempts_total{otel_scope_name="Microsoft.AspNetCore.Routing",aspnetcore_routing_is_fallback="false",aspnetcore_routing_match_status="success",http_route="Forum"} 3 1729267870852
aspnetcore_routing_match_attempts_total{otel_scope_name="Microsoft.AspNetCore.Routing",aspnetcore_routing_is_fallback="false",aspnetcore_routing_match_status="success",http_route="{id:int}M"} 1 1729267870852
aspnetcore_routing_match_attempts_total{otel_scope_name="Microsoft.AspNetCore.Routing",aspnetcore_routing_is_fallback="false",aspnetcore_routing_match_status="success",http_route="Forum/Subforum/{id}"} 1 1729267870852
aspnetcore_routing_match_attempts_total{otel_scope_name="Microsoft.AspNetCore.Routing",aspnetcore_routing_is_fallback="false",aspnetcore_routing_match_status="success",http_route="Forum/Posts/{id}"} 1 1729267870852
aspnetcore_routing_match_attempts_total{otel_scope_name="Microsoft.AspNetCore.Routing",aspnetcore_routing_is_fallback="false",aspnetcore_routing_match_status="success",http_route="Forum/Topics/{id}"} 1 1729267870852
```

And that's all this PR does. No data is stored, no data is visualized.

<hr>

Actually visualizing this data is difficult, because nothing is ever simple.
You need to set up your own Prometheus server that scrapes off this data. This is where data is actually stored: in your own Prometheus instance.
To visualize this data, you need *another* server like Grafana that queries your Prometheus server and makes cool lines on charts and stuff.
Did I say nothing is ever simple? You can't send http headers with the Prometheus server, so you need *another* server that acts as a reverse proxy and adds your authentication cookie with the request.