### PR TITLE
Hide Quote button in Topics for Users who can't make Posts

### DIFF
--- a/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
@@ -32,7 +32,8 @@
 					   class="btn btn-secondary btn-sm d-none d-md-inline-block">
 						<i class="fa fa-envelope"></i> PM
 					</a>
-					<a asp-page="/Forum/Posts/Create"
+					<a condition="User.Has(PermissionTo.CreateForumPosts)"
+					   asp-page="/Forum/Posts/Create"
 					   asp-route-topicId="@Model.TopicId"
 					   asp-route-quoteId="@Model.Id"
 					   class="btn btn-secondary btn-sm">


### PR DESCRIPTION
This basically works the same already for the "+ New Post" button on Topics. So we hide the Quote button too. (This also means bots won't try to click it all the time.)