### PR TITLE
Prevent Userfile cataloging javascript error

### DIFF
--- a/TASVideos/wwwroot/js/catalog.js
+++ b/TASVideos/wwwroot/js/catalog.js
@@ -91,16 +91,16 @@ function enableCataloging() {
 
 	function generateCurrentReturnUrl() {
 		const returnUrlQueryModified = new URLSearchParams();
-		if (systemModel.value) {
+		if (systemModel && systemModel.value) {
 			returnUrlQueryModified.set('SystemId', systemModel.value);
 		}
-		if (gameModel.value) {
+		if (gameModel && gameModel.value) {
 			returnUrlQueryModified.set('GameId', gameModel.value);
 		}
-		if (versionModel.value) {
+		if (versionModel && versionModel.value) {
 			returnUrlQueryModified.set('GameVersionId', versionModel.value);
 		}
-		if (gameGoalModel.value) {
+		if (gameGoalModel && gameGoalModel.value) {
 			returnUrlQueryModified.set('GameGoalId', gameGoalModel.value);
 		}
 


### PR DESCRIPTION
Fixes the JS bug on the userfile cataloging, which prevented the [New] button to work for creating new games.

The cataloging on the userfiles doesn't really work as well as it does on other catalogs anyway, but at least you can create new games from there now.