### PR TITLE
Use default Random constructor

### DIFF
--- a/TASVideos.Common/Extensions/EnumerableExtensions.cs
+++ b/TASVideos.Common/Extensions/EnumerableExtensions.cs
@@ -31,7 +31,7 @@ public static class EnumerableExtensions
 	/// </summary>
 	public static T AtRandom<T>(this ICollection<T> collection)
 	{
-		var randomIndex = new Random(DateTime.UtcNow.Millisecond).Next(0, collection.Count);
+		var randomIndex = new Random().Next(0, collection.Count);
 		return collection.ElementAt(randomIndex);
 	}
 


### PR DESCRIPTION
Previously, the use of `DateTime.UtcNow.Millisecond` for the seed means only 1000 different seeds were possible, which means if the collection is at around 200 items, chances are that it's impossible to get one of the items with the 1000 seeds.

The default constructor uses a good random seed value.