### PR TITLE
Add `[module:bannedusers]`

### DIFF
--- a/TASVideos.Data/Entity/User.cs
+++ b/TASVideos.Data/Entity/User.cs
@@ -207,6 +207,9 @@ public static class UserExtensions
 	public static IQueryable<User> ThatHaveCustomLocale(this IQueryable<User> query)
 		=> query.Where(u => u.DateFormat != UserDateFormat.Auto || u.TimeFormat != UserTimeFormat.Auto || u.DecimalFormat != UserDecimalFormat.Auto);
 
+	public static IQueryable<User> ThatAreBanned(this IQueryable<User> query)
+		=> query.Where(u => u.BannedUntil.HasValue && u.BannedUntil > DateTime.UtcNow); // > and < in these methods, but what about ==?
+
 	public static IQueryable<User> ThatAreNotBanned(this IQueryable<User> query)
 		=> query.Where(u => !u.BannedUntil.HasValue || u.BannedUntil < DateTime.UtcNow);
 

--- a/TASVideos.WikiEngine/ModuleNames.cs
+++ b/TASVideos.WikiEngine/ModuleNames.cs
@@ -8,6 +8,7 @@ public static class ModuleNames
 	public const string AlternateStreaming = "alternatestreaming";
 	public const string Awards = "awards";
 	public const string BannedAvatarSites = "bannedavatarsites";
+	public const string BannedUsers = "bannedusers";
 	public const string BrokenLinks = "brokenlinks";
 	public const string CrossGameObsoletions = "crossgameobsoletions";
 	public const string DisplayGameName = "displaygamename";

--- a/TASVideos/WikiModules/BannedUsers.cshtml
+++ b/TASVideos/WikiModules/BannedUsers.cshtml
@@ -1,0 +1,25 @@
+﻿@model BannedUsers
+
+<partial name="_Pager" model="Model.Users" />
+<standard-table condition="User.Has(PermissionTo.AssignRoles)">
+	<sortable-table-head sorting="@Model.GetPaging()" model-type="typeof(BannedUsers.Entry)" page-override="@Model.CurrentPage" />
+	@foreach (var banned in Model.Users)
+	{
+		<tr>
+			<td><profile-link username="@banned.Name"></profile-link></td>
+			<td><timezone-convert asp-for="@banned.BannedUntil" /></td>
+			<td>
+				@if (banned.LastLoggedIn is not null)
+				{
+					<timezone-convert asp-for="@banned.LastLoggedIn.Value" />
+				}
+				else
+				{
+					@:&mdash;
+				}
+			</td>
+			<td condition="User.Has(PermissionTo.EditUsers)">@(banned.ModeratorComments ?? string.Empty)</td>
+		</tr>
+	}
+</standard-table>
+<partial name="_Pager" model="Model.Users" />

--- a/TASVideos/WikiModules/BannedUsers.cshtml.cs
+++ b/TASVideos/WikiModules/BannedUsers.cshtml.cs
@@ -1,0 +1,39 @@
+﻿using TASVideos.WikiEngine;
+
+namespace TASVideos.WikiModules;
+
+[WikiModule(ModuleNames.BannedUsers)]
+public class BannedUsers(ApplicationDbContext db) : WikiViewComponent
+{
+	public PageOf<Entry> Users { get; set; } = new([], new());
+
+	public async Task<IViewComponentResult> InvokeAsync()
+	{
+		Users = await db.Users
+			.ThatAreBanned()
+			.OrderBy(u => u.UserName)
+			.Select(u => new Entry
+			{
+				Name = u.UserName,
+				BannedUntil = u.BannedUntil!.Value,
+				LastLoggedIn = u.LastLoggedInTimeStamp,
+				ModeratorComments = u.ModeratorComments,
+			})
+			.SortedPageOf(GetPaging());
+		return View();
+	}
+
+	public class Entry
+	{
+		[Sortable]
+		public string Name { get; init; } = "";
+
+		[Sortable]
+		public DateTime BannedUntil { get; init; }
+
+		[Sortable]
+		public DateTime? LastLoggedIn { get; init; }
+
+		public string? ModeratorComments { get; init; }
+	}
+}


### PR DESCRIPTION
Working towards #2068, which from the discussion there and on Discord we agreed should be a module which conditionally renders based on your permissions.

Currently functional (edit: I've since added pagination and sorting):
![screencap](https://github.com/user-attachments/assets/71180200-c8cc-4a0c-b3a1-dec3eeaba8a7)

The module doesn't render anything unless you have the "Assign Roles" permission, which I believe is what lets you ban users?
And the final column with the moderator comments is only included if you also have the "Edit Users" permission, which it seems is the same people as have "Assign Roles" at the moment.

There's no ban start date field so I didn't add that.