### PR TITLE
Add fallback for pagination when `Sort` queryparam doesn't match any props

### DIFF
--- a/TASVideos.Core/Paging/Paginator.cs
+++ b/TASVideos.Core/Paging/Paginator.cs
@@ -94,7 +94,8 @@ public static class Paginator
 	{
 		if (string.IsNullOrWhiteSpace(request?.Sort))
 		{
-			return source0;
+			// per below, can't noop
+			return ApplyDefaultSort(source0);
 		}
 
 		var source = source0;

--- a/TASVideos.Core/Paging/Paginator.cs
+++ b/TASVideos.Core/Paging/Paginator.cs
@@ -104,7 +104,7 @@ public static class Paginator
 		foreach (var column in columns)
 		{
 			source = SortByParam(source, column, thenBy, out var sortApplied);
-			anySortApplied ||= sortApplied;
+			anySortApplied |= sortApplied;
 			thenBy = true;
 		}
 

--- a/TASVideos.Core/Paging/Paginator.cs
+++ b/TASVideos.Core/Paging/Paginator.cs
@@ -174,7 +174,7 @@ public static class Paginator
 			return SortByParamInner(query, idProp, idProp.Name, desc: false, thenBy: false);
 		}
 
-		// worst case, just do everything (DoS potential?)
+		// worst case, just do everything
 		var thenBy = false;
 		foreach (var pi in allProps.Where(pi => pi.GetCustomAttribute<SortableAttribute>() is not null))
 		{

--- a/TASVideos.Core/Paging/Paginator.cs
+++ b/TASVideos.Core/Paging/Paginator.cs
@@ -175,7 +175,7 @@ public static class Paginator
 
 		// worst case, just do everything (DoS potential?)
 		var thenBy = false;
-		foreach (var pi in allProps)
+		foreach (var pi in allProps.Where(pi => pi.GetCustomAttribute<SortableAttribute>() is not null))
 		{
 			query = SortByParamInner(query, pi, pi.Name.ToLowerInvariant(), desc: false, thenBy: thenBy);
 			thenBy = true;

--- a/TASVideos.Core/Paging/Paginator.cs
+++ b/TASVideos.Core/Paging/Paginator.cs
@@ -120,18 +120,13 @@ public static class Paginator
 		column = column?.Trim('-').Trim('+').ToLower() ?? "";
 
 		var prop = typeof(T).GetProperties().FirstOrDefault(p => p.Name.ToLower() == column);
-		return prop is null
+		return prop?.GetCustomAttribute<SortableAttribute>() is null
 			? query
 			: SortByParamInner(query, prop, column, desc: desc, thenBy: thenBy);
 	}
 
 	private static IQueryable<T> SortByParamInner<T>(IQueryable<T> query, PropertyInfo prop, string column, bool desc, bool thenBy)
 	{
-		if (prop.GetCustomAttribute(typeof(SortableAttribute)) is null)
-		{
-			return query;
-		}
-
 		string orderBy;
 		if (thenBy)
 		{
@@ -169,7 +164,7 @@ public static class Paginator
 	{
 		var allProps = typeof(T).GetProperties();
 		var idProp = allProps.SingleOrDefault(x => string.Equals(x.Name, "id", StringComparison.OrdinalIgnoreCase));
-		if (idProp is not null)
+		if (idProp?.GetCustomAttribute<SortableAttribute>() is not null)
 		{
 			return SortByParamInner(query, idProp, idProp.Name, desc: false, thenBy: false);
 		}


### PR DESCRIPTION
Resolves (some of?) the "The query uses a row limiting operator ('Skip'/'Take') without an 'OrderBy' operator. This may lead to unpredictable results." warnings Masterjun's been investigating.