### PR TITLE
Fix a database Take without an OrderBy warning in the movie list

### DIFF
--- a/TASVideos.Data/Entity/Publication.cs
+++ b/TASVideos.Data/Entity/Publication.cs
@@ -155,7 +155,7 @@ public static class PublicationExtensions
 	{
 		if (tokens.MovieIds.Any())
 		{
-			return publications.Where(p => tokens.MovieIds.Contains(p.Id));
+			return publications.Where(p => tokens.MovieIds.Contains(p.Id)).OrderBy(p => p.Id);
 		}
 
 		var query = publications;


### PR DESCRIPTION
I missed this code path when doing PR #2013 . This happens on links like `/Movies-123M-234M` which limit to certain IDs.
Turns out limiting to IDs shortcuts the entire method!