### PR TITLE
Remove Trigram Postgres extension and indexes (pg_trgm)

### DIFF
--- a/TASVideos.Data/ApplicationDbContext.cs
+++ b/TASVideos.Data/ApplicationDbContext.cs
@@ -187,7 +187,6 @@ public class ApplicationDbContext : IdentityDbContext<User, Role, int, UserClaim
 			}
 
 			builder.HasPostgresExtension("citext");
-			builder.HasPostgresExtension("pg_trgm");
 		}
 
 		builder.Entity<Award>(entity =>
@@ -271,9 +270,6 @@ public class ApplicationDbContext : IdentityDbContext<User, Role, int, UserClaim
 
 			if (Database.IsNpgsql())
 			{
-				entity.HasIndex(e => e.Markup)
-					.HasMethod("gin")
-					.HasOperators("gin_trgm_ops");
 				entity
 					.HasGeneratedTsVectorColumn(
 						p => p.SearchVector,
@@ -438,9 +434,6 @@ public class ApplicationDbContext : IdentityDbContext<User, Role, int, UserClaim
 		{
 			if (Database.IsNpgsql())
 			{
-				entity.HasIndex(e => e.Text)
-					.HasMethod("gin")
-					.HasOperators("gin_trgm_ops");
 				entity
 					.HasGeneratedTsVectorColumn(
 						p => p.SearchVector,

--- a/TASVideos.Data/Migrations/20241126210115_RemoveTrigramIndexes.Designer.cs
+++ b/TASVideos.Data/Migrations/20241126210115_RemoveTrigramIndexes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using TASVideos.Data;
 namespace TASVideos.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241126210115_RemoveTrigramIndexes")]
+    partial class RemoveTrigramIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TASVideos.Data/Migrations/20241126210115_RemoveTrigramIndexes.cs
+++ b/TASVideos.Data/Migrations/20241126210115_RemoveTrigramIndexes.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TASVideos.Data.Migrations;
+
+/// <inheritdoc />
+public partial class RemoveTrigramIndexes : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropIndex(
+			name: "ix_wiki_pages_markup",
+			table: "wiki_pages");
+
+		migrationBuilder.DropIndex(
+			name: "ix_forum_posts_text",
+			table: "forum_posts");
+
+		migrationBuilder.AlterDatabase()
+			.Annotation("Npgsql:PostgresExtension:citext", ",,")
+			.OldAnnotation("Npgsql:PostgresExtension:citext", ",,")
+			.OldAnnotation("Npgsql:PostgresExtension:pg_trgm", ",,");
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.AlterDatabase()
+			.Annotation("Npgsql:PostgresExtension:citext", ",,")
+			.Annotation("Npgsql:PostgresExtension:pg_trgm", ",,")
+			.OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+
+		migrationBuilder.CreateIndex(
+			name: "ix_wiki_pages_markup",
+			table: "wiki_pages",
+			column: "markup")
+			.Annotation("Npgsql:IndexMethod", "gin")
+			.Annotation("Npgsql:IndexOperators", new[] { "gin_trgm_ops" });
+
+		migrationBuilder.CreateIndex(
+			name: "ix_forum_posts_text",
+			table: "forum_posts",
+			column: "text")
+			.Annotation("Npgsql:IndexMethod", "gin")
+			.Annotation("Npgsql:IndexOperators", new[] { "gin_trgm_ops" });
+	}
+}


### PR DESCRIPTION
We don't use it at all, and the reindexing can be costly.
(For Search we use the generated tsvector column.)