### PR TITLE
Subtract 1 from FPS for Hourglass WTF parser

### DIFF
--- a/TASVideos.Parsers/Parsers/Wtf.cs
+++ b/TASVideos.Parsers/Parsers/Wtf.cs
@@ -22,10 +22,10 @@ internal class Wtf : Parser, IParser
 		br.ReadInt32(); // input frames
 		result.RerecordCount = br.ReadInt32();
 		br.ReadBytes(8); // keyboard type
-		var fps = br.ReadUInt32() - 1;
-		if (fps > 0)
+		var fps = br.ReadUInt32();
+		if (fps > 1)
 		{
-			result.FrameRateOverride = fps;
+			result.FrameRateOverride = fps - 1;
 		}
 
 		return await Task.FromResult(result);

--- a/TASVideos.Parsers/Parsers/Wtf.cs
+++ b/TASVideos.Parsers/Parsers/Wtf.cs
@@ -22,7 +22,7 @@ internal class Wtf : Parser, IParser
 		br.ReadInt32(); // input frames
 		result.RerecordCount = br.ReadInt32();
 		br.ReadBytes(8); // keyboard type
-		var fps = br.ReadUInt32();
+		var fps = br.ReadUInt32() - 1;
 		if (fps > 0)
 		{
 			result.FrameRateOverride = fps;

--- a/tests/TASVideos.MovieParsers.Tests/WtfTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/WtfTests.cs
@@ -68,7 +68,7 @@ public class WtfTests : BaseParserTests
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.IsNotNull(result.FrameRateOverride);
-		Assert.IsTrue(FrameRatesAreEqual(61, result.FrameRateOverride!.Value));
+		Assert.IsTrue(FrameRatesAreEqual(60, result.FrameRateOverride!.Value));
 	}
 
 	[TestMethod]


### PR DESCRIPTION
If I'm understanding correctly, Hourglass adds 1 to the FPS value before saving, and site doesn't account for this. There's only been a handful of submissions since the new site so it hasn't been very noticeable. Seems like this error originated in the [movie file format](https://code.google.com/archive/p/hourglass-win32/wikis/MovieFileFormat.wiki) page on Google Code.

https://github.com/TASEmulators/hourglass-win32/blob/78fa7c6d2be1b5eb46b8d4c0a37e56af616e1a46/src/wintaser/wintaser.cpp#L936
https://github.com/TASEmulators/hourglass-win32/blob/78fa7c6d2be1b5eb46b8d4c0a37e56af616e1a46/src/wintaser/wintaser.cpp#L1071