### PR TITLE
Remove StringLength attributes from Entities

### DIFF
--- a/TASVideos.Data/Entity/Awards/Award.cs
+++ b/TASVideos.Data/Entity/Awards/Award.cs
@@ -12,9 +12,7 @@ public class Award
 	public int Id { get; set; }
 	public AwardType Type { get; set; }
 
-	[StringLength(25)]
 	public string ShortName { get; set; } = "";
 
-	[StringLength(50)]
 	public string Description { get; set; } = "";
 }

--- a/TASVideos.Data/Entity/DeprecatedMovieFormat.cs
+++ b/TASVideos.Data/Entity/DeprecatedMovieFormat.cs
@@ -4,7 +4,6 @@ public class DeprecatedMovieFormat : BaseEntity
 {
 	public int Id { get; set; }
 
-	[StringLength(8)]
 	public string FileExtension { get; set; } = "";
 
 	public bool Deprecated { get; set; } = true;

--- a/TASVideos.Data/Entity/Flag.cs
+++ b/TASVideos.Data/Entity/Flag.cs
@@ -4,16 +4,12 @@ public class Flag
 {
 	public int Id { get; set; }
 
-	[StringLength(32)]
 	public string Name { get; set; } = "";
 
-	[StringLength(48)]
 	public string? IconPath { get; set; }
 
-	[StringLength(48)]
 	public string? LinkPath { get; set; }
 
-	[StringLength(24)]
 	public string Token { get; set; } = "";
 
 	public PermissionTo? PermissionRestriction { get; set; }

--- a/TASVideos.Data/Entity/Forum/Forum.cs
+++ b/TASVideos.Data/Entity/Forum/Forum.cs
@@ -11,13 +11,10 @@ public class Forum : BaseEntity
 	public ICollection<ForumTopic> ForumTopics { get; init; } = [];
 	public ICollection<ForumPost> ForumPosts { get; init; } = [];
 
-	[StringLength(50)]
 	public string Name { get; set; } = "";
 
-	[StringLength(10)]
 	public string ShortName { get; set; } = "";
 
-	[StringLength(1000)]
 	public string? Description { get; set; }
 
 	public int Ordinal { get; set; }

--- a/TASVideos.Data/Entity/Forum/ForumCategory.cs
+++ b/TASVideos.Data/Entity/Forum/ForumCategory.cs
@@ -6,11 +6,9 @@ public class ForumCategory : BaseEntity
 	public int Id { get; set; }
 	public ICollection<Forum> Forums { get; init; } = [];
 
-	[StringLength(30)]
 	public string Title { get; set; } = "";
 
 	public int Ordinal { get; set; }
 
-	[StringLength(1000)]
 	public string? Description { get; set; }
 }

--- a/TASVideos.Data/Entity/Forum/ForumPoll.cs
+++ b/TASVideos.Data/Entity/Forum/ForumPoll.cs
@@ -8,7 +8,6 @@ public class ForumPoll : BaseEntity
 	public int TopicId { get; set; }
 	public ForumTopic? Topic { get; set; }
 
-	[StringLength(500)]
 	public string Question { get; set; } = "";
 
 	public DateTime? CloseDate { get; set; }

--- a/TASVideos.Data/Entity/Forum/ForumPollOption.cs
+++ b/TASVideos.Data/Entity/Forum/ForumPollOption.cs
@@ -5,7 +5,6 @@ public class ForumPollOption : BaseEntity
 {
 	public int Id { get; set; }
 
-	[StringLength(250)]
 	public string Text { get; set; } = "";
 
 	public int Ordinal { get; set; }

--- a/TASVideos.Data/Entity/Forum/ForumPollOptionVote.cs
+++ b/TASVideos.Data/Entity/Forum/ForumPollOptionVote.cs
@@ -13,6 +13,5 @@ public class ForumPollOptionVote
 
 	public DateTime CreateTimestamp { get; set; }
 
-	[StringLength(50)]
 	public string? IpAddress { get; set; }
 }

--- a/TASVideos.Data/Entity/Forum/ForumPost.cs
+++ b/TASVideos.Data/Entity/Forum/ForumPost.cs
@@ -17,10 +17,8 @@ public class ForumPost : BaseEntity
 	public int PosterId { get; set; }
 	public User? Poster { get; set; }
 
-	[StringLength(50)]
 	public string? IpAddress { get; set; }
 
-	[StringLength(150)]
 	public string? Subject { get; set; }
 
 	public string Text { get; set; } = "";

--- a/TASVideos.Data/Entity/Forum/ForumTopic.cs
+++ b/TASVideos.Data/Entity/Forum/ForumTopic.cs
@@ -18,7 +18,6 @@ public class ForumTopic : BaseEntity
 	public ICollection<ForumPost> ForumPosts { get; init; } = [];
 	public ICollection<ForumTopicWatch> ForumTopicWatches { get; init; } = [];
 
-	[StringLength(500)]
 	public string Title { get; set; } = "";
 
 	public int PosterId { get; set; }

--- a/TASVideos.Data/Entity/Game/Game.cs
+++ b/TASVideos.Data/Entity/Game/Game.cs
@@ -16,19 +16,14 @@ public class Game : BaseEntity
 	public ICollection<GameGameGroup> GameGroups { get; init; } = [];
 	public ICollection<GameGoal> GameGoals { get; init; } = [];
 
-	[StringLength(100)]
 	public string DisplayName { get; set; } = "";
 
-	[StringLength(24)]
 	public string? Abbreviation { get; set; }
 
-	[StringLength(250)]
 	public string? Aliases { get; set; }
 
-	[StringLength(250)]
 	public string? ScreenshotUrl { get; set; }
 
-	[StringLength(300)]
 	public string? GameResourcesPage { get; set; }
 }
 

--- a/TASVideos.Data/Entity/Game/GameGoal.cs
+++ b/TASVideos.Data/Entity/Game/GameGoal.cs
@@ -6,7 +6,6 @@ public class GameGoal
 	public int GameId { get; set; }
 	public Game? Game { get; set; }
 
-	[StringLength(50)]
 	public string DisplayName { get; set; } = "";
 
 	public ICollection<Publication> Publications { get; init; } = [];

--- a/TASVideos.Data/Entity/Game/GameGroup.cs
+++ b/TASVideos.Data/Entity/Game/GameGroup.cs
@@ -5,13 +5,10 @@ public class GameGroup
 {
 	public int Id { get; set; }
 
-	[StringLength(255)]
 	public string Name { get; set; } = "";
 
-	[StringLength(255)]
 	public string? Abbreviation { get; set; }
 
-	[StringLength(2000)]
 	public string? Description { get; set; }
 
 	public ICollection<GameGameGroup> Games { get; init; } = [];

--- a/TASVideos.Data/Entity/Game/GameSystem.cs
+++ b/TASVideos.Data/Entity/Game/GameSystem.cs
@@ -15,10 +15,8 @@ public class GameSystem : BaseEntity
 	public ICollection<Publication> Publications { get; init; } = [];
 	public ICollection<Submission> Submissions { get; init; } = [];
 
-	[StringLength(8)]
 	public string Code { get; set; } = "";
 
-	[StringLength(100)]
 	public string DisplayName { get; set; } = "";
 }
 

--- a/TASVideos.Data/Entity/Game/GameSystemFrameRate.cs
+++ b/TASVideos.Data/Entity/Game/GameSystemFrameRate.cs
@@ -10,7 +10,6 @@ public class GameSystemFrameRate : BaseEntity
 
 	public double FrameRate { get; set; }
 
-	[StringLength(8)]
 	public string RegionCode { get; set; } = "";
 	public bool Preliminary { get; set; }
 

--- a/TASVideos.Data/Entity/Game/GameVersion.cs
+++ b/TASVideos.Data/Entity/Game/GameVersion.cs
@@ -26,30 +26,22 @@ public class GameVersion : BaseEntity
 	public ICollection<Publication> Publications { get; init; } = [];
 	public ICollection<Submission> Submissions { get; init; } = [];
 
-	[StringLength(32)]
 	public string? Md5 { get; set; }
 
-	[StringLength(40)]
 	public string? Sha1 { get; set; }
 
-	[StringLength(255)]
 	public string Name { get; set; } = "";
 
 	public VersionTypes Type { get; set; }
 
-	[StringLength(50)]
 	public string? Region { get; set; }
 
-	[StringLength(50)]
 	public string? Version { get; set; }
 
-	[StringLength(255)]
 	public string? TitleOverride { get; set; }
 
-	[StringLength(50)]
 	public string? SourceDb { get; set; }
 
-	[StringLength(2000)]
 	public string? Notes { get; set; }
 }
 

--- a/TASVideos.Data/Entity/Game/Genre.cs
+++ b/TASVideos.Data/Entity/Game/Genre.cs
@@ -5,7 +5,6 @@ public class Genre
 {
 	public int Id { get; set; }
 
-	[StringLength(20)]
 	public string DisplayName { get; set; } = "";
 
 	public ICollection<GameGenre> GameGenres { get; init; } = [];

--- a/TASVideos.Data/Entity/IpBan.cs
+++ b/TASVideos.Data/Entity/IpBan.cs
@@ -4,6 +4,5 @@ public class IpBan : BaseEntity
 {
 	public int Id { get; set; }
 
-	[StringLength(40)]
 	public string Mask { get; set; } = "";
 }

--- a/TASVideos.Data/Entity/MediaPosts.cs
+++ b/TASVideos.Data/Entity/MediaPosts.cs
@@ -8,21 +8,15 @@ public class MediaPost : BaseEntity
 {
 	public int Id { get; set; }
 
-	[StringLength(512)]
 	public string Title { get; set; } = "";
 
-	[StringLength(255)]
 	public string Link { get; set; } = "";
 
-	[StringLength(1024)]
 	public string Body { get; set; } = "";
 
-	[StringLength(255)]
 	public string Group { get; set; } = "";
 
-	[StringLength(100)]
 	public string Type { get; set; } = "";
 
-	[StringLength(100)]
 	public string User { get; set; } = "";
 }

--- a/TASVideos.Data/Entity/PrivateMessage.cs
+++ b/TASVideos.Data/Entity/PrivateMessage.cs
@@ -11,10 +11,8 @@ public class PrivateMessage : BaseEntity
 	public int ToUserId { get; set; }
 	public User? ToUser { get; set; }
 
-	[StringLength(500)]
 	public string? Subject { get; set; }
 
-	[StringLength(10000)]
 	public string Text { get; set; } = "";
 
 	public bool EnableHtml { get; set; }

--- a/TASVideos.Data/Entity/Publication.cs
+++ b/TASVideos.Data/Entity/Publication.cs
@@ -62,10 +62,8 @@ public class Publication : BaseEntity, ITimeable
 
 	public byte[] MovieFile { get; set; } = [];
 
-	[StringLength(200)]
 	public string MovieFileName { get; set; } = "";
 
-	[StringLength(50)]
 	public string? EmulatorVersion { get; set; }
 
 	public int Frames { get; set; }
@@ -74,11 +72,9 @@ public class Publication : BaseEntity, ITimeable
 	/// <summary>
 	/// Gets or sets Any author's that are not a user. If they are a user, they should be linked, and not listed here.
 	/// </summary>
-	[StringLength(200)]
 	public string? AdditionalAuthors { get; set; }
 
 	// De-normalized name for easy recreation
-	[StringLength(500)]
 	public string Title { get; set; } = "";
 
 	double ITimeable.FrameRate => SystemFrameRate?.FrameRate ?? throw new InvalidOperationException($"{nameof(SystemFrameRate)} must not be lazy loaded!");

--- a/TASVideos.Data/Entity/PublicationClass.cs
+++ b/TASVideos.Data/Entity/PublicationClass.cs
@@ -5,12 +5,9 @@ public class PublicationClass
 {
 	public int Id { get; set; }
 
-	[StringLength(20)]
 	public string Name { get; set; } = "";
 
-	[StringLength(100)]
 	public string? IconPath { get; set; }
 
-	[StringLength(100)]
 	public string Link { get; set; } = "";
 }

--- a/TASVideos.Data/Entity/PublicationFile.cs
+++ b/TASVideos.Data/Entity/PublicationFile.cs
@@ -13,11 +13,9 @@ public class PublicationFile : BaseEntity
 	public int PublicationId { get; set; }
 	public Publication? Publication { get; set; }
 
-	[StringLength(250)]
 	public string Path { get; set; } = "";
 	public FileType Type { get; set; }
 
-	[StringLength(250)]
 	public string? Description { get; set; }
 
 	public byte[]? FileData { get; set; }

--- a/TASVideos.Data/Entity/PublicationMaintenanceLog.cs
+++ b/TASVideos.Data/Entity/PublicationMaintenanceLog.cs
@@ -7,8 +7,6 @@ public class PublicationMaintenanceLog
 
 	public DateTime TimeStamp { get; set; }
 
-	[StringLength(1024)]
-
 	public string Log { get; set; } = "";
 
 	public int PublicationId { get; set; }

--- a/TASVideos.Data/Entity/PublicationUrl.cs
+++ b/TASVideos.Data/Entity/PublicationUrl.cs
@@ -9,12 +9,10 @@ public class PublicationUrl : BaseEntity
 	public Publication? Publication { get; set; }
 
 	[Required]
-	[StringLength(500)]
 	public string? Url { get; set; }
 
 	public PublicationUrlType Type { get; set; } = PublicationUrlType.Streaming;
 
-	[StringLength(100)]
 	public string? DisplayName { get; set; }
 }
 

--- a/TASVideos.Data/Entity/Role.cs
+++ b/TASVideos.Data/Entity/Role.cs
@@ -4,7 +4,6 @@ namespace TASVideos.Data.Entity;
 
 public class Role : IdentityRole<int>, ITrackable
 {
-	[StringLength(50)]
 	public new string Name
 	{
 		get => base.Name!;
@@ -16,7 +15,6 @@ public class Role : IdentityRole<int>, ITrackable
 	/// </summary>
 	public bool IsDefault { get; set; }
 
-	[StringLength(300)]
 	public string Description { get; set; } = "";
 
 	/// <summary>

--- a/TASVideos.Data/Entity/RoleLinks.cs
+++ b/TASVideos.Data/Entity/RoleLinks.cs
@@ -5,7 +5,6 @@ public class RoleLink
 {
 	public int Id { get; set; }
 
-	[StringLength(300)]
 	public string Link { get; set; } = "";
 
 	public int RoleId { get; set; }

--- a/TASVideos.Data/Entity/Submission.cs
+++ b/TASVideos.Data/Entity/Submission.cs
@@ -39,8 +39,6 @@ public class Submission : BaseEntity, ITimeable
 
 	public byte[] MovieFile { get; set; } = [];
 
-	[StringLength(8)]
-
 	public string? MovieExtension { get; set; }
 
 	public int? GameId { get; set; }
@@ -62,22 +60,16 @@ public class Submission : BaseEntity, ITimeable
 	public int RerecordCount { get; set; }
 
 	// Metadata, user entered
-	[StringLength(100)]
 	public string? EncodeEmbedLink { get; set; }
 
-	[StringLength(100)]
 	public string? SubmittedGameVersion { get; set; }
 
-	[StringLength(100)]
 	public string? GameName { get; set; }
 
-	[StringLength(50)]
 	public string? Branch { get; set; }
 
-	[StringLength(250)]
 	public string? RomName { get; set; }
 
-	[StringLength(50)]
 	public string? EmulatorVersion { get; set; }
 
 	public int? MovieStartType { get; set; }
@@ -88,17 +80,14 @@ public class Submission : BaseEntity, ITimeable
 	/// <summary>
 	/// Gets or sets Any author's that are not a user. If they are a user, they should be linked, and not listed here.
 	/// </summary>
-	[StringLength(200)]
 	public string? AdditionalAuthors { get; set; }
 
 	/// <summary>
 	/// Gets or sets a de-normalized column consisting of the submission title for display when linked or in the queue
 	/// ex: N64 The Legend of Zelda: Majora's Mask "low%" in 1:59:01.
 	/// </summary>
-	[StringLength(500)]
 	public string Title { get; set; } = "";
 
-	[StringLength(3500)]
 	public string? Annotations { get; set; }
 
 	double ITimeable.FrameRate => SystemFrameRate?.FrameRate ?? 0;
@@ -157,7 +146,6 @@ public class Submission : BaseEntity, ITimeable
 	public decimal LegacyTime { get; set; }
 	public decimal ImportedTime { get; set; }
 
-	[StringLength(500)]
 	public string? Warnings { get; set; }
 
 	public long? CycleCount { get; set; }
@@ -166,7 +154,6 @@ public class Submission : BaseEntity, ITimeable
 	public User? SyncedByUser { get; set; }
 	public DateTime? SyncedOn { get; set; }
 
-	[StringLength(3000)]
 	public string? AdditionalSyncNotes { get; set; }
 }
 

--- a/TASVideos.Data/Entity/SubmissionRejectionReason.cs
+++ b/TASVideos.Data/Entity/SubmissionRejectionReason.cs
@@ -5,7 +5,6 @@ public class SubmissionRejectionReason
 {
 	public int Id { get; set; }
 
-	[StringLength(100)]
 	public string DisplayName { get; set; } = "";
 
 	public ICollection<Submission> Submissions { get; init; } = [];

--- a/TASVideos.Data/Entity/Tag.cs
+++ b/TASVideos.Data/Entity/Tag.cs
@@ -4,10 +4,8 @@ public class Tag
 {
 	public int Id { get; set; }
 
-	[StringLength(25)]
 	public string Code { get; set; } = "";
 
-	[StringLength(50)]
 	public string DisplayName { get; set; } = "";
 
 	public ICollection<PublicationTag> PublicationTags { get; init; } = [];

--- a/TASVideos.Data/Entity/User.cs
+++ b/TASVideos.Data/Entity/User.cs
@@ -10,28 +10,24 @@ public enum UserPreference
 [ExcludeFromHistory]
 public class User : IdentityUser<int>, ITrackable
 {
-	[StringLength(50)]
 	public new string UserName
 	{
 		get => base.UserName!;
 		set => base.UserName = value;
 	}
 
-	[StringLength(50)]
 	public new string NormalizedUserName
 	{
 		get => base.NormalizedUserName!;
 		set => base.NormalizedUserName = value;
 	}
 
-	[StringLength(100)]
 	public new string Email
 	{
 		get => base.Email!;
 		set => base.Email = value;
 	}
 
-	[StringLength(100)]
 	public new string NormalizedEmail
 	{
 		get => base.NormalizedEmail!;
@@ -40,24 +36,19 @@ public class User : IdentityUser<int>, ITrackable
 
 	public DateTime? LastLoggedInTimeStamp { get; set; }
 
-	[StringLength(250)]
 	public string TimeZoneId { get; set; } = TimeZoneInfo.Utc.Id;
 
 	public DateTime CreateTimestamp { get; set; } = DateTime.UtcNow;
 	public DateTime LastUpdateTimestamp { get; set; } = DateTime.UtcNow;
 
-	[StringLength(250)]
 	public string? Avatar { get; set; }
 
-	[StringLength(100)]
 	public string? From { get; set; }
 
-	[StringLength(1000)]
 	public string? Signature { get; set; }
 
 	public bool PublicRatings { get; set; } = true;
 
-	[StringLength(250)]
 	public string? MoodAvatarUrlBase { get; set; }
 
 	public DateTime? BannedUntil { get; set; }
@@ -68,7 +59,6 @@ public class User : IdentityUser<int>, ITrackable
 	/// </summary>
 	public bool UseRatings { get; set; } = true;
 
-	[StringLength(1024)]
 	public string? ModeratorComments { get; set; }
 
 	public PreferredPronounTypes PreferredPronouns { get; set; } = PreferredPronounTypes.Unspecified;

--- a/TASVideos.Data/Entity/UserDisallow.cs
+++ b/TASVideos.Data/Entity/UserDisallow.cs
@@ -5,6 +5,5 @@ public class UserDisallow : BaseEntity
 {
 	public int Id { get; set; }
 
-	[StringLength(100)]
 	public string RegexPattern { get; set; } = "";
 }

--- a/TASVideos.Data/Entity/UserFile.cs
+++ b/TASVideos.Data/Entity/UserFile.cs
@@ -23,14 +23,12 @@ public class UserFile
 	public int AuthorId { get; set; }
 	public User? Author { get; set; }
 
-	[StringLength(255)]
 	public string FileName { get; set; } = "";
 
 	public byte[] Content { get; set; } = [];
 
 	public UserFileClass Class { get; set; }
 
-	[StringLength(16)]
 	public string Type { get; set; } = "";
 
 	public DateTime UploadTimestamp { get; set; }
@@ -41,7 +39,6 @@ public class UserFile
 
 	public int Rerecords { get; set; }
 
-	[StringLength(255)]
 	public string Title { get; set; } = "";
 
 	public string? Description { get; set; }
@@ -62,7 +59,6 @@ public class UserFile
 
 	public Compression CompressionType { get; set; }
 
-	[StringLength(3500)]
 	public string? Annotations { get; set; }
 
 	public ICollection<UserFileComment> Comments { get; init; } = [];

--- a/TASVideos.Data/Entity/UserFileComment.cs
+++ b/TASVideos.Data/Entity/UserFileComment.cs
@@ -9,13 +9,11 @@ public class UserFileComment
 	public long UserFileId { get; set; }
 	public UserFile? UserFile { get; set; }
 
-	[StringLength(255)]
 	public string? Ip { get; set; }
 
 	public int? ParentId { get; set; }
 	public UserFileComment? Parent { get; set; }
 
-	[StringLength(3500)]
 	public string Text { get; set; } = "";
 
 	public DateTime CreationTimeStamp { get; set; }

--- a/TASVideos.Data/Entity/UserMaintenanceLog.cs
+++ b/TASVideos.Data/Entity/UserMaintenanceLog.cs
@@ -6,7 +6,6 @@ public class UserMaintenanceLog
 	public int Id { get; set; }
 	public DateTime TimeStamp { get; set; }
 
-	[StringLength(50)]
 	public string Log { get; set; } = "";
 
 	public int? EditorId { get; set; }

--- a/TASVideos.Data/Entity/WikiPage.cs
+++ b/TASVideos.Data/Entity/WikiPage.cs
@@ -9,7 +9,6 @@ public class WikiPage : BaseEntity, ISoftDeletable
 {
 	public int Id { get; set; }
 
-	[StringLength(250)]
 	public string PageName { get; set; } = "";
 
 	public string Markup { get; set; } = "";
@@ -18,7 +17,6 @@ public class WikiPage : BaseEntity, ISoftDeletable
 
 	public bool MinorEdit { get; set; }
 
-	[StringLength(1000)]
 	public string? RevisionMessage { get; set; }
 
 	public int? ChildId { get; set; }

--- a/TASVideos.Data/Entity/WikiPageReferral.cs
+++ b/TASVideos.Data/Entity/WikiPageReferral.cs
@@ -5,13 +5,10 @@ public class WikiPageReferral
 {
 	public int Id { get; set; }
 
-	[StringLength(250)]
 	public string Referrer { get; set; } = "";
 
-	[StringLength(1000)]
 	public string Referral { get; set; } = "";
 
-	[StringLength(1000)]
 	public string Excerpt { get; set; } = "";
 }
 

--- a/TASVideos.Data/Migrations/20241126171326_RemoveAllStringLengths.Designer.cs
+++ b/TASVideos.Data/Migrations/20241126171326_RemoveAllStringLengths.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using TASVideos.Data;
 namespace TASVideos.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241126171326_RemoveAllStringLengths")]
+    partial class RemoveAllStringLengths
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TASVideos.Data/Migrations/20241126171326_RemoveAllStringLengths.cs
+++ b/TASVideos.Data/Migrations/20241126171326_RemoveAllStringLengths.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TASVideos.Data.Migrations;
+
+/// <inheritdoc />
+public partial class RemoveAllStringLengths : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+
+	}
+}


### PR DESCRIPTION
This PR removes the string length attributes and makes an empty migration, only changing the model snapshot.

We use postgres columns `text` (or rather `citext`) which [doesn't have string limits](https://www.postgresql.org/docs/current/datatype-character.html).
And we don't need a limited string type, as per the docs:
> While `character(n)` has performance advantages in some other database systems, there is no such advantage in PostgreSQL; in fact `character(n)` is usually the slowest of the three because of its additional storage costs. In most situations `text` or `character varying` should be used instead.

I haven't found any uses of direct Entity types for form binding (this would cause client and server validation to be removed by this PR). We basically always use a separate model for that.
Those models now technically don't need the StringLength either, but even though we can store any lenghts, we still don't need to allow users to spam us with massive strings.