### PR TITLE
Put Forum Post Content into Open Graph Descriptions

### DIFF
--- a/TASVideos.Common/Extensions/StringExtensions.cs
+++ b/TASVideos.Common/Extensions/StringExtensions.cs
@@ -281,6 +281,11 @@ public static partial class StringExtensions
 		return strList.Where(a => !string.IsNullOrWhiteSpace(a)).ToList();
 	}
 
+	public static string RemoveUrls(this string s)
+	{
+		return SimpleUrlsRegex().Replace(s, "");
+	}
+
 	[GeneratedRegex(@"(\/)|(\p{Ll})(?=[\p{Lu}\p{Nd}])|(\p{Nd})(?=[\p{Lu}])|([\p{L}\p{Nd}])(?=[^\p{L}\p{Nd}])|([^\p{L}\p{Nd}])(?=[\p{L}\p{Nd}])")]
 	private static partial Regex SplitCamelCaseCompiledRegex();
 
@@ -289,4 +294,6 @@ public static partial class StringExtensions
 
 	[GeneratedRegex(@"\r\n?|\n")]
 	private static partial Regex NewLinesToSpacesRegex();
+	[GeneratedRegex(@"https?:\/\/\S*")]
+	private static partial Regex SimpleUrlsRegex();
 }

--- a/TASVideos.Core/ServiceCollectionExtensions.cs
+++ b/TASVideos.Core/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using TASVideos.Core.Services.Cache;
 using TASVideos.Core.Services.Email;
 using TASVideos.Core.Services.ExternalMediaPublisher;
 using TASVideos.Core.Services.ExternalMediaPublisher.Distributors;
+using TASVideos.Core.Services.Forum;
 using TASVideos.Core.Services.Wiki;
 using TASVideos.Core.Services.Youtube;
 using TASVideos.Core.Settings;
@@ -89,6 +90,7 @@ public static class ServiceCollectionExtensions
 		services.AddScoped<ITASVideosGrue, TASVideosGrue>();
 
 		services.AddScoped<ForumEngine.IWriterHelper, ForumWriterHelper>();
+		services.AddScoped<IForumToMetaDescriptionRenderer, ForumToMetaDescriptionRenderer>();
 
 		services.AddScoped<IYoutubeSync, YouTubeSync>();
 		services.AddScoped<IGoogleAuthService, GoogleAuthService>();

--- a/TASVideos.Core/Services/Forum/ForumToMetaDescriptionRenderer.cs
+++ b/TASVideos.Core/Services/Forum/ForumToMetaDescriptionRenderer.cs
@@ -1,0 +1,30 @@
+﻿using System.Text;
+using TASVideos.ForumEngine;
+
+namespace TASVideos.Core.Services.Forum;
+
+public interface IForumToMetaDescriptionRenderer
+{
+	Task<string> RenderForumForMetaDescription(string text, bool enableBbCode, bool enableHtml);
+}
+
+public class ForumToMetaDescriptionRenderer(IWriterHelper helper) : IForumToMetaDescriptionRenderer
+{
+	public async Task<string> RenderForumForMetaDescription(string text, bool enableBbCode, bool enableHtml)
+	{
+		Element content;
+		if (enableHtml || enableBbCode)
+		{
+			content = BbParser.Parse(text, enableHtml, enableBbCode);
+		}
+		else
+		{
+			content = new Element { Name = "_root" };
+			content.Children.Add(new Text { Content = text });
+		}
+
+		var sb = new StringBuilder();
+		await content.WriteMetaDescription(sb, helper);
+		return sb.ToString().Trim();
+	}
+}

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml
@@ -1,14 +1,17 @@
 ﻿@page "{id}"
+@using TASVideos.Core.Services.Forum
 @model IndexModel
+@inject IForumToMetaDescriptionRenderer forumToMetaDescriptionRenderer
 @{
 	ViewData.SetTitle($"{Model.Topic.Title} - Topic {Model.Topic.Id}");
+	var description = $"{Model.Topic.ForumName} → {Model.Topic.Title}";
 	if (Model.HighlightedPost is not null)
 	{
-		var description = $"{Model.Topic.ForumName} → {Model.Topic.Title}";
 		if (!string.IsNullOrWhiteSpace(Model.HighlightedPost.Subject) && Model.Topic.Title != Model.HighlightedPost.Subject)
 		{
 			description += $"\nSubject: {Model.HighlightedPost.Subject}";
 		}
+		description += "\n\n" + await forumToMetaDescriptionRenderer.RenderForumForMetaDescription(Model.HighlightedPost.Text, Model.HighlightedPost.EnableBbCode, Model.HighlightedPost.EnableHtml);
 
 		ViewData.SetMetaTags(new MetaTag
 		{
@@ -20,10 +23,11 @@
 	}
 	else
 	{
+		description += "\n\n" + await forumToMetaDescriptionRenderer.RenderForumForMetaDescription(Model.Topic.TopicCreator!.Text, Model.Topic.TopicCreator!.EnableBbCode, Model.Topic.TopicCreator!.EnableHtml);
 		ViewData.SetMetaTags(new MetaTag
 		{
 			Title = $"Topic by {Model.Topic.TopicCreator!.PosterName}",
-			Description = $"{Model.Topic.ForumName} → {Model.Topic.Title}",
+			Description = description,
 			Image = Model.Topic.TopicCreator!.GetCurrentAvatar()
 		});
 	}

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
@@ -73,6 +73,9 @@ public class IndexModel(
 					PosterAvatar = t.Poster!.Avatar,
 					PosterMoodUrlBase = t.Poster!.MoodAvatarUrlBase,
 					PosterMood = t.ForumPosts.OrderBy(p => p.CreateTimestamp).First().PosterMood,
+					Text = t.ForumPosts.OrderBy(p => p.CreateTimestamp).First().Text,
+					EnableBbCode = t.ForumPosts.OrderBy(p => p.CreateTimestamp).First().EnableBbCode,
+					EnableHtml = t.ForumPosts.OrderBy(p => p.CreateTimestamp).First().EnableHtml,
 				}
 			})
 			.SingleOrDefaultAsync(t => t.Id == Id);


### PR DESCRIPTION
With the previous PR #1896 which was for Wiki, this does the same for Forum Posts and Topics and resolves #1644 .

There were some discussions about possible abuse, in particular about malicious links, so this PR also removes all links from the text before putting them in the Open Graph data.

My plan is to pair this with a test phase of enabling embeds in our #updates channel of Discord. Which is the follow-up PR of #2079 .

![image](https://github.com/user-attachments/assets/e9022304-79c2-4173-a571-8039ff5a9d6f)
