### PR TITLE
Encode Topic title in HTML email for reply notifications

### DIFF
--- a/TASVideos.Core/Services/Email/EmailService.cs
+++ b/TASVideos.Core/Services/Email/EmailService.cs
@@ -98,7 +98,7 @@ internal class EmailService(
 						<p>
 						    Hello,<br>
 						    <br>
-						    The {siteName} forum topic "{template.TopicTitle}" has received a new post since your last visit.
+						    The {siteName} forum topic "{HtmlEncoder.Default.Encode(template.TopicTitle)}" has received a new post since your last visit.
 						</p>
 						<p>
 						    <a href="{template.BaseUrl}/Forum/Posts/{template.PostId}">{template.BaseUrl}/Forum/Posts/{template.PostId}</a>


### PR DESCRIPTION
When you get too used to Razor Pages doing the HTML encoding for you, you need to be extra careful about manually writing HTML I guess.