### PR TITLE
Enable Discord embeds for post and topic creations

### DIFF
--- a/TASVideos.Common/Extensions/StringExtensions.cs
+++ b/TASVideos.Common/Extensions/StringExtensions.cs
@@ -281,6 +281,11 @@ public static partial class StringExtensions
 		return strList.Where(a => !string.IsNullOrWhiteSpace(a)).ToList();
 	}
 
+	public static string RemoveUrls(this string s)
+	{
+		return SimpleUrlsRegex().Replace(s, "");
+	}
+
 	[GeneratedRegex(@"(\/)|(\p{Ll})(?=[\p{Lu}\p{Nd}])|(\p{Nd})(?=[\p{Lu}])|([\p{L}\p{Nd}])(?=[^\p{L}\p{Nd}])|([^\p{L}\p{Nd}])(?=[\p{L}\p{Nd}])")]
 	private static partial Regex SplitCamelCaseCompiledRegex();
 
@@ -289,4 +294,6 @@ public static partial class StringExtensions
 
 	[GeneratedRegex(@"\r\n?|\n")]
 	private static partial Regex NewLinesToSpacesRegex();
+	[GeneratedRegex(@"https?:\/\/\S*")]
+	private static partial Regex SimpleUrlsRegex();
 }

--- a/TASVideos.Core/Constants.cs
+++ b/TASVideos.Core/Constants.cs
@@ -2,7 +2,8 @@
 
 public static class PostGroups
 {
-	public const string Forum = "Forum";
+	public const string ForumCreate = "ForumCreate";
+	public const string ForumOther = "ForumOther";
 	public const string Wiki = "Wiki";
 	public const string Submission = "Submission";
 	public const string UserManagement = "UserManagement";

--- a/TASVideos.Core/ServiceCollectionExtensions.cs
+++ b/TASVideos.Core/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using TASVideos.Core.Services.Cache;
 using TASVideos.Core.Services.Email;
 using TASVideos.Core.Services.ExternalMediaPublisher;
 using TASVideos.Core.Services.ExternalMediaPublisher.Distributors;
+using TASVideos.Core.Services.Forum;
 using TASVideos.Core.Services.Wiki;
 using TASVideos.Core.Services.Youtube;
 using TASVideos.Core.Settings;
@@ -89,6 +90,7 @@ public static class ServiceCollectionExtensions
 		services.AddScoped<ITASVideosGrue, TASVideosGrue>();
 
 		services.AddScoped<ForumEngine.IWriterHelper, ForumWriterHelper>();
+		services.AddScoped<IForumToMetaDescriptionRenderer, ForumToMetaDescriptionRenderer>();
 
 		services.AddScoped<IYoutubeSync, YouTubeSync>();
 		services.AddScoped<IGoogleAuthService, GoogleAuthService>();

--- a/TASVideos.Core/Services/ExternalMediaPublisher/Distributors/DiscordDistributor.cs
+++ b/TASVideos.Core/Services/ExternalMediaPublisher/Distributors/DiscordDistributor.cs
@@ -82,7 +82,7 @@ public sealed class DiscordDistributor : IPostDistributor
 			}
 			else
 			{
-				var link = post.Type == PostType.Announcement ? post.Link : $"<{post.Link}>";
+				var link = (post.Type == PostType.Announcement || post.Group == PostGroups.ForumCreate) ? post.Link : $"<{post.Link}>";
 				Content = string.IsNullOrWhiteSpace(post.FormattedTitle)
 					? $"{post.Title}{body} {link}"
 					: $"{string.Format(post.FormattedTitle, link)}{body}";

--- a/TASVideos.Core/Services/Forum/ForumToMetaDescriptionRenderer.cs
+++ b/TASVideos.Core/Services/Forum/ForumToMetaDescriptionRenderer.cs
@@ -1,0 +1,30 @@
+﻿using System.Text;
+using TASVideos.ForumEngine;
+
+namespace TASVideos.Core.Services.Forum;
+
+public interface IForumToMetaDescriptionRenderer
+{
+	Task<string> RenderForumForMetaDescription(string text, bool enableBbCode, bool enableHtml);
+}
+
+public class ForumToMetaDescriptionRenderer(IWriterHelper helper) : IForumToMetaDescriptionRenderer
+{
+	public async Task<string> RenderForumForMetaDescription(string text, bool enableBbCode, bool enableHtml)
+	{
+		Element content;
+		if (enableHtml || enableBbCode)
+		{
+			content = BbParser.Parse(text, enableHtml, enableBbCode);
+		}
+		else
+		{
+			content = new Element { Name = "_root" };
+			content.Children.Add(new Text { Content = text });
+		}
+
+		var sb = new StringBuilder();
+		await content.WriteMetaDescription(sb, helper);
+		return sb.ToString().Trim();
+	}
+}

--- a/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
@@ -153,7 +153,7 @@ public class CreateModel(
 		}
 		else
 		{
-			await publisher.SendForum(
+			await publisher.SendForumCreate(
 				topic.Forum.Restricted,
 				$"[New Post]({{0}}) by {user.UserName}{mood}",
 				$"{topic.Forum.ShortName}: {topic.Title}{subject}",

--- a/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
@@ -141,7 +141,7 @@ public class EditModel(
 		if (result.IsSuccess())
 		{
 			forumService.CacheEditedPostActivity(forumPost.ForumId, forumPost.Topic!.Id, forumPost.Id, (DateTime)forumPost.PostEditedTimestamp);
-			await publisher.SendForum(
+			await publisher.SendForumOther(
 				forumPost.Topic!.Forum!.Restricted,
 				$"[Post]({{0}}) edited by {User.Name()}",
 				$"{forumPost.Topic.Forum.ShortName}: {forumPost.Topic.Title}",
@@ -200,7 +200,7 @@ public class EditModel(
 		SuccessStatusMessage($"Post {Id} deleted");
 		forumService.ClearLatestPostCache();
 		forumService.ClearTopicActivityCache();
-		await publisher.SendForum(
+		await publisher.SendForumOther(
 			post.Restricted,
 			$"[{(topicDeleted ? "Topic" : "Post")} DELETED]({{0}}) by {User.Name()}",
 			$"{post.ForumShortName}: {post.TopicTitle}",
@@ -261,7 +261,7 @@ public class EditModel(
 		forumService.ClearLatestPostCache();
 		forumService.ClearTopicActivityCache();
 		await userManager.PermaBanUser(post.PosterId);
-		await publisher.SendForum(
+		await publisher.SendForumOther(
 			true,
 			$"[{(topicDeleted ? "Topic" : "Post")} DELETED as SPAM]({{0}}), and user {post.PosterName} banned by {User.Name()}",
 			$"{post.ForumShortName}: {post.TopicTitle}",

--- a/TASVideos/Pages/Forum/Topics/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Create.cshtml.cs
@@ -138,7 +138,7 @@ public class CreateModel(
 		await userManager.AssignAutoAssignableRolesByPost(User.GetUserId());
 		await dbTransaction.CommitAsync();
 
-		await publisher.SendForum(
+		await publisher.SendForumCreate(
 			forum.Restricted,
 			$"[New Topic]({{0}}) by {User.Name()}",
 			$"{forum.ShortName}: {Title}",

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml
@@ -1,14 +1,17 @@
 ﻿@page "{id}"
+@using TASVideos.Core.Services.Forum
 @model IndexModel
+@inject IForumToMetaDescriptionRenderer forumToMetaDescriptionRenderer
 @{
 	ViewData.SetTitle($"{Model.Topic.Title} - Topic {Model.Topic.Id}");
+	var description = $"{Model.Topic.ForumName} → {Model.Topic.Title}";
 	if (Model.HighlightedPost is not null)
 	{
-		var description = $"{Model.Topic.ForumName} → {Model.Topic.Title}";
 		if (!string.IsNullOrWhiteSpace(Model.HighlightedPost.Subject) && Model.Topic.Title != Model.HighlightedPost.Subject)
 		{
 			description += $"\nSubject: {Model.HighlightedPost.Subject}";
 		}
+		description += "\n\n" + await forumToMetaDescriptionRenderer.RenderForumForMetaDescription(Model.HighlightedPost.Text, Model.HighlightedPost.EnableBbCode, Model.HighlightedPost.EnableHtml);
 
 		ViewData.SetMetaTags(new MetaTag
 		{
@@ -20,10 +23,11 @@
 	}
 	else
 	{
+		description += "\n\n" + await forumToMetaDescriptionRenderer.RenderForumForMetaDescription(Model.Topic.TopicCreator!.Text, Model.Topic.TopicCreator!.EnableBbCode, Model.Topic.TopicCreator!.EnableHtml);
 		ViewData.SetMetaTags(new MetaTag
 		{
 			Title = $"Topic by {Model.Topic.TopicCreator!.PosterName}",
-			Description = $"{Model.Topic.ForumName} → {Model.Topic.Title}",
+			Description = description,
 			Image = Model.Topic.TopicCreator!.GetCurrentAvatar()
 		});
 	}

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
@@ -73,6 +73,9 @@ public class IndexModel(
 					PosterAvatar = t.Poster!.Avatar,
 					PosterMoodUrlBase = t.Poster!.MoodAvatarUrlBase,
 					PosterMood = t.ForumPosts.OrderBy(p => p.CreateTimestamp).First().PosterMood,
+					Text = t.ForumPosts.OrderBy(p => p.CreateTimestamp).First().Text,
+					EnableBbCode = t.ForumPosts.OrderBy(p => p.CreateTimestamp).First().EnableBbCode,
+					EnableHtml = t.ForumPosts.OrderBy(p => p.CreateTimestamp).First().EnableHtml,
 				}
 			})
 			.SingleOrDefaultAsync(t => t.Id == Id);

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
@@ -268,7 +268,7 @@ public class IndexModel(
 			SetMessage(result, $"Topic {topicTitle} set to locked {lockedState}", $"Unable to set {topicTitle} to status of {lockedState}");
 			if (result.IsSuccess())
 			{
-				await publisher.SendForum(
+				await publisher.SendForumOther(
 					topic.Forum!.Restricted,
 					$"[Topic]({{0}}) {lockedState} by {User.Name()}",
 					$"{topic.Forum.ShortName}: {topic.Title}",

--- a/TASVideos/Pages/Forum/Topics/Merge.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Merge.cshtml.cs
@@ -91,7 +91,7 @@ public class MergeModel(ApplicationDbContext db, ExternalMediaPublisher publishe
 		{
 			forumService.ClearLatestPostCache();
 			forumService.ClearTopicActivityCache();
-			await publisher.SendForum(
+			await publisher.SendForumOther(
 				originalTopic.Forum!.Restricted || destinationTopic.Forum!.Restricted,
 				$"[Topics MERGED]({{0}}) by {User.Name()}",
 				$"\"{originalTopic.Title}\" into \"{destinationTopic.Title}\"",

--- a/TASVideos/Pages/Forum/Topics/Move.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Move.cshtml.cs
@@ -84,7 +84,7 @@ public class MoveModel(
 		forumService.ClearLatestPostCache();
 		forumService.ClearTopicActivityCache();
 
-		await publisher.SendForum(
+		await publisher.SendForumOther(
 			topicWasRestricted || forum.Restricted,
 			$"[Topic]({{0}}) MOVED by {User.Name()}",
 			$"\"{Topic.Topic}\" from {Topic.CurrentForum} to {forum.Name}",

--- a/TASVideos/Pages/Forum/Topics/Split.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Split.cshtml.cs
@@ -113,7 +113,7 @@ public class SplitModel(
 		forumService.ClearLatestPostCache();
 		forumService.ClearTopicActivityCache();
 
-		await publisher.SendForum(
+		await publisher.SendForumOther(
 			destinationForum.Restricted || topic.Forum!.Restricted,
 			$"[Topic]({{0}}) SPLIT by {User.Name()}",
 			$"\"{newTopic.Title}\" from \"{Topic.Title}\"",

--- a/TASVideos/Services/ExternalMediaPublisher.cs
+++ b/TASVideos/Services/ExternalMediaPublisher.cs
@@ -195,7 +195,7 @@ public static class ExternalMediaPublisherExtensions
 		{
 			Announcement = "News Post!",
 			Type = PostType.Announcement,
-			Group = PostGroups.Forum,
+			Group = PostGroups.ForumCreate,
 			Title = Unformat(formattedTitle),
 			FormattedTitle = formattedTitle,
 			Body = body,
@@ -203,14 +203,29 @@ public static class ExternalMediaPublisherExtensions
 		});
 	}
 
-	public static async Task SendForum(this ExternalMediaPublisher publisher, bool restricted, string formattedTitle, string body, string relativeLink)
+	public static async Task SendForumCreate(this ExternalMediaPublisher publisher, bool restricted, string formattedTitle, string body, string relativeLink)
 	{
 		await publisher.Send(new Post
 		{
 			Type = restricted
 				? PostType.Administrative
 				: PostType.General,
-			Group = PostGroups.Forum,
+			Group = PostGroups.ForumCreate,
+			Title = Unformat(formattedTitle),
+			FormattedTitle = formattedTitle,
+			Body = body,
+			Link = publisher.ToAbsolute(relativeLink)
+		});
+	}
+
+	public static async Task SendForumOther(this ExternalMediaPublisher publisher, bool restricted, string formattedTitle, string body, string relativeLink)
+	{
+		await publisher.Send(new Post
+		{
+			Type = restricted
+				? PostType.Administrative
+				: PostType.General,
+			Group = PostGroups.ForumOther,
 			Title = Unformat(formattedTitle),
 			FormattedTitle = formattedTitle,
 			Body = body,


### PR DESCRIPTION
This PR builds upon PR #2077 (and I will rebase once that PR is merged).
It removes the `<` and `>` from post and topic creation links on the discord distributor, meaning they will get an embed.

This is probably a controversal change, because embeds make things much more verbose and maybe cluttered. The upside is that you can read the beginning of posts without even clicking on it.

This is a draft for 2 reasons. Firstly the other PR should be merged, otherwise this one doesn't make sense. And secondly I want to test some things with the embeds. Maybe we show too much info. Maybe there are too many newlines.