### PR TITLE
A couple clarifications on sub create/edit forms

### DIFF
--- a/TASVideos.Common/Constants.cs
+++ b/TASVideos.Common/Constants.cs
@@ -70,7 +70,8 @@ public static class SiteGlobalConstants
 
 	public const string DefaultPublicationText = "''[TODO]: describe this movie here''";
 
-	public const int MaximumMovieSize = 2048 * 1024;
+	public const int MaximumMovieSize = 2 * 1024 * 1024;
+	public const string MaximumMovieSizeHumanReadable = "2 MiB";
 	public const int UserFileStorageLimit = 1000 * 1000 * 50; // 50 MB
 
 	public const int GamesForumCategory = 5;

--- a/TASVideos/Extensions/FormFileExtensions.cs
+++ b/TASVideos/Extensions/FormFileExtensions.cs
@@ -1,4 +1,8 @@
 ﻿using System.IO.Compression;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace TASVideos.Extensions;
 
@@ -44,14 +48,16 @@ public static class FormFileExtensions
 			|| compressedContentTypes.Contains(formFile.ContentType);
 	}
 
-	public static bool LessThanMovieSizeLimit(this IFormFile? formFile)
+	public static void AddModelErrorIfOverSizeLimit(
+		this IFormFile movie,
+		ModelStateDictionary modelState,
+		ClaimsPrincipal user,
+		[CallerArgumentExpression(nameof(movie))] string movieFieldName = default!)
 	{
-		if (formFile is null)
+		if (!user.Has(PermissionTo.OverrideSubmissionConstraints) && movie.Length >= SiteGlobalConstants.MaximumMovieSize)
 		{
-			return true;
+			modelState.AddModelError(movieFieldName, ".zip is too big, are you sure this is a valid movie file?");
 		}
-
-		return formFile.Length < SiteGlobalConstants.MaximumMovieSize;
 	}
 
 	public static bool IsValidImage(this IFormFile? formFile)

--- a/TASVideos/Pages/Publications/AdditionalMovies.cshtml
+++ b/TASVideos/Pages/Publications/AdditionalMovies.cshtml
@@ -42,7 +42,7 @@
 			<fieldset>
 				<label asp-for="AdditionalMovieFile">Add an additional movie file</label>
 				<input asp-for="AdditionalMovieFile" />
-				<div>Your movie packed in a ZIP file (max size: 150k)</div>
+				<div>Your movie packed in a ZIP file (max size: @SiteGlobalConstants.MaximumMovieSizeHumanReadable)</div>
 				<span asp-validation-for="AdditionalMovieFile"></span>
 			</fieldset>
 			<form-button-bar>

--- a/TASVideos/Pages/Publications/AdditionalMovies.cshtml.cs
+++ b/TASVideos/Pages/Publications/AdditionalMovies.cshtml.cs
@@ -60,12 +60,7 @@ public class AdditionalMoviesModel(
 			ModelState.AddModelError(nameof(AdditionalMovieFile), "Not a valid .zip file");
 		}
 
-		if (!AdditionalMovieFile.LessThanMovieSizeLimit())
-		{
-			ModelState.AddModelError(
-				nameof(AdditionalMovieFile),
-				".zip is too big, are you sure this is a valid movie file?");
-		}
+		AdditionalMovieFile?.AddModelErrorIfOverSizeLimit(ModelState, User);
 
 		if (!ModelState.IsValid)
 		{

--- a/TASVideos/Pages/Publications/PrimaryMovie.cshtml
+++ b/TASVideos/Pages/Publications/PrimaryMovie.cshtml
@@ -17,7 +17,7 @@
 			</fieldset>
 			<fieldset>
 				<label asp-for="PrimaryMovieFile"></label>
-				<div>Your movie packed in a ZIP file (max size: 150k)</div>
+				<div>Your movie packed in a ZIP file (max size: @SiteGlobalConstants.MaximumMovieSizeHumanReadable)</div>
 				<input asp-for="PrimaryMovieFile" />
 				<span asp-validation-for="PrimaryMovieFile"></span>
 			</fieldset>

--- a/TASVideos/Pages/Publications/PrimaryMovie.cshtml.cs
+++ b/TASVideos/Pages/Publications/PrimaryMovie.cshtml.cs
@@ -54,6 +54,8 @@ public class PrimaryMoviesModel(
 			ModelState.AddModelError(nameof(PrimaryMovieFile), $"A publication with the filename {PrimaryMovieFile!.FileName} already exists.");
 		}
 
+		PrimaryMovieFile?.AddModelErrorIfOverSizeLimit(ModelState, User);
+
 		if (!ModelState.IsValid)
 		{
 			PublicationTitle = publication.Title;

--- a/TASVideos/Pages/Submissions/Edit.cshtml
+++ b/TASVideos/Pages/Submissions/Edit.cshtml
@@ -21,7 +21,7 @@
 			<fieldset>
 				<label asp-for="Submission.ReplaceMovieFile"></label>
 				<input asp-for="Submission.ReplaceMovieFile" />
-				<div>Your movie packed in a ZIP file (max size: 150k)</div>
+				<div>Your movie packed in a ZIP file (max size: @SiteGlobalConstants.MaximumMovieSizeHumanReadable)</div>
 				<span asp-validation-for="Submission.ReplaceMovieFile"></span>
 			</fieldset>
 		</column>

--- a/TASVideos/Pages/Submissions/Edit.cshtml
+++ b/TASVideos/Pages/Submissions/Edit.cshtml
@@ -52,8 +52,9 @@
 				<span asp-validation-for="Submission.GameName"></span>
 			</fieldset>
 			<fieldset>
-				<label asp-for="Submission.Emulator"></label>
-				<input asp-for="Submission.Emulator" spellcheck="false" placeholder="Needs to be a specific version that sync was verified on. Does not necessarily need to be the version used by the author." />
+				<label asp-for="Submission.Emulator">Emulator and version</label>
+				<input asp-for="Submission.Emulator" spellcheck="false" placeholder="Example: BizHawk 2.8.0" />
+				<div>Needs to be a specific version that sync was verified on. Does not necessarily need to be the version used by the author.</div>
 				<span asp-validation-for="Submission.Emulator"></span>
 			</fieldset>
 		</column>

--- a/TASVideos/Pages/Submissions/Edit.cshtml
+++ b/TASVideos/Pages/Submissions/Edit.cshtml
@@ -71,7 +71,8 @@
 			</fieldset>
 			<fieldset>
 				<label asp-for="Submission.EncodeEmbedLink"></label>
-				<input asp-for="Submission.EncodeEmbedLink" placeholder="Embedded link to a video of your movie, Ex: www.youtube.com/embed/0mregEW6kVU" />
+				<input asp-for="Submission.EncodeEmbedLink" placeholder="https://www.youtube.com/embed/0mregEW6kVU" />
+				<div>Embedded link to a video of your movie. Must be YouTube or niconico.</div>
 				<span asp-validation-for="Submission.EncodeEmbedLink"></span>
 			</fieldset>
 		</column>

--- a/TASVideos/Pages/Submissions/Edit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Edit.cshtml.cs
@@ -114,10 +114,7 @@ public class EditModel(
 				ModelState.AddModelError(FileFieldName, "Not a valid .zip file");
 			}
 
-			if (!User.Has(PermissionTo.OverrideSubmissionConstraints) && !Submission.ReplaceMovieFile.LessThanMovieSizeLimit())
-			{
-				ModelState.AddModelError(FileFieldName, ".zip is too big, are you sure this is a valid movie file?");
-			}
+			Submission.ReplaceMovieFile?.AddModelErrorIfOverSizeLimit(ModelState, User, movieFieldName: FileFieldName);
 		}
 		else if (!User.Has(PermissionTo.ReplaceSubmissionMovieFile))
 		{

--- a/TASVideos/Pages/Submissions/Submit.cshtml
+++ b/TASVideos/Pages/Submissions/Submit.cshtml
@@ -44,7 +44,7 @@
 		<column lg="6">
 			<fieldset>
 				<label asp-for="GameVersion"></label>
-				<input asp-for="GameVersion" placeholder="Example: USA" />
+				<input asp-for="GameVersion" placeholder="USA v1.0" />
 				<span asp-validation-for="GameVersion"></span>
 			</fieldset>
 			<fieldset>

--- a/TASVideos/Pages/Submissions/Submit.cshtml
+++ b/TASVideos/Pages/Submissions/Submit.cshtml
@@ -71,7 +71,8 @@
 			</fieldset>
 			<fieldset>
 				<label asp-for="EncodeEmbeddedLink"></label>
-				<input asp-for="EncodeEmbeddedLink" placeholder="Embedded link to a video of your movie, Ex: www.youtube.com/embed/0mregEW6kVU" />
+				<input asp-for="EncodeEmbeddedLink" placeholder="https://www.youtube.com/embed/0mregEW6kVU" />
+				<div>Embedded link to a video of your movie. Must be YouTube or niconico.</div>
 				<span asp-validation-for="EncodeEmbeddedLink"></span>
 			</fieldset>
 		</column>

--- a/TASVideos/Pages/Submissions/Submit.cshtml
+++ b/TASVideos/Pages/Submissions/Submit.cshtml
@@ -22,7 +22,7 @@
 			<fieldset>
 				<label asp-for="MovieFile"></label>
 				<input asp-for="MovieFile" />
-				<div>Your movie packed in a ZIP file (max size: 500k)</div>
+				<div>Your movie packed in a ZIP file (max size: @SiteGlobalConstants.MaximumMovieSizeHumanReadable)</div>
 				<span asp-validation-for="MovieFile"></span>
 			</fieldset>
 		</column>

--- a/TASVideos/Pages/Submissions/Submit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Submit.cshtml.cs
@@ -191,10 +191,7 @@ public class SubmitModel(
 			ModelState.AddModelError(FileFieldName, "Not a valid .zip file");
 		}
 
-		if (!MovieFile.LessThanMovieSizeLimit())
-		{
-			ModelState.AddModelError(FileFieldName, ".zip is too big, are you sure this is a valid movie file?");
-		}
+		MovieFile?.AddModelErrorIfOverSizeLimit(ModelState, User, movieFieldName: FileFieldName);
 
 		foreach (var author in Authors)
 		{


### PR DESCRIPTION
Max. movie size was never updated properly.

Spike wanted the list of valid domains for encodes, which from
https://github.com/TASVideos/tasvideos/blob/be53468c1882e7308febe2f97db88d9d97fbd171/TASVideos/Pages/Submissions/View.cshtml#L102-L105
seems to be YT and niconico only.