### PR TITLE
Reduce Identity-Cookie size by not putting Roles in it

### DIFF
--- a/TASVideos/Extensions/ServiceCollectionExtensions.cs
+++ b/TASVideos/Extensions/ServiceCollectionExtensions.cs
@@ -139,6 +139,7 @@ public static class ServiceCollectionExtensions
 	public static IServiceCollection AddIdentity(this IServiceCollection services, IHostEnvironment env)
 	{
 		services.Configure<PasswordHasherOptions>(options => options.IterationCount = 720_000);
+		services.AddScoped<IUserClaimsPrincipalFactory<User>, UserClaimsPrincipalFactory<User>>(); // the default would use UserClaimsPrincipalFactory<User, Role>, but like this we prevent it putting roles in the principal and thus in the identity cookie
 		services.AddIdentity<User, Role>(config =>
 			{
 				config.SignIn.RequireConfirmedEmail = env.IsProduction() || env.IsStaging();


### PR DESCRIPTION
Our access system is based on Permissions, and we add the Permission Claims manually to the Principal (and thus the identity cookie). This means we have no need for the Roles inside it.

The `services.AddIdentity<User, Role>` would add `UserClaimsPrincipalFactory<User, Role>` to the services, but we pre-empt that by putting the "less powerful" base class `UserClaimsPrincipalFactory<User>` to the services.
These are for creating a ClaimsPrincipal, and the original one would add the Roles and their Claims to the Principal.
Instead, the one we now use only adds the usual Claims, like Name and Email.

And this is exactly what we want.