### PR TITLE
Add crawl delay to robots.txt (unofficial, but some bots adhere to it)

### DIFF
--- a/TASVideos/Middleware/RobotHandlingMiddleware.cs
+++ b/TASVideos/Middleware/RobotHandlingMiddleware.cs
@@ -23,6 +23,7 @@ public class RobotHandlingMiddleware(RequestDelegate request, IHostEnvironment e
 						Disallow: /Wiki/PageNotFound
 						Disallow: /Wiki/Referrers
 						Disallow: /Wiki/ViewSource
+						Crawl-delay: 60
 
 						User-agent: Fasterfox
 						Disallow: /

--- a/TASVideos/Middleware/RobotHandlingMiddleware.cs
+++ b/TASVideos/Middleware/RobotHandlingMiddleware.cs
@@ -24,9 +24,6 @@ public class RobotHandlingMiddleware(RequestDelegate request, IHostEnvironment e
 						Disallow: /Wiki/Referrers
 						Disallow: /Wiki/ViewSource
 						Crawl-delay: 60
-
-						User-agent: Fasterfox
-						Disallow: /
 						""");
 		}
 		else


### PR DESCRIPTION
For bots following this directive, it limits the requests of bots to 60 seconds between requests.
Currently 94% of requests to our site are coming from bots. Maybe this will slow them down a bit.

The Crawl-delay directive is unofficial, but has an [entry on wikipedia](https://en.wikipedia.org/wiki/Robots.txt#Crawl-delay_directive).