### PR TITLE
Increase allowed game version notes length

### DIFF
--- a/TASVideos/Pages/Games/Versions/Edit.cshtml.cs
+++ b/TASVideos/Pages/Games/Versions/Edit.cshtml.cs
@@ -220,7 +220,7 @@ public class EditModel(ApplicationDbContext db, ExternalMediaPublisher publisher
 		[StringLength(50)]
 		public string? SourceDb { get; init; }
 
-		[StringLength(2000)]
+		[StringLength(30000)]
 		public string? Notes { get; init; }
 	}
 }


### PR DESCRIPTION
Because with all the file hashes they can become quite large.

(This is the corrected PR. This was the wrong one: #2047 )