### PR TITLE
Fix accidental AutoHistory nullable change

### DIFF
--- a/TASVideos.Data/AutoHistory/AutoHistoryEntry.cs
+++ b/TASVideos.Data/AutoHistory/AutoHistoryEntry.cs
@@ -5,7 +5,7 @@ public class AutoHistoryEntry
 	public int Id { get; set; }
 	public string RowId { get; set; } = "";
 	public string TableName { get; set; } = "";
-	public string Changed { get; set; } = "";
+	public string? Changed { get; set; }
 	public EntityState Kind { get; set; }
 	public DateTime Created { get; set; } = DateTime.UtcNow;
 	public int UserId { get; set; }

--- a/TASVideos/Pages/Logs/Index.cshtml.cs
+++ b/TASVideos/Pages/Logs/Index.cshtml.cs
@@ -26,7 +26,7 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 				UserName = user == null ? "Unknown_User" : user.UserName,
 				Created = g.h.Created,
 				TableName = g.h.TableName,
-				Changed = g.h.Changed,
+				Changed = g.h.Changed ?? "",
 				Kind = g.h.Kind
 			});
 


### PR DESCRIPTION
I missed this in my previous PR of the AutoHistory Rework #2120 .
I accidentally missed the AutoHistory manually configuring the nullability, so it generated a DB migration we don't want.
This PR fixes it, so we keep the same schema, so there is no DB migration generated.