### PR TITLE
Make Search page number resilient against negative values

### DIFF
--- a/TASVideos/Pages/Search/Advanced.cshtml.cs
+++ b/TASVideos/Pages/Search/Advanced.cshtml.cs
@@ -14,6 +14,7 @@ public class AdvancedModel(ApplicationDbContext db) : BasePageModel
 	public string SearchTerms { get; set; } = "";
 
 	[FromQuery]
+	[Range(1, int.MaxValue)]
 	public int PageNumber { get; set; } = 1;
 
 	public List<PageResult> PageResults { get; set; } = [];

--- a/TASVideos/Pages/Search/Index.cshtml.cs
+++ b/TASVideos/Pages/Search/Index.cshtml.cs
@@ -13,6 +13,7 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 	public string SearchTerms { get; set; } = "";
 
 	[FromQuery]
+	[Range(1, int.MaxValue)]
 	public int PageNumber { get; set; } = 1;
 
 	public List<PageSearch> PageResults { get; set; } = [];


### PR DESCRIPTION
Negative values cause a DB exception. The only way to cause this exception is by screwing around with the URL. 
But these keep showing up in the logs, so either a negative value url has accidentally been indexed (unlikely), or there is someone out there who puts a lot of effort into spamming exceptions.