### PR TITLE
Fix meta descriptions that need a db lookup text

### DIFF
--- a/TASVideos.ForumEngine/Node.cs
+++ b/TASVideos.ForumEngine/Node.cs
@@ -556,7 +556,8 @@ public class Element : INode
 	{
 		if (Options == "")
 		{
-			sb.Append((await transformUrlText(Options)).RemoveUrls());
+			var text = Children.Cast<Text>().SingleOrDefault()?.Content ?? "";
+			sb.Append((await transformUrlText(text)).RemoveUrls());
 		}
 		else
 		{


### PR DESCRIPTION
Fixes the syntax like `[game]123[/game]` which is converted to custom text. It was empty in meta descriptions before.