### PR TITLE
Fix missing images everywhere when running locally

### DIFF
--- a/TASVideos/Pages/Wiki/Render.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Render.cshtml.cs
@@ -4,7 +4,12 @@ using TASVideos.Core.Services.Wiki;
 namespace TASVideos.Pages.Wiki;
 
 [AllowAnonymous]
-public class RenderModel(IWikiPages wikiPages, ApplicationDbContext db, ILogger<RenderModel> logger) : BasePageModel
+public class RenderModel(
+	IWikiPages wikiPages,
+	ApplicationDbContext db,
+	IHostEnvironment env,
+	ILogger<RenderModel> logger
+) : BasePageModel
 {
 	public IWikiPage WikiPage { get; set; } = null!;
 
@@ -30,6 +35,12 @@ public class RenderModel(IWikiPages wikiPages, ApplicationDbContext db, ILogger<
 			if (await wikiPages.Exists(LinkConstants.HomePages + url))
 			{
 				return Redirect(LinkConstants.HomePages + url);
+			}
+
+			if (env.IsDevelopment() && url.StartsWith("media/"))
+			{
+				// fix missing images everywhere when running locally
+				return Redirect("/images/tasvideos_rss.png");
 			}
 
 			return RedirectToPage("/Wiki/PageNotFound", new { possibleUrl = WikiEngine.Builtins.NormalizeInternalLink(url) });

--- a/tests/TASVideos.Test/Pages/Wiki/RenderModelTests.cs
+++ b/tests/TASVideos.Test/Pages/Wiki/RenderModelTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using TASVideos.Core.Services.Wiki;
 using TASVideos.Pages.Wiki;
@@ -15,7 +16,11 @@ public class RenderModelTests : BasePageModelTests
 	public RenderModelTests()
 	{
 		_mockWikiPages = Substitute.For<IWikiPages>();
-		_model = new RenderModel(_mockWikiPages, _db, NullLogger<RenderModel>.Instance)
+		_model = new(
+			_mockWikiPages,
+			_db,
+			Substitute.For<IHostEnvironment>(),
+			NullLogger<RenderModel>.Instance)
 		{
 			PageContext = TestPageContext()
 		};


### PR DESCRIPTION
Before/after:
![side-by-side](https://github.com/user-attachments/assets/7c02727c-ff74-4ec5-a2d8-d82f37fc6e49)
Only has effect in dev environments.