### PR TITLE
Fix autowatch user setting logic and add explanations

### DIFF
--- a/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
@@ -75,10 +75,13 @@ public class CreateModel(
 		WatchTopic = await topicWatcher.IsWatchingTopic(TopicId, User.GetUserId());
 
 		var user = await userManager.GetRequiredUser(User);
-		if (user.AutoWatchTopic == UserPreference.Always)
+		WatchTopic = user.AutoWatchTopic switch
 		{
-			WatchTopic = true;
-		}
+			UserPreference.Auto => WatchTopic,
+			UserPreference.Always => true,
+			UserPreference.Never => false,
+			_ => WatchTopic,
+		};
 
 		PreviousPosts = await db.ForumPosts
 			.ForTopic(TopicId)

--- a/TASVideos/Pages/Forum/Topics/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Create.cshtml.cs
@@ -62,10 +62,13 @@ public class CreateModel(
 		UserAvatars = await forumService.UserAvatars(User.GetUserId());
 
 		var user = await userManager.GetRequiredUser(User);
-		if (user.AutoWatchTopic == UserPreference.Always)
+		WatchTopic = user.AutoWatchTopic switch
 		{
-			WatchTopic = true;
-		}
+			UserPreference.Auto => true,
+			UserPreference.Always => true,
+			UserPreference.Never => false,
+			_ => true,
+		};
 
 		BackupSubmissionDeterminator = (await db.ForumTopics
 			.ForForum(ForumId)

--- a/TASVideos/Pages/Profile/Settings.cshtml
+++ b/TASVideos/Pages/Profile/Settings.cshtml
@@ -65,8 +65,15 @@
 				</div>
 			</fieldset>
 			<fieldset>
-				<label asp-for="AutoWatchTopic">Automatically Watch Topics When Posting</label>
+				<label asp-for="AutoWatchTopic">Preselect "Watch Topic" When Posting</label>
 				<select asp-for="AutoWatchTopic" asp-items="@SettingsModel.AvailableUserPreferenceTypes"></select>
+				<small>
+					This setting affects how the "Watch Topic" checkbox will be preselected when creating a new Post or Topic.<br />
+					<strong>Auto:</strong> Keep the current Watch Topic setting.
+					<strong>Always:</strong> Always enable the checkbox.
+					<strong>Never:</strong> Always disable the checkbox.<br />
+					Note that this is only a preselect. No matter what you choose here, you can always override it manually when creating a new Post or Topic.
+				</small>
 			</fieldset>
 		</column>
 		<column lg="6">


### PR DESCRIPTION
Resolves #1972 by fixing the logic.

Since it was unclear what this setting is supposed to even do, I also added an explanation to the Settings page.

Before | After
![image](https://github.com/user-attachments/assets/9e78e737-bc7a-494a-8c1a-3cdf825bf49a)
