### PR TITLE
Small fix for user profile formatting

### DIFF
--- a/TASVideos/Pages/Shared/_Profile.cshtml
+++ b/TASVideos/Pages/Shared/_Profile.cshtml
@@ -75,12 +75,13 @@
 							</div>
 							<br/>
 							<label asp-for="EmailConfirmed"></label>
-							<span condition="Model.EmailConfirmed" class="fa fa-check-square text-success"></span><span> Yes</span>
-							<div><span condition="!Model.EmailConfirmed" class="fa fa-exclamation-triangle text-danger"></span> No</div>
+							<div condition="Model.EmailConfirmed"><i class="fa fa-check-square text-success"></i> No</div>
+							<div condition="!Model.EmailConfirmed"><i class="fa fa-exclamation-triangle text-danger"></i> No</div>
 							<br/>
 							<label asp-for="LockedOutStatus"></label>
-							<span condition="Model.LockedOutStatus" class="fa fa-exclamation-triangle text-danger"></span><span> Locked out</span>
-							<span condition="!Model.LockedOutStatus" class="fa fa-check-square text-success"></span><span> Not locked</span>
+							<div condition="Model.LockedOutStatus"><i class="fa fa-exclamation-triangle text-danger"></i><span> Locked out</span></div>
+							<div condition="!Model.LockedOutStatus"><i class="fa fa-check-square text-success"></i><span> Not locked</span></div>
+							<br />
 							<div>
 								<a permission="ViewPrivateUserData" asp-page="/Users/Ips" asp-route-username="@Model.UserName" class="btn btn-warning btn-sm">IP Addresses used</a>
 							</div>


### PR DESCRIPTION
Email confirmation status and Locked out status formatting was broken a bit.
(Note that while the formatting was broken, it is *not* the case that anyone could see information they weren't supposed to. That is handled elsewhere in the code.)

Before | After
![image](https://github.com/user-attachments/assets/9b03da30-0963-4c7b-9864-f324d5f836e9)
