### PR TITLE
Don't cause exceptions on submission title generation on missing data

### DIFF
--- a/TASVideos.Data/Entity/Submission.cs
+++ b/TASVideos.Data/Entity/Submission.cs
@@ -103,16 +103,6 @@ public class Submission : BaseEntity, ITimeable
 
 	public void GenerateTitle()
 	{
-		if (System is null)
-		{
-			throw new ArgumentNullException($"{nameof(System)} can not be null.");
-		}
-
-		if (SystemFrameRate is null)
-		{
-			throw new ArgumentNullException($"{nameof(SystemFrameRate)} can not be null.");
-		}
-
 		var authorList = SubmissionAuthors
 			.OrderBy(sa => sa.Ordinal)
 			.Select(sa => sa.Author?.UserName)
@@ -143,7 +133,7 @@ public class Submission : BaseEntity, ITimeable
 		};
 
 		Title =
-		$"#{Id}: {string.Join(", ", authorList).LastCommaToAmpersand()}'s {System.Code} {gameName}"
+		$"#{Id}: {string.Join(", ", authorList).LastCommaToAmpersand()}'s {System?.Code ?? "Unknown"} {gameName}"
 			+ (!string.IsNullOrWhiteSpace(goal) ? $" \"{goal}\"" : "")
 			+ $" in {this.Time().ToStringWithOptionalDaysAndHours()}";
 	}


### PR DESCRIPTION
Resolves #1539 .

Causing an exception here is a bad idea. Those properties are nullable, and an exception in this method will cause MANY pages to cause an exception and not load, that is, every page that tries to show this submission:
- Frontpage
- Submission list
- Forum

Instead, in case of null values, for the title generation we will use "Unknown" as the System, and a null SystemFrameRate will be assumed to be 0, giving the maximum time in the submission. Staff members can then easily fix this with a catalog entry.

So why can these nullable values be null? A situation is explained in the issue ticket. For Framerates we have hardcoded Regions of `Unknown`, `Ntsc`, and `Pal`. And our staff has to magically know that when creating a new System. And if a movie file parser returns a region with an unconfigured framerate, then this SystemFrameRate will be null.
And as explained above, we really can't throw an exception in this case.