### PR TITLE
Change libman provider

### DIFF
--- a/TASVideos/libman.json
+++ b/TASVideos/libman.json
@@ -3,7 +3,6 @@
   "defaultProvider": "cdnjs",
   "libraries": [
     {
-      "provider": "unpkg",
       "library": "bootstrap@5.3.1",
       "destination": "wwwroot/lib/bootstrap/",
       "files": [


### PR DESCRIPTION
So unpkg has suddenly changed its format and libman seems to run into problems loading the files (even newer versions of libman that should have adjusted to the unpkg change run into errors).
So instead we can use cdnjs which we already specified anyway.