### PR TITLE
Add OpenSSF Best Practices badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,9 @@ Most of our code style rules are configured in EditorConfig, so you can use `dot
 - Do not mark lambdas as `static`.
 - Do not use `required` with `init` props.
 
+If possible, please include unit tests when adding new features.
+We don't have Selenium or anything set up so you can't really test the frontend automatically, but any increase in test coverage is welcomed.
+
 ## Site Design
 
 The site has a [design document](DESIGN-SPEC.md) which details the structure, philosophy, and design goals of the frontend segments of the codebase which is great study for aspiring frontend contributors.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,10 +5,15 @@
 	</PropertyGroup>
 	<PropertyGroup>
 		<Nullable>enable</Nullable>
+		<AnalysisLevel>6</AnalysisLevel>
 		<CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 		<CodeAnalysisRuleSet>$(SolutionDir)Common.ruleset</CodeAnalysisRuleSet>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+		<Features>strict</Features>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+		<RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
 	</PropertyGroup>
 	<ItemGroup>
 		<AdditionalFiles Include="$(SolutionDir).stylecop.json" />

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ![.NET Core](https://github.com/TASVideos/tasvideos/workflows/.NET%20Core/badge.svg)
 
+[![GitHub open issues counter](https://img.shields.io/github/issues-raw/TASVideos/tasvideos.svg?logo=github&logoColor=333333&style=popout)](https://github.com/TASVideos/tasvideos/issues)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/7161/badge)](https://www.bestpractices.dev/projects/7161)
+
 # TASVideos
 This is the https://tasvideos.org source code.
 


### PR DESCRIPTION
This builds on #2070 (only because I touched the same section of Markdown, it should be independent otherwise).
[Actual diff](https://github.com/YoshiRulz/tasvideos/compare/autolint...openssf).

Once this is merged, and assuming I haven't made any mistakes [filling in the checklist](https://www.bestpractices.dev/projects/7161), it will be ~97% towards passing. You can edit the checklist yourself with GitHub OAuth.
If you couldn't tell, the purpose of the OpenSSF Best Practices badge is both to increase (awareness of) software security and integrity in this project, as well as to advertise how much time we've spent on security. Though it is only self-certification, it's better than nothing, helping to eliminate low-hanging fruit and improve documentation/rigour.