### PR TITLE
Change homepage link on edit history to profile link

### DIFF
--- a/TASVideos/Pages/Wiki/EditHistory.cshtml
+++ b/TASVideos/Pages/Wiki/EditHistory.cshtml
@@ -4,7 +4,7 @@
 	ViewData.SetTitle("Edit History For User " + Model.UserName);
 }
 
-<h4>Edits by <a href="@WikiEngine.Builtins.NormalizeInternalLink("/HomePages/" + Model.UserName)">@Model.UserName</a></h4>
+<h4>Edits by <profile-link username="@Model.UserName"></profile-link></h4>
 <standard-table>
 	<table-head columns="Page,Date,Minor Edit,Revision Message,Actions"></table-head>
 	@foreach (var revision in Model.History)


### PR DESCRIPTION
Small consistency change. Seems like only instance of linking to a homepage outside of explicit references to homepages.