### PR TITLE
Allow zipless Submissions

### DIFF
--- a/TASVideos.Core/Services/FileService.cs
+++ b/TASVideos.Core/Services/FileService.cs
@@ -11,6 +11,7 @@ public interface IFileService
 	/// Unzips the file, and re-zips it while renaming the contained file
 	/// </summary>
 	Task<byte[]> CopyZip(byte[] zipBytes, string fileName);
+	Task<byte[]> ZipFile(byte[] fileBytes, string fileName);
 
 	Task<ZippedFile?> GetSubmissionFile(int id);
 	Task<ZippedFile?> GetPublicationFile(int id);
@@ -69,6 +70,11 @@ internal class FileService(ApplicationDbContext db) : IFileService
 		await stream.CopyToAsync(singleStream);
 		var fileBytes = singleStream.ToArray();
 
+		return await ZipFile(fileBytes, fileName);
+	}
+
+	public async Task<byte[]> ZipFile(byte[] fileBytes, string fileName)
+	{
 		await using var outStream = new MemoryStream();
 		using (var archive = new ZipArchive(outStream, ZipArchiveMode.Create, true))
 		{

--- a/TASVideos/Extensions/FormFileExtensions.cs
+++ b/TASVideos/Extensions/FormFileExtensions.cs
@@ -109,6 +109,7 @@ public static class FormFileExtensions
 			var decompressedFileStream = new MemoryStream(); // TODO: To avoid zip bombs we should limit the max size of this MemoryStream
 			await gzip.CopyToAsync(decompressedFileStream);
 			await rawFileStream.DisposeAsync(); // manually dispose because we specified leaveOpen
+			decompressedFileStream.Position = 0;
 			return decompressedFileStream;
 		}
 		catch (InvalidDataException) // happens if file was uploaded without compression (e.g. no javascript), so we continue and return the raw bytes

--- a/TASVideos/Extensions/ViewDataDictionaryExtensions.cs
+++ b/TASVideos/Extensions/ViewDataDictionaryExtensions.cs
@@ -147,4 +147,10 @@ public static class ViewDataDictionaryExtensions
 
 	public static bool UsesMoodPreview(this ViewDataDictionary viewData)
 		=> viewData["use-mood-preview"] is not null;
+
+	public static void UseClientFileCompression(this ViewDataDictionary viewData)
+		=> viewData["use-client-file-compression"] = true;
+
+	public static bool UsesClientFileCompression(this ViewDataDictionary viewData)
+		=> viewData["use-client-file-compression"] is not null;
 }

--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -198,6 +198,11 @@
 				crossorigin="anonymous">
 		</script>
 	}
+	<script condition="ViewData.UsesClientFileCompression()"
+		src="https://cdnjs.cloudflare.com/ajax/libs/pako/2.1.0/pako_deflate.min.js"
+		integrity="sha512-oEsmlMj4bUaKNfYtsxV2eZm+5L0I/JhLsXftLFKeywkgAq8QMLKRlZrMIkMC2AHZQ/gT8YtI+fP1WUwNjF1PoQ=="
+		crossorigin="anonymous"
+		referrerpolicy="no-referrer"></script>
 	<script condition="ViewData.UsesSelectImprover()" src="/js/select-improver.js"></script>
 	<noscript condition="ViewData.UsesSelectImprover()"><style>.d-none-except-noscript { display: block !important; }</style></noscript>
 	<script condition="ViewData.UsesUserSearch()" src="/js/user-search.js"></script>

--- a/TASVideos/Pages/Submissions/Edit.cshtml
+++ b/TASVideos/Pages/Submissions/Edit.cshtml
@@ -2,6 +2,7 @@
 @model EditModel
 @{
 	ViewData.SetTitle($"Edit Submission {Model.Submission.Title}");
+	ViewData.UseClientFileCompression();
 	var canEditPublicationClass = User.Has(PermissionTo.JudgeSubmissions)
 		&& Model.AvailableStatuses.Any(s => s == SubmissionStatus.Accepted);
 }
@@ -20,8 +21,8 @@
 		<column lg="6" permission="ReplaceSubmissionMovieFile">
 			<fieldset>
 				<label asp-for="Submission.ReplaceMovieFile"></label>
-				<input asp-for="Submission.ReplaceMovieFile" />
-				<div>Your movie packed in a ZIP file (max size: @SiteGlobalConstants.MaximumMovieSizeHumanReadable)</div>
+				<input asp-for="Submission.ReplaceMovieFile" data-id="movie-file" />
+				<div>(Max size: @SiteGlobalConstants.MaximumMovieSizeHumanReadable)</div>
 				<span asp-validation-for="Submission.ReplaceMovieFile"></span>
 			</fieldset>
 		</column>
@@ -130,4 +131,5 @@
 
 @section Scripts {
 	<script src="/js/submissions-edit.js"></script>
+	<script src="/js/compress-file.js"></script>
 }

--- a/TASVideos/Pages/Submissions/Submit.cshtml
+++ b/TASVideos/Pages/Submissions/Submit.cshtml
@@ -23,8 +23,8 @@
 			<fieldset>
 				<label asp-for="MovieFile"></label>
 				<input asp-for="MovieFile" data-id="movie-file" />
-				<div>(Max size: @SiteGlobalConstants.MaximumMovieSizeHumanReadable)</div>
 				<span asp-validation-for="MovieFile"></span>
+				<div data-id="nozip-reminder" class="alert alert-warning d-none">Note: You no longer need to zip your movie file. You can select your original movie file and your browser will automatically compress it before uploading.</div>
 			</fieldset>
 		</column>
 		<column lg="6">

--- a/TASVideos/Pages/Submissions/Submit.cshtml
+++ b/TASVideos/Pages/Submissions/Submit.cshtml
@@ -2,6 +2,7 @@
 @model SubmitModel
 @{
 	ViewData.SetTitle("Submit Movie");
+	ViewData.UseClientFileCompression();
 	var notSupportedError = ViewData.ModelState.Values.Any(v => v.Errors.Any(e => e.ErrorMessage.Contains("not currently supported"))); // TODO: a less brittle check
 	var parseErrors = !notSupportedError && ViewData.ModelState.Keys.Any(e => e == "Parser");
 }
@@ -21,8 +22,8 @@
 		<column lg="6">
 			<fieldset>
 				<label asp-for="MovieFile"></label>
-				<input asp-for="MovieFile" />
-				<div>Your movie packed in a ZIP file (max size: @SiteGlobalConstants.MaximumMovieSizeHumanReadable)</div>
+				<input asp-for="MovieFile" data-id="movie-file" data-max-size="@SiteGlobalConstants.MaximumMovieSize" />
+				<div>(Max size: @SiteGlobalConstants.MaximumMovieSizeHumanReadable)</div>
 				<span asp-validation-for="MovieFile"></span>
 			</fieldset>
 		</column>
@@ -117,10 +118,11 @@
 	</row>
 	<form-button-bar>
 		<preview-button></preview-button>
-		<submit-button id="submit-btn" class="@(Model.Markup.Length > 0 ? "" : "d-none")">Submit</submit-button>
+		<submit-button id="submit-btn">Submit</submit-button>
 	</form-button-bar>
 </form>
 <wiki-preview></wiki-preview>
 @section Scripts {
 	<script src="/js/submit.js"></script>
+	<script src="/js/compress-file.js"></script>
 }

--- a/TASVideos/Pages/Submissions/Submit.cshtml
+++ b/TASVideos/Pages/Submissions/Submit.cshtml
@@ -22,7 +22,7 @@
 		<column lg="6">
 			<fieldset>
 				<label asp-for="MovieFile"></label>
-				<input asp-for="MovieFile" data-id="movie-file" data-max-size="@SiteGlobalConstants.MaximumMovieSize" />
+				<input asp-for="MovieFile" data-id="movie-file" />
 				<div>(Max size: @SiteGlobalConstants.MaximumMovieSizeHumanReadable)</div>
 				<span asp-validation-for="MovieFile"></span>
 			</fieldset>

--- a/TASVideos/Pages/UserFiles/Upload.cshtml
+++ b/TASVideos/Pages/UserFiles/Upload.cshtml
@@ -2,6 +2,7 @@
 @model UploadModel
 @{
 	ViewData.SetTitle("Upload a User file");
+	ViewData.UseClientFileCompression();
 }
 
 <info-alert dismissible="true">
@@ -59,9 +60,5 @@
 <wiki-preview></wiki-preview>
 @section Scripts {
 	<script src="/js/userfile.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/pako/2.1.0/pako_deflate.min.js"
-			integrity="sha512-oEsmlMj4bUaKNfYtsxV2eZm+5L0I/JhLsXftLFKeywkgAq8QMLKRlZrMIkMC2AHZQ/gT8YtI+fP1WUwNjF1PoQ=="
-			crossorigin="anonymous"
-			referrerpolicy="no-referrer"></script>
 	<script src="/js/userfiles-upload.js"></script>
 }

--- a/TASVideos/Pages/UserFiles/Upload.cshtml.cs
+++ b/TASVideos/Pages/UserFiles/Upload.cshtml.cs
@@ -77,18 +77,7 @@ public class UploadModel(
 			return Page();
 		}
 
-		byte[] fileData = await UserFile.ToBytes();
-		try
-		{
-			using var fileStream = new MemoryStream(fileData);
-			using var gzip = new GZipStream(fileStream, CompressionMode.Decompress);
-			using var tempStream = new MemoryStream(fileData.Length); // TODO: TO avoid zip bombs we should limit the max size of tempStream
-			await gzip.CopyToAsync(tempStream);
-			fileData = tempStream.ToArray();
-		}
-		catch (InvalidDataException) // happens if file was uploaded without compression (e.g. no javascript), so we continue and try to parse the raw bytes
-		{
-		}
+		byte[] fileData = (await UserFile.DecompressOrTakeRaw()).ToArray();
 
 		var (id, parseResult) = await userFiles.Upload(User.GetUserId(), new(
 			Title,

--- a/TASVideos/wwwroot/js/compress-file.js
+++ b/TASVideos/wwwroot/js/compress-file.js
@@ -1,0 +1,24 @@
+﻿document.addEventListener("DOMContentLoaded", registerFileInputs);
+
+function registerFileInputs() {
+	Array.from(document.querySelectorAll('[data-id="movie-file"]')).forEach(elem => {
+		elem.addEventListener("input", async () => {
+			await compressInput(elem);
+		})
+	});
+}
+
+async function compressInput(fileInput) {
+	const inputFile = fileInput.files[0];
+	if (!inputFile) {
+		return;
+	}
+
+	const inputBytes = await inputFile.arrayBuffer();
+	const zippedBytes = pako.gzip(inputBytes);
+
+	const newFile = new File([zippedBytes], inputFile.name, { type: inputFile.type, lastModified: inputFile.lastModified });
+	const dto = new DataTransfer;
+	dto.items.add(newFile);
+	fileInput.files = dto.files;
+}

--- a/TASVideos/wwwroot/js/compress-file.js
+++ b/TASVideos/wwwroot/js/compress-file.js
@@ -1,17 +1,28 @@
 ﻿document.addEventListener("DOMContentLoaded", registerFileInputs);
 
 function registerFileInputs() {
+	const noZipReminder = document.querySelector('[data-id="nozip-reminder"]');
 	Array.from(document.querySelectorAll('[data-id="movie-file"]')).forEach(elem => {
 		elem.addEventListener("input", async () => {
-			await compressInput(elem);
+			await compressInput(elem, noZipReminder);
 		})
 	});
 }
 
-async function compressInput(fileInput) {
+async function compressInput(fileInput, noZipReminder) {
 	const inputFile = fileInput.files[0];
 	if (!inputFile) {
 		return;
+	}
+
+	if (noZipReminder) {
+		const ext = (s => s.substring(s.lastIndexOf('.') + 1))(inputFile.name);
+		if (ext.toLowerCase() === "zip") {
+			noZipReminder.classList.remove('d-none');
+		}
+		else {
+			noZipReminder.classList.add('d-none');
+		}
 	}
 
 	const inputBytes = await inputFile.arrayBuffer();

--- a/TASVideos/wwwroot/js/submit.js
+++ b/TASVideos/wwwroot/js/submit.js
@@ -12,6 +12,10 @@ document.getElementById('prefill-btn').onclick = function () {
 			markupBox.value = data.text;
 		});
 };
+const submitBtn = document.getElementById('submit-btn');
+if (markupBox.value.length === 0) {
+	submitBtn.classList.add('d-none');
+}
 document.getElementById('preview-button').addEventListener('click', function () {
 	document.getElementById('submit-btn').classList.remove('d-none');
 });


### PR DESCRIPTION
Resolves #1187 .

Previously, users had to compress their submission files into .zip files to submit movies to the site.
With this PR, submissions and submission file replacements don't have to be in the .zip format anymore.

This PR does not change the internal representation of files. The PR still manually zips the files to store them in the db. This can be changed in a later PR, because this change is already big enough.

We avoid the massive filesizes of text-based movie files by doing a client compression step in JS. We already did this in userfiles. However, unlike userfiles, we want to be backwards-compatible for now, meaning .zip files will still be accepted and properly handled like before.
For non-JS users, this PR also handled uncompressed files.

<hr>

**Does not require .zip files:**
- Submission files
- Submission replacement files

**Still requires .zip files:**
- Publication file replacements
- Publication additional movie files

Why do publications still need to be .zip files? It's because the filename of the upload is taken from the uploaded .zip file. Without a .zip file we would need some other way to enter the filename. For submissions the filename is always `submission[id].zip`.