### PR TITLE
Add Change Log buttons on Subs and Pubs to their /Logs page

### DIFF
--- a/TASVideos/Pages/Logs/Index.cshtml
+++ b/TASVideos/Pages/Logs/Index.cshtml
@@ -5,6 +5,8 @@
 	ViewData.UseDiff();
 }
 
+<back-link condition="@(Model.Table.Equals("submissions", StringComparison.InvariantCultureIgnoreCase) && Model.RowId is not null)" href="/@(Model.RowId)S" name-override="Back to Submission"></back-link>
+<back-link condition="@(Model.Table.Equals("publications", StringComparison.InvariantCultureIgnoreCase) && Model.RowId is not null)" href="/@(Model.RowId)M" name-override="Back to Publication"></back-link>
 <partial name="_Pager" model="Model.History" />
 <standard-table>
 	<sortable-table-head sorting="@Model.Search" model-type="typeof(IndexModel.LogEntry)" page-override="@HttpContext.Request.Path" />

--- a/TASVideos/Pages/Publications/View.cshtml
+++ b/TASVideos/Pages/Publications/View.cshtml
@@ -34,3 +34,9 @@
    class="btn btn-info btn-sm">
    List referrers
 </a>
+<a asp-page="/Logs/Index"
+   asp-route-table="Publications"
+   asp-route-rowId="@Model.Id"
+   class="btn btn-info btn-sm">
+	<i class="fa fa-plus-minus"></i> Change Log
+</a>

--- a/TASVideos/Pages/Submissions/View.cshtml
+++ b/TASVideos/Pages/Submissions/View.cshtml
@@ -269,3 +269,9 @@
    class="btn btn-info btn-sm">
    List referrers
 </a>
+<a asp-page="/Logs/Index"
+   asp-route-table="Submissions"
+   asp-route-rowId="@Model.Id"
+   class="btn btn-info btn-sm">
+	<i class="fa fa-plus-minus"></i> Change Log
+</a>


### PR DESCRIPTION
This isn't really perfect, since we now have the Page History which links to the wiki history, and then a different button that shows a different kind of history for the DB entity.

But this is better than no button at all.

![image](https://github.com/user-attachments/assets/1649106a-8d39-479e-b646-cb5d3345fb28)

This PR sort of hard-codes the expected "submissions" and "publications" table names. If we instead want to do it programmatically, we need a full DBContext object to load those table names. But to me that seemed a bit much.