### PR TITLE
Disable the require-trusted-types-for csp directive

### DIFF
--- a/TASVideos/Extensions/ApplicationBuilderExtensions.cs
+++ b/TASVideos/Extensions/ApplicationBuilderExtensions.cs
@@ -62,7 +62,6 @@ public static class ApplicationBuilderExtensions
 			"form-action 'self'", // domains allowed for `<form action/>` (POST target page)
 			"frame-src 'self' https://www.youtube.com/embed/", // allow these domains in <iframe/>
 			"img-src * data:", // allow hotlinking images from any domain in UGC (not great)
-			"require-trusted-types-for 'script'", // experimental, but Google seems to be pushing it: should block `HTMLScriptElement.innerHTML = "user.pwn();";`, and similarly block adding in-line scripts as attrs
 			$"script-src 'self' {string.Join(' ', trustedJsHosts)}", // `<script/>`s will be blocked unless they're from one of these domains
 			"style-src 'unsafe-inline' 'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/", // allow `<style/>`, and `<link rel="stylesheet"/>` if it's from our domain or trusted CDN
 			"upgrade-insecure-requests", // browser should automagically replace links to any `http://tasvideos.org/...` URL (in UGC, for example) with HTTPS


### PR DESCRIPTION
Our jquery validation scripts don't work with it.