### PR TITLE
Allow case-renaming Users

### DIFF
--- a/TASVideos.Core/Services/UserManager.cs
+++ b/TASVideos.Core/Services/UserManager.cs
@@ -406,4 +406,19 @@ public class UserManager(
 		user.BannedUntil = DateTime.UtcNow.AddYears(100);
 		await db.TrySaveChanges();
 	}
+
+	public async Task<bool> CanRenameUser(string oldUserName, string newUserName)
+	{
+		if (string.IsNullOrWhiteSpace(newUserName))
+		{
+			return false;
+		}
+
+		var users = await db.Users
+			.Select(user => user.UserName)
+			.Where(userName => userName == oldUserName || userName == newUserName)
+			.ToListAsync();
+
+		return users.Count == 1 && users[0] == oldUserName;
+	}
 }

--- a/TASVideos/Pages/Users/Edit.cshtml.cs
+++ b/TASVideos/Pages/Users/Edit.cshtml.cs
@@ -83,9 +83,16 @@ public class EditModel(
 			? user.UserName
 			: null;
 
-		if (UserToEdit.UserName is not null)
+		if (userNameChange is not null)
 		{
-			user.UserName = UserToEdit.UserName;
+			if (await userManager.CanRenameUser(user.UserName, UserToEdit.UserName!))
+			{
+				user.UserName = UserToEdit.UserName!;
+			}
+			else
+			{
+				userNameChange = null;
+			}
 		}
 
 		user.TimeZoneId = UserToEdit.TimeZone;

--- a/TASVideos/Pages/Users/List.cshtml.cs
+++ b/TASVideos/Pages/Users/List.cshtml.cs
@@ -1,7 +1,7 @@
 ﻿namespace TASVideos.Pages.Users;
 
 [AllowAnonymous]
-public class ListModel(ApplicationDbContext db, ICacheService cache) : BasePageModel
+public class ListModel(ApplicationDbContext db, ICacheService cache, UserManager userManager) : BasePageModel
 {
 	[FromQuery]
 	public PagingModel Search { get; set; } = new();
@@ -37,15 +37,9 @@ public class ListModel(ApplicationDbContext db, ICacheService cache) : BasePageM
 		return Json(matches);
 	}
 
-	public async Task<IActionResult> OnGetVerifyUniqueUserName(string userName)
+	public async Task<IActionResult> OnGetCanRenameUser(string oldUserName, string newUserName)
 	{
-		if (string.IsNullOrWhiteSpace(userName))
-		{
-			return Json(false);
-		}
-
-		var exists = await db.Users.Exists(userName);
-		return Json(exists);
+		return Json(await userManager.CanRenameUser(oldUserName, newUserName));
 	}
 
 	private async ValueTask<IEnumerable<string>> GetUsersByPartial(string partialUserName)

--- a/TASVideos/wwwroot/js/user-edit.js
+++ b/TASVideos/wwwroot/js/user-edit.js
@@ -26,7 +26,7 @@ function showCheckNameBtn() {
 }
 
 function hideCheckNameBtn() {
-	checkUserBtn.classList.add("div-none");
+	checkUserBtn.classList.add("d-none");
 	checkUserBtn.parentNode.classList.remove('col-sm-2');
 	userNameDiv.classList.remove('col-sm-10');
 	userNameDiv.classList.add('col-sm-12');
@@ -62,14 +62,14 @@ checkUserBtn.onclick = function () {
 		return;
 	}
 
-	fetch(`/Users/List?handler=VerifyUniqueUserName&userName=${userNameBox.value}`)
+	fetch(`/Users/List?handler=CanRenameUser&oldUserName=${originalUserNameBox.value}&newUserName=${userNameBox.value}`)
 		.then(handleFetchErrors)
 		.then(r => r.text())
 		.then(d => {
 			if (d === "true") {
-				markUserNameBad();
-			} else {
 				markUserNameGood();
+			} else {
+				markUserNameBad();
 			}
 		});
 };

--- a/tests/TASVideos.Core.Tests/Services/UserManagerTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/UserManagerTests.cs
@@ -316,5 +316,20 @@ public sealed class UserManagerTests : TestDbBase, IDisposable
 		Assert.AreEqual(2, _db.Publications.Count(s => s.Title.Contains(newName)));
 	}
 
+	[TestMethod]
+	[DataRow("OldUser", "NewUser", "OtherExistingUser", true)]
+	[DataRow("User", "user", "OtherExistingUser", true)]
+	[DataRow("User", "CoolUser", "CoolUser", false)]
+	[DataRow("User", "coolUser", "CoolUser", false)]
+	public async Task CanRenameUser(string oldUserName, string newUserName, string otherExistingUserName, bool expected)
+	{
+		_db.AddUser(oldUserName);
+		_db.AddUser(otherExistingUserName);
+		await _db.SaveChangesAsync();
+
+		var actual = await _userManager.CanRenameUser(oldUserName, newUserName);
+		Assert.AreEqual(expected, actual);
+	}
+
 	public void Dispose() => _userManager.Dispose();
 }


### PR DESCRIPTION
Before this, we couldn't rename users from "CoolDude" into "cooldude" because we did the check case insensitively. If we carelessly allowed it, then someone could be renamed into "Adelikat" when "adelikat" already exists.

This PR changes this so that both cases are now properly handled. The critical line is
`.Where(userName => userName == oldUserName || userName == newUserName)`
We ourselves don't check anything with letter case, and instead we let the DB do everything. We use it to check for both the old user name and the new one, and if the DB finds 2 different people, then we can't rename.

Also there are unit tests. :D