### PR TITLE
exposes required permissions to users next to the header with a shiel…

### DIFF
--- a/TASVideos/Extensions/ClaimsPrincipalExtensions.cs
+++ b/TASVideos/Extensions/ClaimsPrincipalExtensions.cs
@@ -5,5 +5,5 @@ namespace TASVideos;
 public static class ClaimsPrincipalExtensions
 {
 	public static bool CanEditWiki(this ClaimsPrincipal user, string pageName)
-		=> WikiHelper.UserCanEditWikiPage(pageName, user.Name(), user.Permissions());
+		=> WikiHelper.UserCanEditWikiPage(pageName, user.Name(), user.Permissions(), out _);
 }

--- a/TASVideos/Extensions/HttpContextExtensions.cs
+++ b/TASVideos/Extensions/HttpContextExtensions.cs
@@ -1,9 +1,24 @@
-﻿namespace TASVideos.Extensions;
+﻿using TASVideos.Pages;
+
+namespace TASVideos.Extensions;
 
 public static class HttpContextExtensions
 {
 	public static string CurrentPathToReturnUrl(this HttpContext? context)
 	{
 		return context is null ? "" : $"{context.Request.Path}{context.Request.QueryString}";
+	}
+
+	public static void SetRequiredPermissionsView(this HttpContext? context, RequirePermissionsView requiredPermissions)
+	{
+		if (context is not null)
+		{
+			context.Items["RequiredPermissions"] = requiredPermissions;
+		}
+	}
+
+	public static RequirePermissionsView? GetRequiredPermissionsView(this HttpContext? context)
+	{
+		return context?.Items["RequiredPermissions"] as RequirePermissionsView;
 	}
 }

--- a/TASVideos/Pages/RequireBase.cs
+++ b/TASVideos/Pages/RequireBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Collections.Generic;
+using System.Net;
 using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace TASVideos.Pages;
@@ -40,4 +41,15 @@ public class RequireBase : Attribute
 
 		return context.HttpContext.User.Permissions();
 	}
+
+	protected static void SetRequiredPermissionsView(PageHandlerExecutingContext context, HashSet<PermissionTo> requiredPermissions, bool matchAny)
+	{
+		context.HttpContext.SetRequiredPermissionsView(new RequirePermissionsView { Permissions = requiredPermissions, MatchAny = matchAny });
+	}
+}
+
+public class RequirePermissionsView
+{
+	public HashSet<PermissionTo> Permissions { get; set; } = [];
+	public bool MatchAny { get; set; }
 }

--- a/TASVideos/Pages/RequireEdit.cs
+++ b/TASVideos/Pages/RequireEdit.cs
@@ -28,10 +28,12 @@ public class RequireEdit : RequireBase, IAsyncPageFilter
 
 		var userPerms = await GetUserPermissions(context);
 		var canEdit = WikiHelper
-			.UserCanEditWikiPage(pageToEdit, user.Name(), userPerms);
+			.UserCanEditWikiPage(pageToEdit, user.Name(), userPerms, out HashSet<PermissionTo> relevantPermissions);
 
 		if (canEdit)
 		{
+			SetRequiredPermissionsView(context, relevantPermissions, matchAny: true);
+
 			await next.Invoke();
 		}
 		else

--- a/TASVideos/Pages/RequirePermission.cs
+++ b/TASVideos/Pages/RequirePermission.cs
@@ -38,6 +38,7 @@ public class RequirePermissionAttribute : RequireBase, IAsyncPageFilter
 		if ((MatchAny && RequiredPermissions.Any(r => userPerms.Contains(r)))
 			|| RequiredPermissions.IsSubsetOf(userPerms))
 		{
+			SetRequiredPermissionsView(context, RequiredPermissions, MatchAny);
 			await next.Invoke();
 		}
 		else

--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -100,6 +100,9 @@
 			}
 		}
 
+		var permissionsRequired = Context.GetRequiredPermissionsView() as RequirePermissionsView;
+		bool requiresPermissions = permissionsRequired is not null && permissionsRequired.Permissions.Count > 0;
+
 		<div class="container mb-2">
 			<h1 class="page-title card card-body d-block">
 				<a condition="prev.HasValue" href="@string.Format(fmtStr!, prev)"><i class="fa fa-arrow-left"></i></a>
@@ -112,7 +115,31 @@
 					@heading
 				}
 				<a condition="next.HasValue" class="float-end" href="@string.Format(fmtStr!, next)"><i class="fa fa-arrow-right"></i></a>
+				<a condition="requiresPermissions" class="float-end text-body-secondary" data-id="permission-modal-button" href="#"><i class="fa-solid fa-shield-halved"></i></a>
 			</h1>
+		</div>
+
+		<div condition="requiresPermissions" id="permission-modal" class="modal fade" tabindex="-1">
+			<div class="modal-dialog">
+				<div class="modal-content">
+					<div class="modal-header">
+						<h5 class="modal-title"><i class="fa-solid fa-shield-halved"></i> This page requires permissions</h5>
+						<button type='button' class='btn-close' data-bs-dismiss='modal'></button>
+					</div>
+					<div class="modal-body">
+						<p>You can visit this page because you have @(permissionsRequired!.Permissions.Count == 1 ? "" : permissionsRequired.MatchAny ? "one of " : "all of ")the following required permissions:</p>
+						<ul>
+							@foreach (var permission in permissionsRequired.Permissions)
+							{
+								<li>@permission.ToString().SplitCamelCase()</li>
+							}
+						</ul>
+					</div>
+					<div class="modal-footer">
+						<button type="button" class="btn btn-silver" data-bs-dismiss="modal">Close</button>
+					</div>
+				</div>
+			</div>
 		</div>
 	}
 

--- a/TASVideos/Pages/Wiki/PageHistory.cshtml
+++ b/TASVideos/Pages/Wiki/PageHistory.cshtml
@@ -4,7 +4,7 @@
 	ViewData.SetTitle("Page History For " + Model.PageName);
 	ViewData.UseDiff();
 	bool hasDiff = Model.FromRevision.HasValue && Model.ToRevision.HasValue;
-	var canEdit = WikiHelper.UserCanEditWikiPage(Model.Path, User.Name(), User.Permissions());
+	var canEdit = WikiHelper.UserCanEditWikiPage(Model.Path, User.Name(), User.Permissions(), out _);
 }
 
 @functions {

--- a/TASVideos/wwwroot/js/site.js
+++ b/TASVideos/wwwroot/js/site.js
@@ -50,3 +50,11 @@ if (location.hash) {
 		}
 	}
 }
+
+Array.from(document.querySelectorAll('[data-id="permission-modal-button"]')).forEach(popupBtn => {
+	popupBtn.addEventListener('click', () => {
+		let modal = new bootstrap.Modal('#permission-modal')
+		modal.show();
+		return false;
+	})
+});

--- a/tests/TASVideos.Test/Extensions/WikiHelperTests.cs
+++ b/tests/TASVideos.Test/Extensions/WikiHelperTests.cs
@@ -58,7 +58,8 @@ public class WikiHelperTests
 		var actual = WikiHelper.UserCanEditWikiPage(
 			pageName,
 			userName,
-			userPermissions.ToList());
+			userPermissions.ToList(),
+			out _);
 
 		Assert.AreEqual(expected, actual);
 	}


### PR DESCRIPTION
This PR adds a shield icon on pages that require permissions to view.

![image](https://github.com/user-attachments/assets/e65cced8-e181-4e07-8244-6af718587ce6)

Clicking on the shield icon shows a modal:

![image](https://github.com/user-attachments/assets/6e91c37c-cd8d-4991-abd0-a949aa6d4831)

This PR automatically adds this behavior to pages that use the Require attribute. It can also show multiple permissions, where it will then say the user has "one of" or "all of" permissions, depending on which applies.