### PR TITLE
Replace "noreply" with "TASVideos" for the name of our emails

### DIFF
--- a/TASVideos.Core/Services/Email/SmtpSender.cs
+++ b/TASVideos.Core/Services/Email/SmtpSender.cs
@@ -45,7 +45,7 @@ internal class SmtpSender(
 	private MimeMessage BccList(IEmail email)
 	{
 		var recipients = email.Recipients.ToList();
-		var from = env.IsProduction() ? "noreply" : $"TASVideos {env.EnvironmentName} environment noreply";
+		var from = env.IsProduction() ? "TASVideos" : $"TASVideos {env.EnvironmentName} environment";
 		var message = new MimeMessage();
 		message.From.Add(new MailboxAddress(from, _settings.Email));
 


### PR DESCRIPTION
Resolves #2025 .

Based on this identifier, email services group messages, generate automatic profile pictures, and do other stuff. So instead of "noreply" the site name is better.

See e.g. my inbox before this change:

![image](https://github.com/user-attachments/assets/d5b27985-bf89-4362-a80d-9c8c837ef854)
