### PR TITLE
Order before Take on Userfile page

### DIFF
--- a/TASVideos/Pages/UserFiles/Index.cshtml.cs
+++ b/TASVideos/Pages/UserFiles/Index.cshtml.cs
@@ -31,7 +31,8 @@ public class IndexModel(ApplicationDbContext db, ExternalMediaPublisher publishe
 			.ToListAsync();
 		UncatalogedFiles = await db.UserFiles
 			.Where(uf => uf.GameId == null)
-			.Where(uf => !uf.Hidden)
+			.ThatArePublic()
+			.ByRecentlyUploaded()
 			.ToUnCatalogedModel()
 			.Take(25)
 			.ToListAsync();


### PR DESCRIPTION
Fixes the warnings and also properly orders the list. See this screenshot for the random order before:

![image](https://github.com/user-attachments/assets/9c5e4a79-cb50-408e-b06f-8c6e14d7a48d)
