### PR TITLE
Add a custom Metric of User Agent counts

### DIFF
--- a/TASVideos/Extensions/ServiceCollectionExtensions.cs
+++ b/TASVideos/Extensions/ServiceCollectionExtensions.cs
@@ -193,11 +193,15 @@ public static class ServiceCollectionExtensions
 							Boundaries = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]
 						});
 
+					builder.AddMeter("TASVideos");
+
 					builder.AddPrometheusExporter(options =>
 					{
 						options.ScrapeEndpointPath = "/Metrics";
 					});
 				});
+
+			services.AddSingleton<TASVideosMetrics>();
 		}
 
 		return services;

--- a/TASVideos/Extensions/ServiceCollectionExtensions.cs
+++ b/TASVideos/Extensions/ServiceCollectionExtensions.cs
@@ -201,7 +201,11 @@ public static class ServiceCollectionExtensions
 					});
 				});
 
-			services.AddSingleton<TASVideosMetrics>();
+			services.AddSingleton<ITASVideosMetrics, TASVideosMetrics>();
+		}
+		else
+		{
+			services.AddSingleton<ITASVideosMetrics, NullMetrics>();
 		}
 
 		return services;

--- a/TASVideos/Middleware/UserAgentMetricsMiddleware.cs
+++ b/TASVideos/Middleware/UserAgentMetricsMiddleware.cs
@@ -1,0 +1,26 @@
+﻿using TASVideos.Core.Settings;
+
+namespace TASVideos.Middleware;
+
+public class UserAgentMetricsMiddleware(RequestDelegate next)
+{
+	public async Task Invoke(HttpContext context, TASVideosMetrics metrics)
+	{
+		metrics.AddUserAgent(context.Request.Headers.UserAgent);
+
+		await next(context);
+	}
+}
+
+public static class UserAgentMetricsMiddlewareExtensions
+{
+	public static IApplicationBuilder UseUserAgentMetrics(this IApplicationBuilder app, AppSettings settings)
+	{
+		if (settings.EnableMetrics)
+		{
+			return app.UseMiddleware<UserAgentMetricsMiddleware>();
+		}
+
+		return app;
+	}
+}

--- a/TASVideos/Middleware/UserAgentMetricsMiddleware.cs
+++ b/TASVideos/Middleware/UserAgentMetricsMiddleware.cs
@@ -4,7 +4,7 @@ namespace TASVideos.Middleware;
 
 public class UserAgentMetricsMiddleware(RequestDelegate next)
 {
-	public async Task Invoke(HttpContext context, TASVideosMetrics metrics)
+	public async Task Invoke(HttpContext context, ITASVideosMetrics metrics)
 	{
 		metrics.AddUserAgent(context.Request.Headers.UserAgent);
 

--- a/TASVideos/Program.cs
+++ b/TASVideos/Program.cs
@@ -60,6 +60,7 @@ app
 	.UseExceptionHandlers(app.Environment)
 	.UseTasvideosApiEndpoints(builder.Environment)
 	.UseRobots()
+	.UseUserAgentMetrics(settings)
 	.UseMiddleware<HtmlRedirectionMiddleware>()
 	.UseRequestLocalization()
 	.UseGzipCompression(settings)

--- a/TASVideos/Services/TASVideosMetrics.cs
+++ b/TASVideos/Services/TASVideosMetrics.cs
@@ -2,7 +2,19 @@
 
 namespace TASVideos.Services;
 
-public class TASVideosMetrics
+public interface ITASVideosMetrics
+{
+	public void AddUserAgent(string? userAgent);
+}
+
+public class NullMetrics : ITASVideosMetrics
+{
+	public void AddUserAgent(string? userAgent)
+	{
+	}
+}
+
+public class TASVideosMetrics : ITASVideosMetrics
 {
 	private readonly Counter<long> _userAgentCounter;
 

--- a/TASVideos/Services/TASVideosMetrics.cs
+++ b/TASVideos/Services/TASVideosMetrics.cs
@@ -1,0 +1,19 @@
+﻿using System.Diagnostics.Metrics;
+
+namespace TASVideos.Services;
+
+public class TASVideosMetrics
+{
+	private readonly Counter<long> _userAgentCounter;
+
+	public TASVideosMetrics(IMeterFactory meterFactory)
+	{
+		var meter = meterFactory.Create("TASVideos");
+		_userAgentCounter = meter.CreateCounter<long>("tasvideos.useragent.count");
+	}
+
+	public void AddUserAgent(string? userAgent)
+	{
+		_userAgentCounter.Add(1, new KeyValuePair<string, object?>("user_agent", userAgent));
+	}
+}


### PR DESCRIPTION
This PR adds a custom metric, as instructed by the [Microsoft docs](https://learn.microsoft.com/en-us/aspnet/core/log-mon/metrics/metrics?view=aspnetcore-8.0#create-custom-metrics).

The reason for this PR is mostly to gain information whether there is anything abnormal going on with the requests. For example [this blog article](https://thelibre.news/foss-infrastructure-is-under-attack-by-ai-companies/) talks about their site and about "70% of the entire requests being from AI companies".

The data is part of the opentelemetry metrics, and it's all in memory, so will always be reset when we redeploy.

I placed the middleware after the robots.txt middleware. I think this is also after the API middleware, so this only counts requests that are neither API, nor robots.txt.

The resulting metrics look like this:

```
# TYPE tasvideos_useragent_count_total counter
tasvideos_useragent_count_total{otel_scope_name="TASVideos",user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:136.0) Gecko/20100101 Firefox/136.0"} 52 1742941315609
tasvideos_useragent_count_total{otel_scope_name="TASVideos",user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"} 10 1742941315609
```