### PR TITLE
Show banned users their ban info

### DIFF
--- a/TASVideos.Common/Constants.cs
+++ b/TASVideos.Common/Constants.cs
@@ -78,6 +78,8 @@ public static class SiteGlobalConstants
 	public const int OtherGamesForum = 5;
 
 	public const int MetaDescriptionLength = 350;
+
+	public const int YearsOfBanDisplayedAsIndefinite = 2;
 }
 
 public static class ForumConstants

--- a/TASVideos.Core/Services/JwtAuthenticator.cs
+++ b/TASVideos.Core/Services/JwtAuthenticator.cs
@@ -17,7 +17,7 @@ internal class JwtAuthenticator(SignInManager signInManager, AppSettings setting
 
 	public async Task<string> Authenticate(string userName, string password)
 	{
-		var (result, user) = await signInManager.SignIn(userName, password);
+		var (result, user, _) = await signInManager.SignIn(userName, password);
 		if (!result.Succeeded)
 		{
 			return "";

--- a/TASVideos.Core/Services/TagService.cs
+++ b/TASVideos.Core/Services/TagService.cs
@@ -180,7 +180,7 @@ public class UserProfile
 	public UserFileSummary UserFiles { get; init; } = new();
 	public int SubmissionCount => Submissions.Sum(s => s.Count);
 	public bool IsBanned => BannedUntil.HasValue && BannedUntil >= DateTime.UtcNow;
-	public bool BanIsIndefinite => BannedUntil >= DateTime.UtcNow.AddYears(2);
+	public bool BanIsIndefinite => BannedUntil >= DateTime.UtcNow.AddYears(SiteGlobalConstants.YearsOfBanDisplayedAsIndefinite);
 
 	public class SubmissionEntry
 	{

--- a/TASVideos/Constants.cs
+++ b/TASVideos/Constants.cs
@@ -18,6 +18,7 @@ public static class SystemWiki
 {
 	public const string ActivitySummary = "System/ActivitySummary";
 	public const string AvatarRequirements = "System/AvatarRequirements";
+	public const string BannedUserNotice = "System/BannedUserNotice";
 	public const string ClassEditingHelp = "System/ClassEditingHelp";
 	public const string EditMovieHeader = "System/EditMovieHeader";
 	public const string EmailConfirmationSentMessage = "System/EmailConfirmationSentMessage";

--- a/TASVideos/Pages/Account/Banned.cshtml
+++ b/TASVideos/Pages/Account/Banned.cshtml
@@ -1,0 +1,15 @@
+﻿@page
+@model TASVideos.Pages.Account.BannedModel
+@{
+	ViewData.SetTitle("Banned");
+}
+<p>
+	Your TASVideos account <strong>@Model.UserName</strong> is banned.
+</p>
+<p condition="Model.BanIsIndefinite">
+	Your ban is indefinite.
+</p>
+<p condition="!Model.BanIsIndefinite">
+	Your ban is temporary and lasts until: <timezone-convert relative-time="false" asp-for="BannedUntil" />
+</p>
+@await Html.RenderWiki(SystemWiki.BannedUserNotice)

--- a/TASVideos/Pages/Account/Banned.cshtml.cs
+++ b/TASVideos/Pages/Account/Banned.cshtml.cs
@@ -1,0 +1,38 @@
+namespace TASVideos.Pages.Account;
+
+public class BannedModel(ApplicationDbContext db) : BasePageModel
+{
+	[TempData]
+	public int? BannedUserId { get; set; }
+
+	public string UserName { get; set; } = "";
+	public DateTime? BannedUntil { get; set; }
+	public bool BanIsIndefinite => BannedUntil >= DateTime.UtcNow.AddYears(SiteGlobalConstants.YearsOfBanDisplayedAsIndefinite);
+
+	public async Task<IActionResult> OnGet()
+	{
+		if (BannedUserId is null)
+		{
+			return Home();
+		}
+
+		var user = await db.Users
+			.Where(u => u.Id == BannedUserId)
+			.Select(u => new
+			{
+				u.UserName,
+				u.BannedUntil
+			})
+			.FirstOrDefaultAsync();
+
+		if (user == null)
+		{
+			return Home();
+		}
+
+		UserName = user.UserName;
+		BannedUntil = user.BannedUntil;
+
+		return Page();
+	}
+}

--- a/TASVideos/Pages/Account/Login.cshtml.cs
+++ b/TASVideos/Pages/Account/Login.cshtml.cs
@@ -31,11 +31,17 @@ public class LoginModel(SignInManager signInManager, IHostEnvironment env) : Bas
 			return Page();
 		}
 
-		var (result, user) = await signInManager.SignIn(UserName, Password, RememberMe);
+		var (result, user, failedDueToBan) = await signInManager.SignIn(UserName, Password, RememberMe);
 
 		if (result.Succeeded)
 		{
 			return BaseReturnUrlRedirect();
+		}
+
+		if (user is not null && failedDueToBan)
+		{
+			TempData[nameof(BannedModel.BannedUserId)] = user.Id;
+			return RedirectToPage("/Account/Banned");
 		}
 
 		if (user is not null && !await signInManager.UserManager.IsEmailConfirmedAsync(user) && !env.IsDevelopment())


### PR DESCRIPTION
Resolves #1543 .

This PR adds a page that's displayed when a banned user enters correct log in data. We don't log them in and instead show them how long they are banned. They either see they're banned temporarily and see the timestamp, or indefinitely which is shown when a user is banned for over 2 years.

Below this info, it also displays the wiki page `System/BannedUserNotice`, intended for contact info for ban appeals and maybe other information.

![image](https://github.com/user-attachments/assets/36ca8752-d523-4004-ad10-35ca7feab027)

![image](https://github.com/user-attachments/assets/5322edea-b32e-4bbe-8ebc-c9eb534c0153)
