### PR TITLE
Suppress WebOptimizer file-not-found warning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,7 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageVersion Include="RoslynCodeTaskFactory" Version="2.0.7" />
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageVersion Include="Serilog.Expressions" Version="4.0.0" />
     <PackageVersion Include="SharpCompress" Version="0.36.0" />
     <PackageVersion Include="StackExchange.Redis" Version="2.7.10" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />

--- a/TASVideos/TASVideos.csproj
+++ b/TASVideos/TASVideos.csproj
@@ -46,6 +46,7 @@
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" />
 		<PackageReference Include="RoslynCodeTaskFactory" />
 		<PackageReference Include="Serilog.AspNetCore" />
+		<PackageReference Include="Serilog.Expressions" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/TASVideos/appsettings.Production.json
+++ b/TASVideos/appsettings.Production.json
@@ -19,6 +19,13 @@
         "Microsoft.AspNetCore.Identity": "Error"
       }
     },
+    "Using": [ "Serilog.Expressions" ],
+    "Filter": [
+      {
+        "Name": "ByExcluding",
+        "Args": { "expression": "EventId.Id = 1005 and SourceContext = 'WebOptimizer.AssetBuilder'" }
+      }
+    ],
     "WriteTo": [
       { "Name": "Console" },
       {


### PR DESCRIPTION
Our site logs are full of people accessing js files that do not exist. Some are probably automated exploit-searching bots, some are webcrawlers on old versions of the site.

For some inexplicable reason, WebOptimizer logs these situations as [warning logs](https://github.com/puhnastik/WebOptimizer/blob/a1cb720241120cb569abaa6d49475b87dde0f75a/src/WebOptimizer.Core/Extensions/LoggerExtensions.cs#L29), which is really weird. Even native ASP.NET Core merely uses [debug logs](https://github.com/dotnet/aspnetcore/blob/cd5ca6985645aa4929747bd690109a99a97126e3/src/Middleware/StaticFiles/src/LoggerExtensions.cs#L38) for files not found.

In any case, they're not useful and are polluting our site logs. So this PR disables these log events via Serilog Expressions.