### PR TITLE
Make Publication list sorting more robust by adding final ID sort

### DIFF
--- a/TASVideos.Data/Entity/Publication.cs
+++ b/TASVideos.Data/Entity/Publication.cs
@@ -217,9 +217,10 @@ public static class PublicationExtensions
 			query = query.Where(p => p.Authors.Select(a => a.UserId).Any(a => tokens.Authors.Contains(a)));
 		}
 
+		IOrderedQueryable<Publication> orderedQuery;
 		if (!string.IsNullOrEmpty(tokens.SortBy))
 		{
-			query = tokens.SortBy switch
+			orderedQuery = tokens.SortBy switch
 			{
 				"v" => query.OrderBy(p => p.CreateTimestamp),
 				"u" => query.OrderByDescending(p => p.CreateTimestamp),
@@ -232,10 +233,12 @@ public static class PublicationExtensions
 		}
 		else
 		{
-			query = query
+			orderedQuery = query
 				.OrderBy(p => p.System!.Code)
 				.ThenBy(p => p.Game!.DisplayName);
 		}
+
+		query = orderedQuery.ThenBy(p => p.Id);
 
 		if (tokens.Limit.HasValue)
 		{


### PR DESCRIPTION
Resolves #2012 .
This issue happened because the page was only sorting by System Code and then Game Name. But publications of the same game have the same ones, so the sorting between those is undefined. And that's why it's possible for items to get lost on page boundaries.
This adds a final ID sort to the publications, so that there is a uniquely defined order for all items.