### PR TITLE
make submit poll add/edit button tell what it will do: add or save

### DIFF
--- a/TASVideos/Pages/Forum/Topics/AddEditPoll.cshtml
+++ b/TASVideos/Pages/Forum/Topics/AddEditPoll.cshtml
@@ -1,8 +1,7 @@
 ﻿@page "{topicId}"
 @model AddEditPollModel
 @{
-	var mode = Model.PollId.HasValue ? "Edit" : "Add";
-	ViewData.SetTitle($"{mode}ing Poll for Topic {Model.TopicTitle}");
+	ViewData.SetTitle((Model.PollId.HasValue ? "Edit" : "Add") + "ing Poll for Topic " + Model.TopicTitle);
 	ViewData.UseStringList(); // Hack for now, partial views use a different viewDataDictionary, so the component will not work
 }
 
@@ -11,7 +10,7 @@
 <form client-side-validation="true" method="post">
 	<partial name="_PollCreate" model="Model.Poll" />
 	<form-button-bar>
-		<submit-button><i class="fa fa-save"></i> @mode</submit-button>
+		<submit-button><i class="fa fa-save"></i> @(Model.PollId.HasValue ? "Save" : "Add")</submit-button>
 		<cancel-link asp-page="Index" asp-route-id="@Model.TopicId"></cancel-link>
 	</form-button-bar>
 </form>


### PR DESCRIPTION
Currently it says "edit" which everywhere else means "open the page where the thing can be edited, and then that edit can be saved separately, or canceled".

I wanted to see if I can edit poll options after some votes, and the button says "edit" so I expected it to send me to some extra editing page (even tho I was already on one), and that overrode poll duration, which is always rounded down to whole days and right after you set it to some amount of days, it will decrease by 1, so accidentally saving that messes up actual duration.