### PR TITLE
Add Rater statistics and Top leaderboard

### DIFF
--- a/TASVideos.Common/Extensions/NumberExtensions.cs
+++ b/TASVideos.Common/Extensions/NumberExtensions.cs
@@ -62,4 +62,15 @@ public static class NumberExtensions
 	{
 		return Math.Round(overallRating, 2, MidpointRounding.AwayFromZero).ToString();
 	}
+
+	/// <summary>Displays a number between 0 and 1 as a percentage. It rounds down so that 0.999999 is not shown as 100%</summary>
+	public static string ToPercentage(this double ratio, int decimalPlaces = 0)
+	{
+		if (double.IsNaN(ratio) || double.IsInfinity(ratio))
+		{
+			return "n/a";
+		}
+
+		return (Math.Floor(ratio * 100 * Math.Pow(10, decimalPlaces)) / Math.Pow(10, decimalPlaces)).ToString($"F{decimalPlaces}") + "%";
+	}
 }

--- a/TASVideos.Core/Services/RatingService.cs
+++ b/TASVideos.Core/Services/RatingService.cs
@@ -115,6 +115,42 @@ internal class RatingService(ApplicationDbContext db) : IRatingService
 			})
 			.SortedPageOf(paging);
 
+		dto.RatingsCount = await db.PublicationRatings
+			.ForUser(dto.Id)
+			.IncludeObsolete(false)
+			.CountAsync();
+
+		dto.Summary.TotalPublicationCount = await db.Publications
+			.ThatAreCurrent()
+			.CountAsync();
+
+		var allTopRaters = await db.PublicationRatings
+			.IncludeObsolete(false)
+			.GroupBy(pr => pr.User)
+			.Select(group => new
+			{
+				group.Key!.UserName,
+				RatingsCount = group.Count()
+			})
+			.OrderByDescending(tr => tr.RatingsCount)
+			.ToListAsync();
+
+		dto.Summary.TopRaters = allTopRaters
+			.GroupBy(tr => tr.RatingsCount)
+			.Select(group => new UserRatings.RatingSummary.TopRaterEntry
+			{
+				RatingsCount = group.Key,
+				UserNames = group.Select(tr => tr.UserName).OrderBy(userName => userName).ToList()
+			})
+			.OrderByDescending(group => group.RatingsCount)
+			.Take(30)
+			.ToList();
+
+		dto.Summary.TotalRaterCount = allTopRaters.Count;
+		dto.UsersWithLowerRatingsCount = allTopRaters.Count(tr => tr.RatingsCount < dto.RatingsCount);
+		dto.UsersWithEqualRatingsCount = allTopRaters.Count(tr => tr.RatingsCount == dto.RatingsCount) - 1; // subtract the user themself
+		dto.UsersWithHigherRatingsCount = allTopRaters.Count(tr => tr.RatingsCount > dto.RatingsCount);
+
 		return dto;
 	}
 }
@@ -129,6 +165,12 @@ public class UserRatings
 
 	public PageOf<Rating, RatingRequest> Ratings { get; set; } = new([], new());
 
+	public RatingSummary Summary { get; set; } = new();
+	public int RatingsCount { get; set; }
+	public int UsersWithLowerRatingsCount { get; set; }
+	public int UsersWithEqualRatingsCount { get; set; }
+	public int UsersWithHigherRatingsCount { get; set; }
+
 	public class Rating
 	{
 		[TableIgnore]
@@ -142,6 +184,19 @@ public class UserRatings
 
 		[Sortable]
 		public bool IsObsolete { get; init; }
+	}
+
+	public class RatingSummary
+	{
+		public List<TopRaterEntry> TopRaters { get; set; } = [];
+		public int TotalRaterCount { get; set; }
+		public int TotalPublicationCount { get; set; }
+
+		public class TopRaterEntry
+		{
+			public int RatingsCount { get; set; }
+			public List<string> UserNames { get; set; } = [];
+		}
 	}
 }
 

--- a/TASVideos.Core/Services/RatingService.cs
+++ b/TASVideos.Core/Services/RatingService.cs
@@ -148,7 +148,7 @@ internal class RatingService(ApplicationDbContext db) : IRatingService
 
 		dto.Summary.TotalRaterCount = allTopRaters.Count;
 		dto.UsersWithLowerRatingsCount = allTopRaters.Count(tr => tr.RatingsCount < dto.RatingsCount);
-		dto.UsersWithEqualRatingsCount = allTopRaters.Count(tr => tr.RatingsCount == dto.RatingsCount) - 1; // subtract the user themself
+		dto.UsersWithEqualRatingsCount = dto.RatingsCount == 0 ? 0 : allTopRaters.Count(tr => tr.RatingsCount == dto.RatingsCount) - 1; // subtract the user themself
 		dto.UsersWithHigherRatingsCount = allTopRaters.Count(tr => tr.RatingsCount > dto.RatingsCount);
 
 		return dto;

--- a/TASVideos.Core/Services/RatingService.cs
+++ b/TASVideos.Core/Services/RatingService.cs
@@ -98,23 +98,6 @@ internal class RatingService(ApplicationDbContext db) : IRatingService
 			return null;
 		}
 
-		if (!dto.PublicRatings && !includeHidden)
-		{
-			return dto;
-		}
-
-		dto.Ratings = await db.PublicationRatings
-			.ForUser(dto.Id)
-			.IncludeObsolete(paging.IncludeObsolete)
-			.Select(pr => new UserRatings.Rating
-			{
-				PublicationId = pr.PublicationId,
-				PublicationTitle = pr.Publication!.Title,
-				IsObsolete = pr.Publication.ObsoletedById.HasValue,
-				Value = pr.Value
-			})
-			.SortedPageOf(paging);
-
 		dto.RatingsCount = await db.PublicationRatings
 			.ForUser(dto.Id)
 			.IncludeObsolete(false)
@@ -150,6 +133,23 @@ internal class RatingService(ApplicationDbContext db) : IRatingService
 		dto.UsersWithLowerRatingsCount = allTopRaters.Count(tr => tr.RatingsCount < dto.RatingsCount);
 		dto.UsersWithEqualRatingsCount = dto.RatingsCount == 0 ? 0 : allTopRaters.Count(tr => tr.RatingsCount == dto.RatingsCount) - 1; // subtract the user themself
 		dto.UsersWithHigherRatingsCount = allTopRaters.Count(tr => tr.RatingsCount > dto.RatingsCount);
+
+		if (!dto.PublicRatings && !includeHidden)
+		{
+			return dto;
+		}
+
+		dto.Ratings = await db.PublicationRatings
+			.ForUser(dto.Id)
+			.IncludeObsolete(paging.IncludeObsolete)
+			.Select(pr => new UserRatings.Rating
+			{
+				PublicationId = pr.PublicationId,
+				PublicationTitle = pr.Publication!.Title,
+				IsObsolete = pr.Publication.ObsoletedById.HasValue,
+				Value = pr.Value
+			})
+			.SortedPageOf(paging);
 
 		return dto;
 	}

--- a/TASVideos/Pages/Shared/_Ratings.cshtml
+++ b/TASVideos/Pages/Shared/_Ratings.cshtml
@@ -2,7 +2,40 @@
 @{
 	var isMyPage = User.GetUserId() == Model.Id;
 	ViewData.SetTitle($"Ratings for {Model.UserName}");
+	string userHasString = isMyPage ? "You have" : "User has";
+	int totalUserRatingsCountWithoutOwn = Model.UsersWithLowerRatingsCount + Model.UsersWithEqualRatingsCount + Model.UsersWithHigherRatingsCount;
 }
+<h4>Summary</h4>
+<p>
+	@userHasString rated @(((double)(Model.RatingsCount) / Model.Summary.TotalPublicationCount).ToPercentage(1)) (@Model.RatingsCount of @Model.Summary.TotalPublicationCount) of all non-obsoleted published movies.
+	<br />
+	@userHasString rated more movies than @(((double)(Model.UsersWithLowerRatingsCount) / totalUserRatingsCountWithoutOwn).ToPercentage(1)) of users,
+	and less than @(((double)(Model.UsersWithHigherRatingsCount) / totalUserRatingsCountWithoutOwn).ToPercentage(1)) of users.
+	(@(((double)(Model.UsersWithEqualRatingsCount) / totalUserRatingsCountWithoutOwn).ToPercentage(1)) same.)
+	<br />
+	The raters' top-30 (out of @Model.Summary.TotalRaterCount users who have rated):
+</p>
+<ol style="column-width: 11rem; column-count: 3;">
+	@{
+		int rank = 1;
+	}
+	@foreach (var topRater in Model.Summary.TopRaters)
+	{
+		<li value="@rank">
+			@(((double)(topRater.RatingsCount) / Model.Summary.TotalPublicationCount).ToPercentage(1)):
+			@foreach (var userName in topRater.UserNames)
+			{
+				@(userName == topRater.UserNames.First() ? "" : "&")
+				<a asp-page="/Users/Ratings" asp-route-username="@userName">@userName</a>
+			}
+		</li>
+		rank += topRater.UserNames.Count;
+		if (rank > 30)
+		{
+			break;
+		}
+	}
+</ol>
 <h4 condition="!isMyPage">User: <profile-link username="@Model.UserName"></profile-link></h4>
 <div condition="isMyPage && !Model.PublicRatings" class="alert alert-warning">
 	Your ratings are currently private and will not be visible to others. This can be changed on the

--- a/TASVideos/Pages/Shared/_Ratings.cshtml
+++ b/TASVideos/Pages/Shared/_Ratings.cshtml
@@ -45,7 +45,7 @@
 	<div class="alert alert-warning">This user's ratings are private</div>
 </div>
 <div condition="isMyPage || Model.PublicRatings || User.Has(PermissionTo.SeePrivateRatings)">
-	<warning-alert condition="!isMyPage && User.Has(PermissionTo.SeePrivateRatings)">
+	<warning-alert condition="!isMyPage && !Model.PublicRatings && User.Has(PermissionTo.SeePrivateRatings)">
 		This user has elected to keep their ratings private. You are seeing this because you have the @nameof(PermissionTo.SeePrivateRatings) permission
 	</warning-alert>
 	<form id="obsolete-form">

--- a/tests/TASVideos.Common.Tests/Extensions/NumberExtensions.cs
+++ b/tests/TASVideos.Common.Tests/Extensions/NumberExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.InteropServices;
-using TASVideos.Extensions;
+﻿using TASVideos.Extensions;
 
 namespace TASVideos.Common.Tests.Extensions;
 

--- a/tests/TASVideos.Common.Tests/Extensions/NumberExtensions.cs
+++ b/tests/TASVideos.Common.Tests/Extensions/NumberExtensions.cs
@@ -1,4 +1,5 @@
-﻿using TASVideos.Extensions;
+﻿using System.Runtime.InteropServices;
+using TASVideos.Extensions;
 
 namespace TASVideos.Common.Tests.Extensions;
 
@@ -45,6 +46,20 @@ public class NumberExtensions
 	public void ToSizeString(int byteCount, string expected)
 	{
 		var actual = byteCount.ToSizeString();
+		Assert.AreEqual(expected, actual);
+	}
+
+	[TestMethod]
+	[DataRow(0, 0, "0%")]
+	[DataRow(1, 0, "100%")]
+	[DataRow(double.NaN, 0, "n/a")]
+	[DataRow(double.PositiveInfinity, 0, "n/a")]
+	[DataRow(double.NegativeInfinity, 0, "n/a")]
+	[DataRow(0.4567, 1, "45.6%")]
+	[DataRow(0.99999, 1, "99.9%")]
+	public void ToPercentage(double ratio, int decimalPlaces, string expected)
+	{
+		var actual = ratio.ToPercentage(decimalPlaces);
 		Assert.AreEqual(expected, actual);
 	}
 }

--- a/tests/TASVideos.Core.Tests/Services/RatingServiceTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/RatingServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿using TASVideos.Data;
 using TASVideos.Data.Entity;
-using ZstdSharp.Unsafe;
 
 namespace TASVideos.Core.Tests.Services;
 

--- a/tests/TASVideos.Core.Tests/Services/RatingServiceTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/RatingServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using TASVideos.Data;
 using TASVideos.Data.Entity;
+using ZstdSharp.Unsafe;
 
 namespace TASVideos.Core.Tests.Services;
 
@@ -304,5 +305,39 @@ public class RatingServiceTests : TestDbBase
 		var actual = await _ratingService.GetUserRatings(userName, new RatingRequest { IncludeObsolete = true });
 		Assert.IsNotNull(actual);
 		Assert.AreEqual(2, actual.Ratings.RowCount);
+	}
+
+	[TestMethod]
+	public async Task GetUserRatings_Summary_ReturnsSensibleValues()
+	{
+		var userA = _db.AddUser("A").Entity;
+		var userB = _db.AddUser("B").Entity;
+		var userC = _db.AddUser("C").Entity;
+		var userD = _db.AddUser("D").Entity;
+		_db.AddUser("E");
+		var pub1 = _db.AddPublication().Entity;
+		var pub2 = _db.AddPublication().Entity;
+		var pub3 = _db.AddPublication().Entity;
+		_db.PublicationRatings.Add(new PublicationRating { Publication = pub1, User = userA });
+		_db.PublicationRatings.Add(new PublicationRating { Publication = pub2, User = userA });
+		_db.PublicationRatings.Add(new PublicationRating { Publication = pub3, User = userA });
+
+		_db.PublicationRatings.Add(new PublicationRating { Publication = pub1, User = userB });
+		_db.PublicationRatings.Add(new PublicationRating { Publication = pub2, User = userB });
+
+		_db.PublicationRatings.Add(new PublicationRating { Publication = pub1, User = userC });
+		_db.PublicationRatings.Add(new PublicationRating { Publication = pub2, User = userC });
+
+		_db.PublicationRatings.Add(new PublicationRating { Publication = pub1, User = userD });
+		await _db.SaveChangesAsync();
+
+		var actual = await _ratingService.GetUserRatings(userB.UserName, new RatingRequest());
+		Assert.IsNotNull(actual);
+		Assert.AreEqual(3, actual.Summary.TotalPublicationCount);
+		Assert.AreEqual(4, actual.Summary.TotalRaterCount);
+		Assert.AreEqual(2, actual.RatingsCount);
+		Assert.AreEqual(1, actual.UsersWithHigherRatingsCount);
+		Assert.AreEqual(1, actual.UsersWithEqualRatingsCount);
+		Assert.AreEqual(1, actual.UsersWithLowerRatingsCount);
 	}
 }


### PR DESCRIPTION
Resolves #864 .

Adds back the rating comparison with other users and also the top 30 list. This will appear on your own rating page `/Profile/Ratings` and also on all user rating pages e.g. `/Users/Ratings/Memory`.

These statistics are only based on the rating count, so they will show up and users will be counted no matter whether they have public ratings enabled or not.

![image](https://github.com/user-attachments/assets/8a8f4405-222d-4f19-b41b-e8d52e67a602)

