### PR TITLE
Use SharpCompress zip handling rather than BCL's zip handling

### DIFF
--- a/TASVideos.Parsers/Extensions/Extensions.cs
+++ b/TASVideos.Parsers/Extensions/Extensions.cs
@@ -1,4 +1,7 @@
-﻿namespace TASVideos.MovieParsers.Extensions;
+﻿using SharpZipArchive = SharpCompress.Archives.Zip.ZipArchive;
+using SharpZipArchiveEntry = SharpCompress.Archives.Zip.ZipArchiveEntry;
+
+namespace TASVideos.MovieParsers.Extensions;
 
 internal static class Extensions
 {
@@ -126,18 +129,28 @@ internal static class Extensions
 		return string.Equals(val, "true", StringComparison.InvariantCultureIgnoreCase);
 	}
 
+	public static async Task<SharpZipArchive> OpenZipArchiveRead(this Stream stream)
+	{
+		// A seekable stream is required for SharpZipArchive.Open
+		// Doing a copy here should be fairly cheap, and is fine for reading
+		// (This is normally done implicitly in BCL's ZipArchive ctor in Read mode)
+		var ms = new MemoryStream();
+		await stream.CopyToAsync(ms);
+		return SharpZipArchive.Open(ms);
+	}
+
 	/// <summary>
 	/// Gets a file that matches or starts with the given name
 	/// with a case-insensitive match.
 	/// </summary>
-	public static ZipArchiveEntry? Entry(this ZipArchive archive, string name)
+	public static SharpZipArchiveEntry? Entry(this SharpZipArchive archive, string name)
 	{
-		return archive.Entries.SingleOrDefault(e => e.Name.StartsWith(name, StringComparison.InvariantCultureIgnoreCase));
+		return archive.Entries.SingleOrDefault(e => e.Key.StartsWith(name, StringComparison.InvariantCultureIgnoreCase));
 	}
 
-	public static bool HasEntry(this ZipArchive archive, string name)
+	public static bool HasEntry(this SharpZipArchive archive, string name)
 	{
-		return archive.Entries.Any(e => string.Equals(e.Name, name, StringComparison.InvariantCultureIgnoreCase));
+		return archive.Entries.Any(e => string.Equals(e.Key, name, StringComparison.InvariantCultureIgnoreCase));
 	}
 
 	// Returns a boolean indicating whether the given git is set in the given byte

--- a/tests/TASVideos.MovieParsers.Tests/BaseParserTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/BaseParserTests.cs
@@ -1,5 +1,5 @@
-﻿using System.IO.Compression;
-using System.Reflection;
+﻿using System.Reflection;
+using SharpZipArchive = SharpCompress.Archives.Zip.ZipArchive;
 
 namespace TASVideos.MovieParsers.Tests;
 
@@ -27,18 +27,17 @@ public abstract class BaseParserTests
 		// in the real site will always be from within a zip file.
 		var ms = new MemoryStream();
 
-		using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, true))
+		using (var zip = SharpZipArchive.Create())
 		{
-			var entry = zip.CreateEntry("foobar");
-			using var dest = entry.Open();
-			input.CopyTo(dest);
+			zip.AddEntry("foobar", input, input.Length);
+			zip.SaveTo(ms);
 		}
 
 		ms.Position = 0;
 
-		var zip2 = new ZipArchive(ms);
-		var movieFile = zip2.Entries[0];
-		var movieFileStream = movieFile.Open();
+		var zip2 = SharpZipArchive.Open(ms);
+		var movieFile = zip2.Entries.First();
+		var movieFileStream = movieFile.OpenEntryStream();
 		return movieFileStream;
 	}
 


### PR DESCRIPTION
The BCL's zip handling is rather basic, only able to handle Deflate and Deflate64. Zips can use more compression formats than these. BCL does not implement support for these (although for BZip2 and LZMA are detected and explicitly named in unsupported exceptions), while SharpCompress supports many more compression formats.

In practice, this shouldn't really change too much, except it does end up allowing for pushing through much larger movies which need to be compressed with better formats (deflate is rather poor in this regard) in order to go below the current nginx 20MiB limit, including a currently accepted movie: https://tasvideos.org/9578S

(Alternatively, instead of doing this, just raising the nginx limit by like to 30MiBs or even 25MiBs could work)