### PR TITLE
Add more entries to `robots.txt`

### DIFF
--- a/TASVideos/Middleware/RobotHandlingMiddleware.cs
+++ b/TASVideos/Middleware/RobotHandlingMiddleware.cs
@@ -11,15 +11,11 @@ public class RobotHandlingMiddleware(RequestDelegate request, IHostEnvironment e
 
 		if (env.IsProduction())
 		{
-			// TODO the format for this was recently codified to basically match what Google was using, anyway each entry has an implicit trailing wildcard so there's a small chance of false positives
 			sb.AppendLine("""
 						User-agent: *
 						Disallow: /Movies-
 						Disallow: /MovieMaintenanceLog
 						Disallow: /UserMaintenanceLog
-						Disallow: /Account/
-						Disallow: /Forum/Posts/User/
-						Disallow: /Forum/Topics/Create/
 						Disallow: /InternalSystem/
 						Disallow: /Search
 						Disallow: /*?revision=*

--- a/TASVideos/Middleware/RobotHandlingMiddleware.cs
+++ b/TASVideos/Middleware/RobotHandlingMiddleware.cs
@@ -11,14 +11,22 @@ public class RobotHandlingMiddleware(RequestDelegate request, IHostEnvironment e
 
 		if (env.IsProduction())
 		{
+			// TODO the format for this was recently codified to basically match what Google was using, anyway each entry has an implicit trailing wildcard so there's a small chance of false positives
 			sb.AppendLine("""
 						User-agent: *
 						Disallow: /Movies-
 						Disallow: /MovieMaintenanceLog
 						Disallow: /UserMaintenanceLog
+						Disallow: /Account/
+						Disallow: /Forum/Posts/User/
+						Disallow: /Forum/Topics/Create/
 						Disallow: /InternalSystem/
+						Disallow: /Search
 						Disallow: /*?revision=*
 						Disallow: /Wiki/PageHistory
+						Disallow: /Wiki/PageNotFound
+						Disallow: /Wiki/Referrers
+						Disallow: /Wiki/ViewSource
 
 						User-agent: Fasterfox
 						Disallow: /


### PR DESCRIPTION
It should be apparent why each of these isn't useful to crawl.
- Might want to keep `/Wiki/ViewSource` for archival purposes?
- Might want to block `/Forum/Posts/User/` for humans who aren't logged in?
- The false positive thing: [spec](https://www.rfc-editor.org/rfc/rfc9309.html#name-the-allow-and-disallow-line), [Google's nicer docs](https://developers.google.com/search/docs/crawling-indexing/robots/robots_txt#url-matching-based-on-path-values)