### PR TITLE
Fix regression in pubs RSS feed

### DIFF
--- a/TASVideos/Pages/RssFeeds/Publications.cshtml
+++ b/TASVideos/Pages/RssFeeds/Publications.cshtml
@@ -25,7 +25,7 @@
 						<wiki-markup markup="@pub.Wiki?.Markup" page-data="@pub.Wiki"></wiki-markup>
 					</html-encode>
 				</description>
-				@foreach (var tag in pub.Categories)
+				@foreach (var tag in pub.TagNames)
 				{
 					<category>@tag</category>
 				}

--- a/TASVideos/Pages/RssFeeds/Publications.cshtml.cs
+++ b/TASVideos/Pages/RssFeeds/Publications.cshtml.cs
@@ -17,9 +17,7 @@ public class PublicationsModel(ApplicationDbContext db, IWikiPages wikiPages) : 
 				p.MovieFile.Length,
 				p.CreateTimestamp,
 				p.Title,
-				p.PublicationFlags.Select(pf => pf.Flag!.Token)
-					.Concat(p.PublicationTags.Select(pt => pt.Tag!.DisplayName))
-					.ToList(),
+				p.PublicationTags.Select(pt => pt.Tag!.DisplayName).ToList(),
 				p.Files
 					.Select(pf => new PubFile(pf.Path, pf.Type))
 					.ToList(),
@@ -42,7 +40,7 @@ public class PublicationsModel(ApplicationDbContext db, IWikiPages wikiPages) : 
 	}
 
 	public record RssPublication(
-		int Id, int MovieFileSize, DateTime CreateTimestamp, string Title, List<string> Categories, List<PubFile> Files, List<string> StreamingUrls, List<double> Ratings)
+		int Id, int MovieFileSize, DateTime CreateTimestamp, string Title, List<string> TagNames, List<PubFile> Files, List<string> StreamingUrls, List<double> Ratings)
 	{
 		public IWikiPage? Wiki { get; set; }
 		public string ScreenshotPath => Files.First(f => f.Type == FileType.Screenshot).Path;


### PR DESCRIPTION
`/publications.rss` is currently a 500:
```
System.InvalidOperationException: Unable to translate a collection subquery in a projection since either parent or the subquery doesn't project necessary information required to uniquely identify it and correctly generate results on the client side. This can happen when trying to correlate on keyless entity type. This can also happen for some cases of projection before 'Distinct' or some shapes of grouping key in case of 'GroupBy'. These should either contain all key properties of the entity that the operation is applied on, or only contain simple property access expressions.
   at Microsoft.EntityFrameworkCore.Query.SqlExpressions.SelectExpression.ApplyProjection(Expression shaperExpression, ResultCardinality resultCardinality, QuerySplittingBehavior querySplittingBehavior)
   at Microsoft.EntityFrameworkCore.Query.Internal.SelectExpressionProjectionApplyingExpressionVisitor.VisitExtension(Expression extensionExpression)
   at Microsoft.EntityFrameworkCore.Query.RelationalQueryTranslationPostprocessor.Process(Expression query)
   at Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal.NpgsqlQueryTranslationPostprocessor.Process(Expression query)
   at Microsoft.EntityFrameworkCore.Query.QueryCompilationContext.CreateQueryExecutor[TResult](Expression query)
   at Microsoft.EntityFrameworkCore.Storage.Database.CompileQuery[TResult](Expression query, Boolean async)
   at Microsoft.EntityFrameworkCore.Query.Internal.QueryCompiler.CompileQueryCore[TResult](IDatabase database, Expression query, IModel model, Boolean async)
   at Microsoft.EntityFrameworkCore.Query.Internal.QueryCompiler.<>c__DisplayClass12_0`1.<ExecuteAsync>b__0()
   at Microsoft.EntityFrameworkCore.Query.Internal.CompiledQueryCache.GetOrAddQuery[TResult](Object cacheKey, Func`1 compiler)
   at Microsoft.EntityFrameworkCore.Query.Internal.QueryCompiler.ExecuteAsync[TResult](Expression query, CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryProvider.ExecuteAsync[TResult](Expression expression, CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1.GetAsyncEnumerator(CancellationToken cancellationToken)
   at System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable`1.GetAsyncEnumerator()
   at Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync[TSource](IQueryable`1 source, CancellationToken cancellationToken)
   at TASVideos.Pages.RssFeeds.PublicationsModel.OnGet() in /home/yoshi/Documents/tasvideos/TASVideos/Pages/RssFeeds/Publications.cshtml.cs:line 12
   at Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.ExecutorFactory.GenericTaskHandlerMethod.Convert[T](Object taskAsObject)
   at Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.ExecutorFactory.GenericTaskHandlerMethod.Execute(Object receiver, Object[] arguments)
   at Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.PageActionInvoker.InvokeHandlerMethodAsync()
   at Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.PageActionInvoker.InvokeNextPageFilterAsync()
   at Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.PageActionInvoker.Rethrow(PageHandlerExecutedContext context)
   at Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.PageActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.PageActionInvoker.InvokeInnerFilterAsync()
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|25_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|7_0(Endpoint endpoint, Task requestTask, ILogger logger)
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
   at TASVideos.Extensions.ApplicationBuilderExtensions.<>c__DisplayClass4_0.<<UseMvcWithOptions>b__0>d.MoveNext() in /home/yoshi/Documents/tasvideos/TASVideos/Extensions/ApplicationBuilderExtensions.cs:line 101
--- End of stack trace from previous location ---
   at Serilog.AspNetCore.RequestLoggingMiddleware.Invoke(HttpContext httpContext)
   at TASVideos.Middleware.CustomLocalizationMiddleware.Invoke(HttpContext context, ApplicationDbContext db, ICacheService cache) in /home/yoshi/Documents/tasvideos/TASVideos/Middleware/CustomLocalizationMiddleware.cs:line 44
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware.InvokeCore(HttpContext context)
   at Microsoft.AspNetCore.Localization.RequestLocalizationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddlewareImpl.<Invoke>g__Awaited|10_0(ExceptionHandlerMiddlewareImpl middleware, HttpContext context, Task task)
```