### PR TITLE
Add some metrics configuration

### DIFF
--- a/TASVideos/Extensions/ServiceCollectionExtensions.cs
+++ b/TASVideos/Extensions/ServiceCollectionExtensions.cs
@@ -171,13 +171,26 @@ public static class ServiceCollectionExtensions
 				.AddOpenTelemetry()
 				.WithMetrics(builder =>
 				{
+					builder.AddMeter("Microsoft.AspNetCore.Hosting")
+						.AddView("http.server.request.duration", new ExplicitBucketHistogramConfiguration
+						{
+							Boundaries = [] // disable duration histograms of endpoints, which is a LOT of data, but keep total counts
+						});
+
 					builder.AddMeter(
-						"Microsoft.AspNetCore.Hosting",
 						"Microsoft.AspNetCore.Server.Kestrel",
 						"Microsoft.AspNetCore.Routing",
 						"Microsoft.AspNetCore.Diagnostics");
 
-					builder.AddMeter("Npgsql");
+					builder.AddMeter("Npgsql")
+						.AddView("db.client.commands.duration", new ExplicitBucketHistogramConfiguration
+						{
+							Boundaries = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]
+						})
+						.AddView("db.client.connections.create_time", new ExplicitBucketHistogramConfiguration
+						{
+							Boundaries = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]
+						});
 
 					builder.AddPrometheusExporter(options =>
 					{


### PR DESCRIPTION
This PR does two things to our metrics:
1. Disable the duration histograms for each endpoint. This reduces our 1MB 4000 line data file down to just 45kB and 250 lines.
2. Make the db call histogram more precise. Previously the lowest precision was 5 seconds of db time. But most of our calls are below that. The actual values for the buckets are taken from the standard.