### PR TITLE
Properly reset Submission-Judge when setting status to New

### DIFF
--- a/TASVideos.Data/Helpers/SubmissionHelper.cs
+++ b/TASVideos.Data/Helpers/SubmissionHelper.cs
@@ -66,9 +66,9 @@ public static class SubmissionHelper
 		return oldS != SubmissionStatus.JudgingUnderWay && newS == SubmissionStatus.JudgingUnderWay;
 	}
 
-	public static bool JudgeIsUnclaiming(SubmissionStatus oldS, SubmissionStatus newS)
+	public static bool JudgeIsUnclaiming(SubmissionStatus newS)
 	{
-		return oldS == SubmissionStatus.JudgingUnderWay && newS == SubmissionStatus.New;
+		return newS == SubmissionStatus.New;
 	}
 
 	public static bool PublisherIsClaiming(SubmissionStatus oldS, SubmissionStatus newS)

--- a/TASVideos/Pages/Submissions/Edit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Edit.cshtml.cs
@@ -231,7 +231,7 @@ public class EditModel(
 		{
 			submission.Judge = await db.Users.SingleAsync(u => u.UserName == userName);
 		}
-		else if (SubmissionHelper.JudgeIsUnclaiming(submission.Status, Submission.Status))
+		else if (SubmissionHelper.JudgeIsUnclaiming(Submission.Status))
 		{
 			submission.Judge = null;
 		}


### PR DESCRIPTION
Previously it would only reset in the situation JudgingUnderway -> New.
This caused a bug where a Delayed submission set to New wasn't clearing the Judge.

So I think the proper logic is to always clear the Judge when going to New, no matter what the previous state was.