### PR TITLE
Add Bluesky support as an external media publisher (via AT Protocol)

### DIFF
--- a/TASVideos.Core/Constants.cs
+++ b/TASVideos.Core/Constants.cs
@@ -16,6 +16,7 @@ internal static class HttpClients
 	public const string GoogleAuth = "GoogleAuth";
 	public const string Youtube = "Youtube";
 	public const string Discord = "Discord";
+	public const string Bluesky = "Bluesky";
 }
 
 internal static class PlayerPointConstants

--- a/TASVideos.Core/Extensions/HttpClientExtensions.cs
+++ b/TASVideos.Core/Extensions/HttpClientExtensions.cs
@@ -42,4 +42,9 @@ public static class HttpClientExtensions
 	{
 		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", basicAuthHeader);
 	}
+
+	public static void ResetAuthorization(this HttpClient client)
+	{
+		client.DefaultRequestHeaders.Authorization = null;
+	}
 }

--- a/TASVideos.Core/ServiceCollectionExtensions.cs
+++ b/TASVideos.Core/ServiceCollectionExtensions.cs
@@ -38,6 +38,11 @@ public static class ServiceCollectionExtensions
 			{
 				client.BaseAddress = new Uri("https://www.googleapis.com/youtube/v3/");
 			});
+		services
+			.AddHttpClient(HttpClients.Bluesky, client =>
+			{
+				client.BaseAddress = new Uri("https://bsky.social/xrpc/");
+			});
 
 		return services.AddServices(settings);
 	}
@@ -129,6 +134,11 @@ public static class ServiceCollectionExtensions
 		if (settings.Discord.IsEnabled())
 		{
 			services.AddScoped<IPostDistributor, DiscordDistributor>();
+		}
+
+		if (settings.Bluesky.IsEnabled())
+		{
+			services.AddScoped<IPostDistributor, BlueskyDistributor>();
 		}
 
 		return services.AddScoped<IPostDistributor, DistributorStorage>();

--- a/TASVideos.Core/Services/ExternalMediaPublisher/Distributors/BlueskyDistributor.cs
+++ b/TASVideos.Core/Services/ExternalMediaPublisher/Distributors/BlueskyDistributor.cs
@@ -1,0 +1,150 @@
+﻿using System.Globalization;
+using System.Text;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using TASVideos.Core.HttpClientExtensions;
+using TASVideos.Core.Settings;
+
+namespace TASVideos.Core.Services.ExternalMediaPublisher.Distributors;
+public sealed class BlueskyDistributor(
+	AppSettings appSettings,
+	IHttpClientFactory httpClientFactory,
+	ILogger<BlueskyDistributor> logger) : IPostDistributor
+{
+	private readonly HttpClient _client = httpClientFactory.CreateClient(HttpClients.Bluesky);
+	private readonly AppSettings.BlueskyConnection _settings = appSettings.Bluesky;
+
+	public IEnumerable<PostType> Types => [PostType.Announcement];
+
+	public async Task Post(IPostable post)
+	{
+		if (!_settings.IsEnabled())
+		{
+			return;
+		}
+
+		_client.ResetAuthorization();
+		var sessionResponse = await _client.PostAsync("com.atproto.server.createSession", new BlueskyCreateSessionRequest(_settings.Identifier, _settings.Password).ToStringContent());
+		if (!sessionResponse.IsSuccessStatusCode)
+		{
+			logger.LogError("Failed to create Bluesky session");
+			return;
+		}
+
+		var session = await sessionResponse.ReadAsync<BlueskyCreateSessionResponse>();
+		_client.SetBearerToken(session.AccessJwt);
+
+		var postResponse = await _client.PostAsync("com.atproto.repo.createRecord", new BlueskyCreateRecordRequest(session.Did, post).ToStringContent());
+		if (!postResponse.IsSuccessStatusCode)
+		{
+			logger.LogError("Failed to create Bluesky post");
+		}
+	}
+
+	public class BlueskyCreateSessionRequest(string identifier, string password)
+	{
+		[JsonPropertyName("identifier")]
+		public string Identifier { get; set; } = identifier;
+
+		[JsonPropertyName("password")]
+		public string Password { get; set; } = password;
+	}
+
+	public class BlueskyCreateSessionResponse
+	{
+		[JsonPropertyName("accessJwt")]
+		public string AccessJwt { get; set; } = "";
+		[JsonPropertyName("did")]
+		public string Did { get; set; } = "";
+	}
+
+	public class BlueskyCreateRecordRequest(string repo, IPostable post)
+	{
+		[JsonPropertyName("repo")]
+		public string Repo { get; set; } = repo;
+
+		[JsonPropertyName("collection")]
+		public string Collection { get; } = "app.bsky.feed.post";
+
+		[JsonPropertyName("record")]
+		public BlueskyPost Record { get; set; } = new BlueskyPost(post);
+	}
+
+	public class BlueskyPost
+	{
+		public BlueskyPost(IPostable post)
+		{
+			var body = post.Group switch
+			{
+				PostGroups.Submission => post.Title,
+				PostGroups.Publication => post.Title,
+				_ => post.Body
+			};
+
+			if (!string.IsNullOrWhiteSpace(post.Link))
+			{
+				body = body.CapAndEllipse(300 - (post.Link.Length + 2));
+
+				body += '\n';
+				var bodyLengthUtf8 = Encoding.UTF8.GetByteCount(body);
+				var linkLengthUtf8 = Encoding.UTF8.GetByteCount(post.Link);
+
+				body += post.Link;
+
+				int byteStart = bodyLengthUtf8;
+				int byteEnd = byteStart + linkLengthUtf8;
+
+				Facets.Add(new BlueskyFacet(byteStart, byteEnd, post.Link));
+			}
+			else
+			{
+				body = body.CapAndEllipse(300);
+			}
+
+			Text = body;
+			CreatedAt = DateTime.UtcNow.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture);
+		}
+
+		[JsonPropertyName("$type")]
+		public string Type { get; } = "app.bsky.feed.post";
+
+		[JsonPropertyName("text")]
+		public string Text { get; set; }
+
+		[JsonPropertyName("facets")]
+		public List<BlueskyFacet> Facets { get; set; } = [];
+
+		[JsonPropertyName("langs")]
+		public List<string> Langs { get; } = ["en-US"];
+
+		[JsonPropertyName("createdAt")]
+		public string CreatedAt { get; set; }
+	}
+
+	public class BlueskyFacet(int byteStart, int byteEnd, string uri)
+	{
+		[JsonPropertyName("index")]
+		public BlueskyFacetIndex Index { get; set; } = new BlueskyFacetIndex(byteStart, byteEnd);
+
+		[JsonPropertyName("features")]
+		public List<BlueskyFacetFeature> Features { get; set; } = [new BlueskyFacetFeature(uri)];
+
+		public class BlueskyFacetIndex(int byteStart, int byteEnd)
+		{
+			[JsonPropertyName("byteStart")]
+			public int ByteStart { get; set; } = byteStart;
+
+			[JsonPropertyName("byteEnd")]
+			public int ByteEnd { get; set; } = byteEnd;
+		}
+
+		public class BlueskyFacetFeature(string uri)
+		{
+			[JsonPropertyName("$type")]
+			public string Type { get; } = "app.bsky.richtext.facet#link";
+
+			[JsonPropertyName("uri")]
+			public string Uri { get; set; } = uri;
+		}
+	}
+}

--- a/TASVideos.Core/Settings/AppSettings.cs
+++ b/TASVideos.Core/Settings/AppSettings.cs
@@ -15,6 +15,7 @@ public class AppSettings
 
 	public IrcConnection Irc { get; set; } = new();
 	public DiscordConnection Discord { get; set; } = new();
+	public BlueskyConnection Bluesky { get; set; } = new();
 
 	public JwtSettings Jwt { get; set; } = new();
 	public GoogleAuthSettings YouTube { get; set; } = new();
@@ -74,6 +75,16 @@ public class AppSettings
 		public bool IsPrivateChannelEnabled() => IsEnabled()
 			&& !string.IsNullOrWhiteSpace(PrivateChannelId)
 			&& !string.IsNullOrWhiteSpace(PrivateUserChannelId);
+	}
+
+	public class BlueskyConnection : DistributorConnection
+	{
+		public string Identifier { get; set; } = "";
+		public string Password { get; set; } = "";
+
+		public bool IsEnabled() => Disable != true
+			&& !string.IsNullOrWhiteSpace(Identifier)
+			&& !string.IsNullOrWhiteSpace(Password);
 	}
 
 	public class DistributorConnection


### PR DESCRIPTION
Bluesky is a microblogging social media service. This PR implements for Bluesky almost the same thing we had for Twitter back when Twitter was a thing: Posting about new submissions and publications.

![image](https://github.com/user-attachments/assets/1e07e9e5-0707-4fcd-995b-5a73cafe668d)

The image shows there are no automatic embeds on Bluesky.

One big difference with Bluesky posts is how we have to handle things like links and embeds manually. This PR implements the handling of links, because otherwise this posting about submissions and publications would be somewhat useless.
However, I added no support for embeds, because those are a lot more difficult. As described in the [website card embed docs](https://docs.bsky.app/docs/advanced-guides/posts#website-card-embeds) we need to upload the image separately and link it with the title and description. This can be done at a later time.

For now, this PR should be sufficient.

The app settings need these fields in a `Bluesky` configuration block for this feature to work:
- The `Identifier` field is for the bluesky handle. This would look like `tasvideos.bsky.social`, or if we already switched to a domain account it would be `tasvideos.org`.
- The `Password` field for the password. It should ideally be an App password, so it can easily be revoked if necessary!

Oh and btw, Bluesky uses the usual access tokens and refresh tokens. However, this PR only ever uses access tokens once, and for the next post it simply create a completely new session with a new access token. This made more sense to me than keeping the refresh token alive, considering we only post like 2-3 times a day.