### PR TITLE
Rework Forgot Password Page

### DIFF
--- a/TASVideos.Core/Services/Email/EmailService.cs
+++ b/TASVideos.Core/Services/Email/EmailService.cs
@@ -7,7 +7,7 @@ namespace TASVideos.Core.Services.Email;
 public interface IEmailService
 {
 	Task SendEmail(string recipient, string subject, string message);
-	Task ResetPassword(string recipient, string link);
+	Task ResetPassword(string recipient, string link, string userName);
 	Task EmailConfirmation(string recipient, string link);
 	Task PasswordResetConfirmation(string recipient, string resetLink);
 	Task TopicReplyNotification(IEnumerable<string> recipients, TopicReplyNotificationTemplate template);
@@ -33,13 +33,26 @@ internal class EmailService(
 		});
 	}
 
-	public async Task ResetPassword(string recipient, string link)
+	public async Task ResetPassword(string recipient, string link, string userName)
 	{
 		await emailSender.SendEmail(new SingleEmail
 		{
 			Recipient = recipient,
 			Subject = "TASVideos - Reset Password",
-			Message = $"Please reset your password for your TASVideos user account by clicking here: <a href='{link}'>link</a>",
+			Message = $"""
+						<p>
+							Hello {HtmlEncoder.Default.Encode(userName)},<br>
+							We received a request to reset your password for your TASVideos user account.<br>
+							If you made this request, please click the link below to reset your password:
+						</p>
+						<p>
+							<a href='{HtmlEncoder.Default.Encode(link)}'>Reset your password.</a>
+						</p>
+						<p>
+							If you did not request a password reset, please ignore this email.<br>
+							This link will expire in 24 hours.
+						</p>
+						""",
 			ContainsHtml = true
 		});
 	}

--- a/TASVideos/Pages/Account/ForgotPassword.cshtml.cs
+++ b/TASVideos/Pages/Account/ForgotPassword.cshtml.cs
@@ -18,9 +18,9 @@ public class ForgotPasswordModel : BasePageModel
 		}
 
 		var user = await userManager.FindByEmailAsync(Email);
-		if (user is null || !await userManager.IsEmailConfirmedAsync(user))
+		if (user is null)
 		{
-			// Don't reveal that the user does not exist or is not confirmed
+			// Don't reveal that the user does not exist
 			return RedirectToPage("ForgotPasswordConfirmation");
 		}
 

--- a/TASVideos/Pages/Account/ForgotPassword.cshtml.cs
+++ b/TASVideos/Pages/Account/ForgotPassword.cshtml.cs
@@ -26,7 +26,7 @@ public class ForgotPasswordModel : BasePageModel
 
 		var code = await userManager.GeneratePasswordResetTokenAsync(user);
 		var callbackUrl = Url.ResetPasswordCallbackLink(user.Id.ToString(), code);
-		await emailService.ResetPassword(Email, callbackUrl);
+		await emailService.ResetPassword(Email, callbackUrl, user.UserName);
 
 		return RedirectToPage("ForgotPasswordConfirmation");
 	}

--- a/TASVideos/Pages/Account/ResetPassword.cshtml
+++ b/TASVideos/Pages/Account/ResetPassword.cshtml
@@ -9,20 +9,22 @@
 	<column lg="4">
 		<form client-side-validation="true" method="post">
 			<input asp-for="Code" type="hidden" />
-			<input id="UserName" name="UserName" class="d-none" value="@User.Name()" autocomplete="username" />
+			<fieldset>
+				<label asp-for="UserName"></label>
+				<input disable asp-for="UserName" />
+			</fieldset>
 			<fieldset>
 				<label asp-for="Email"></label>
-				<input asp-for="Email" autocomplete="off" />
-				<span asp-validation-for="Email"></span>
+				<input disable asp-for="Email" />
 			</fieldset>
 			<fieldset>
 				<label asp-for="NewPassword"></label>
-				<input asp-for="NewPassword" autocomplete="new-password" />
+				<input asp-for="NewPassword" autocomplete="new-password" class="form-control" />
 				<span asp-validation-for="NewPassword"></span>
 			</fieldset>
 			<fieldset>
 				<label asp-for="ConfirmNewPassword"></label>
-				<input asp-for="ConfirmNewPassword" autocomplete="new-password" />
+				<input asp-for="ConfirmNewPassword" autocomplete="new-password" class="form-control" />
 				<span asp-validation-for="ConfirmNewPassword"></span>
 			</fieldset>
 			<submit-button>Reset</submit-button>

--- a/TASVideos/Pages/Account/ResetPassword.cshtml.cs
+++ b/TASVideos/Pages/Account/ResetPassword.cshtml.cs
@@ -3,9 +3,9 @@
 [IpBanCheck]
 public class ResetPasswordModel(UserManager userManager) : BasePageModel
 {
-	[BindProperty]
-	[EmailAddress]
 	public string Email { get; set; } = "";
+
+	public string UserName { get; set; } = "";
 
 	[BindProperty]
 	[StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 12)]
@@ -42,6 +42,7 @@ public class ResetPasswordModel(UserManager userManager) : BasePageModel
 		}
 
 		Email = user.Email;
+		UserName = user.UserName;
 		return Page();
 	}
 
@@ -52,11 +53,15 @@ public class ResetPasswordModel(UserManager userManager) : BasePageModel
 			return Page();
 		}
 
-		var user = await userManager.FindByEmailAsync(Email);
+		if (string.IsNullOrWhiteSpace(Code))
+		{
+			return Home();
+		}
+
+		var user = await userManager.FindByIdAsync(UserId ?? "");
 		if (user is null)
 		{
-			// Don't reveal that the user does not exist
-			return RedirectToPage("ResetPasswordConfirmation");
+			return Home();
 		}
 
 		var code = Code ?? "";


### PR DESCRIPTION
IMPORTANT: This is a PR concerning security matters.
While I made sure for myself that these changes are secure, we should carefully confirm these changes anyway.

Resolves #2051 . The main issue was that users had no idea what their user name was throughout the entire Reset Password process. While I was going through these changes I found some other small things to be improved, including one behavior change.

Behavior Changes:
- Users can now reset their password even if their Email is not confirmed.

Email Changes:
- The user name is now displayed.
- We tell the user to ignore the password reset request if they didn't request it.
- We tell the user the link expires in 24 hours (ASP.NET Core default).

Page Changes:
- The user name is now displayed.

<hr>

Before | After

![image](https://github.com/user-attachments/assets/8f9b701f-e8d7-4b40-89a0-b518f114af3b)

![image](https://github.com/user-attachments/assets/54eb2d47-6f2b-4efc-890f-06fe5605ca21)
