### PR TITLE
Replace Gravatar with Libravatar (ivatar)

### DIFF
--- a/TASVideos.Common/Constants.cs
+++ b/TASVideos.Common/Constants.cs
@@ -81,7 +81,7 @@ public static class SiteGlobalConstants
 
 	public const int YearsOfBanDisplayedAsIndefinite = 2;
 
-	public const string MainGravatarDomain = "gravatar.com"; // keep in sync with profile-settings.js
+	public const string MainIvatarDomain = "gravatar.com"; // keep in sync with profile-settings.js
 }
 
 public static class ForumConstants

--- a/TASVideos.Common/Constants.cs
+++ b/TASVideos.Common/Constants.cs
@@ -80,6 +80,8 @@ public static class SiteGlobalConstants
 	public const int MetaDescriptionLength = 350;
 
 	public const int YearsOfBanDisplayedAsIndefinite = 2;
+
+	public const string MainGravatarDomain = "gravatar.com"; // keep in sync with profile-settings.js
 }
 
 public static class ForumConstants

--- a/TASVideos.Common/Constants.cs
+++ b/TASVideos.Common/Constants.cs
@@ -81,7 +81,7 @@ public static class SiteGlobalConstants
 
 	public const int YearsOfBanDisplayedAsIndefinite = 2;
 
-	public const string MainIvatarDomain = "gravatar.com"; // keep in sync with profile-settings.js
+	public const string MainIvatarDomain = "seccdn.libravatar.org"; // keep in sync with profile-settings.js
 }
 
 public static class ForumConstants

--- a/TASVideos/Pages/Profile/Settings.cshtml
+++ b/TASVideos/Pages/Profile/Settings.cshtml
@@ -7,7 +7,7 @@
 	const string ratingsFalseId = nameof(Model.PublicRatings) + "-false";
 	const string emailOnPmTrueId = nameof(Model.EmailOnPrivateMessage) + "-true";
 	const string emailOnPmFalseId = nameof(Model.EmailOnPrivateMessage) + "-false";
-	var usingGravatar = Model.AvatarUrl?.Contains($"//{SiteGlobalConstants.MainGravatarDomain}/") ?? false;
+	var usingIvatar = Model.AvatarUrl?.Contains($"//{SiteGlobalConstants.MainIvatarDomain}/") ?? false;
 }
 
 <form client-side-validation="true" method="post">
@@ -116,19 +116,19 @@
 		</column>
 	</row>
 	<hr />
-	<label>Use Gravatar</label>
+	<label>Use ivatar (Gravatar)</label>
 	<div class="btn-group btn-group-toggle" data-bs-toggle="buttons">
-		<label class="btn btn-secondary @(usingGravatar ? "active" : "")">
-			<input id="UseGravatar-true" type="radio" value="True" name="UseGravatar" @(usingGravatar ? "checked" : "") /> Yes
+		<label class="btn btn-secondary @(usingIvatar ? "active" : "")">
+			<input id="UseIvatar-true" type="radio" value="True" name="UseIvatar" @(usingIvatar ? "checked" : "") /> Yes
 		</label>
-		<label class="btn btn-secondary" value="True"  @(!usingGravatar ? "active" : "")>
-			<input id="UseGravatar-false" type="radio" value="False" name="UseGravatar" @(!usingGravatar ? "checked" : "") /> No
+		<label class="btn btn-secondary" value="True"  @(!usingIvatar ? "active" : "")>
+			<input id="UseIvatar-false" type="radio" value="False" name="UseIvatar" @(!usingIvatar ? "checked" : "") /> No
 		</label>
 	</div>
-	<div class="mt-3" id="gravatar-section">
+	<div class="mt-3" id="ivatar-section">
 		<fieldset>
-			<label>Email to Use for Gravatar Image</label>
-			<input id="gravatar-email" class="form-control" />
+			<label>Email to Use for ivatar Lookup</label>
+			<input id="ivatar-email" class="form-control" />
 		</fieldset>
 	</div>
 	<fullrow class="mt-3">

--- a/TASVideos/Pages/Profile/Settings.cshtml
+++ b/TASVideos/Pages/Profile/Settings.cshtml
@@ -130,6 +130,10 @@
 			<label>Email to Use for ivatar Lookup</label>
 			<input id="ivatar-email" class="form-control" />
 		</fieldset>
+		<small>
+			This address will be used for the hash below.
+			<br>We currently won't honor any server choice in DNS&mdash;if you don't want to use Libravatar/Gravatar, manually set the relevant URL.
+		</small>
 	</div>
 	<fullrow class="mt-3">
 		<label asp-for="AvatarUrl"></label>

--- a/TASVideos/Pages/Profile/Settings.cshtml
+++ b/TASVideos/Pages/Profile/Settings.cshtml
@@ -7,7 +7,7 @@
 	const string ratingsFalseId = nameof(Model.PublicRatings) + "-false";
 	const string emailOnPmTrueId = nameof(Model.EmailOnPrivateMessage) + "-true";
 	const string emailOnPmFalseId = nameof(Model.EmailOnPrivateMessage) + "-false";
-	bool usingGravatar = Model.AvatarUrl?.Contains("gravatar") ?? false;
+	var usingGravatar = Model.AvatarUrl?.Contains($"//{SiteGlobalConstants.MainGravatarDomain}/") ?? false;
 }
 
 <form client-side-validation="true" method="post">

--- a/TASVideos/wwwroot/js/profile-settings.js
+++ b/TASVideos/wwwroot/js/profile-settings.js
@@ -1,4 +1,7 @@
-﻿let emailBoxElem = document.querySelector('[data-email-box]');
+﻿const mainGravatarDomain = "gravatar.com";
+const noAvatarImagePath = "/images/empty.png";
+
+let emailBoxElem = document.querySelector('[data-email-box]');
 
 let avatarBoxElem = document.querySelector('[data-avatar-box]');
 let gravatarBoxElem = document.getElementById('gravatar-email');
@@ -6,11 +9,11 @@ let gravatarBoxElem = document.getElementById('gravatar-email');
 document.addEventListener("DOMContentLoaded", validateAvatar);
 document.addEventListener("DOMContentLoaded", onGravatarToggle);
 avatarBoxElem.addEventListener('input', generateAvatarPreview);
-document.getElementById('gravatar-email').addEventListener('input', generateGravatarPreview)
+gravatarBoxElem.addEventListener('input', generateGravatarPreview);
 let avatarImgElem = document.getElementById('avatar-img');
 avatarImgElem.onload = validateAvatar;
 avatarImgElem.onerror = () => {
-    avatarImgElem.src = '/images/empty.png'
+    avatarImgElem.src = noAvatarImagePath;
 };
 Array.from(document.querySelectorAll('[name="UseGravatar"]')).forEach(elem => elem.addEventListener('click', onGravatarToggle));
 
@@ -46,7 +49,7 @@ function preventSave(prevent) {
 }
 
 function avatarIsGravatar() {
-    return avatarBoxElem.value?.includes('gravatar');
+    return avatarBoxElem.value?.includes(`//${mainGravatarDomain}/`);
 }
 
 async function onGravatarToggle() {
@@ -84,7 +87,7 @@ async function getGravatarUrl(boxElem) {
     }
 
     const hash = await createSha256(email);
-    return `https://gravatar.com/avatar/${hash}`;
+    return `https://${mainGravatarDomain}/avatar/${hash}?d=${noAvatarImagePath}`;
 }
 
 async function createSha256(string) {

--- a/TASVideos/wwwroot/js/profile-settings.js
+++ b/TASVideos/wwwroot/js/profile-settings.js
@@ -1,21 +1,21 @@
-﻿const mainGravatarDomain = "gravatar.com";
+﻿const mainIvatarDomain = "gravatar.com";
 const noAvatarImagePath = "/images/empty.png";
 
 let emailBoxElem = document.querySelector('[data-email-box]');
 
 let avatarBoxElem = document.querySelector('[data-avatar-box]');
-let gravatarBoxElem = document.getElementById('gravatar-email');
+let ivatarBoxElem = document.getElementById('ivatar-email');
 
 document.addEventListener("DOMContentLoaded", validateAvatar);
-document.addEventListener("DOMContentLoaded", onGravatarToggle);
+document.addEventListener("DOMContentLoaded", onIvatarToggle);
 avatarBoxElem.addEventListener('input', generateAvatarPreview);
-gravatarBoxElem.addEventListener('input', generateGravatarPreview);
+ivatarBoxElem.addEventListener('input', generateIvatarPreview);
 let avatarImgElem = document.getElementById('avatar-img');
 avatarImgElem.onload = validateAvatar;
 avatarImgElem.onerror = () => {
     avatarImgElem.src = noAvatarImagePath;
 };
-Array.from(document.querySelectorAll('[name="UseGravatar"]')).forEach(elem => elem.addEventListener('click', onGravatarToggle));
+Array.from(document.querySelectorAll('[name="UseIvatar"]')).forEach(elem => elem.addEventListener('click', onIvatarToggle));
 
 function generateAvatarPreview() {
     const avatar = avatarBoxElem.value;
@@ -48,31 +48,31 @@ function preventSave(prevent) {
     document.getElementById('submit-btn').disabled = prevent;
 }
 
-function avatarIsGravatar() {
-    return avatarBoxElem.value?.includes(`//${mainGravatarDomain}/`);
+function avatarIsIvatar() {
+    return avatarBoxElem.value?.includes(`//${mainIvatarDomain}/`);
 }
 
-async function onGravatarToggle() {
-    const checked = document.querySelector('[name="UseGravatar"]:checked').value == 'True';
+async function onIvatarToggle() {
+    const checked = document.querySelector('[name="UseIvatar"]:checked').value == 'True';
     if (checked) {
-        document.getElementById('gravatar-section').classList.remove('d-none');
+        document.getElementById('ivatar-section').classList.remove('d-none');
         console.log('profile email value', emailBoxElem.value)
-        const profileEmailGravatarValue = await getGravatarUrl(emailBoxElem);
-        console.log('gravatar generated from email value', profileEmailGravatarValue)
-        if (avatarIsGravatar() && profileEmailGravatarValue != avatarBoxElem.value) {
-            gravatarBoxElem.value = '';
+        const profileEmailIvatarValue = await getIvatarUrl(emailBoxElem);
+        console.log('Ivatar generated from email value', profileEmailIvatarValue)
+        if (avatarIsIvatar() && profileEmailIvatarValue != avatarBoxElem.value) {
+            ivatarBoxElem.value = '';
         } else {
-            gravatarBoxElem.value = emailBoxElem.value;
+            ivatarBoxElem.value = emailBoxElem.value;
         }
 
-        await generateGravatarPreview();
+        await generateIvatarPreview();
     } else {
-        document.getElementById('gravatar-section').classList.add('d-none');
+        document.getElementById('ivatar-section').classList.add('d-none');
     }
 }
 
-async function generateGravatarPreview() {
-    const url = await getGravatarUrl(gravatarBoxElem);
+async function generateIvatarPreview() {
+    const url = await getIvatarUrl(ivatarBoxElem);
     if (url) {
         avatarBoxElem.value = url;
     }
@@ -80,14 +80,14 @@ async function generateGravatarPreview() {
     generateAvatarPreview();
 }
 
-async function getGravatarUrl(boxElem) {
+async function getIvatarUrl(boxElem) {
     const email = boxElem?.value.toLowerCase();
     if (!email) {
         return;
     }
 
     const hash = await createSha256(email);
-    return `https://${mainGravatarDomain}/avatar/${hash}?d=${noAvatarImagePath}`;
+    return `https://${mainIvatarDomain}/avatar/${hash}?d=${noAvatarImagePath}`;
 }
 
 async function createSha256(string) {

--- a/TASVideos/wwwroot/js/profile-settings.js
+++ b/TASVideos/wwwroot/js/profile-settings.js
@@ -1,4 +1,4 @@
-﻿const mainIvatarDomain = "gravatar.com";
+﻿const mainIvatarDomain = "seccdn.libravatar.org";
 const noAvatarImagePath = "/images/empty.png";
 
 let emailBoxElem = document.querySelector('[data-email-box]');


### PR DESCRIPTION
It's the same but theoretically decentralised, except IDK how to make DNS queries from a Razor Page and approximately 0 people will have that set up, so I just left it and told the user to do it themself.

Mass-rename is a bit noisy but I figured it would be confusing to leave references to Gravatar everywhere.

Should this be rejected: Should take the `//gravatar.com/` change and the `d=` change, and also need to set `r=pg` (latter does not apply to ivatar hence it's not in this PR).