### PR TITLE
Add paging to the Split topics feature

### DIFF
--- a/TASVideos/Pages/Forum/Topics/Split.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Split.cshtml
@@ -11,6 +11,14 @@
 }
 
 <partial Name="_ForumHeader" />
+<div condition="Model.TotalPages > 1" class="btn-group flex-wrap" role="group">
+	@for (int iteratorPage = 1; iteratorPage <= Model.TotalPages; iteratorPage++)
+	{
+		<a asp-page="@ViewContext.Page()"
+		   asp-route-CurrentPage="@iteratorPage"
+		   type="button" class="btn btn-secondary border-dark flex-grow-0 @(iteratorPage == Model.CurrentPage ? "active" : "")">@iteratorPage</a>
+	}
+</div>
 <form client-side-validation="true" method="post">
 	<input type="hidden" asp-for="Topic.ForumName" />
 	<input type="hidden" asp-for="Topic.ForumId" />

--- a/TASVideos/Pages/Forum/Topics/Split.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Split.cshtml.cs
@@ -179,15 +179,6 @@ public class SplitModel(
 		AvailableForums = await db.Forums.ToDropdownList(CanSeeRestricted, Topic.ForumId);
 	}
 
-	public class TopicSplitRequest : PagingModel
-	{
-		public TopicSplitRequest()
-		{
-			PageSize = 500;
-			CurrentPage = -1;
-		}
-	}
-
 	public class TopicSplit
 	{
 		public int? SplitPostsStartingAt { get; init; }


### PR DESCRIPTION
Resolves #1668 .

This adds paging to the split feature. This avoids the form limit and also avoids loading thousands of posts resulting in a very slow page.

Unlike usual paging, we want a "backfilled" paging here.
Say you have 312 posts and a pagesize of 100. Usually the four pages go like 100, 100, 100, 12 in terms of item size. However, because the latest posts are the most important, we instead want the four pages to go like 12, 100, 100, 100, meaning the first page has only 12 elements. For that reason the last page is also the default page upon opening the Split page.