### PR TITLE
Show canonical URLs on wiki pages, and fix wrong casing in the browser via javascript

### DIFF
--- a/TASVideos.Core/Extensions/WikiHelper.cs
+++ b/TASVideos.Core/Extensions/WikiHelper.cs
@@ -76,7 +76,7 @@ public static class WikiHelper
 		return relevantPermissions.Any(userPermissions.Contains);
 	}
 
-	public static bool IsValidWikiPageName(string pageName)
+	public static bool IsValidWikiPageName(string pageName, bool validateLoosely = false)
 	{
 		// If the page is a homepage, then don't validate the username portion
 		// However we want to validate any subpages off the user
@@ -101,8 +101,9 @@ public static class WikiHelper
 			&& !test.EndsWith('/')
 			&& !test.EndsWith(".html")
 			&& Regex.IsMatch(test, @"^\S*$")
-			&& char.IsUpper(test[0])
-			&& IsProperCased(test);
+			&& (validateLoosely || (
+				char.IsUpper(test[0])
+				&& IsProperCased(test)));
 	}
 
 	public static bool IsSystemGameResourcePath(this string path)

--- a/TASVideos/Extensions/ViewDataDictionaryExtensions.cs
+++ b/TASVideos/Extensions/ViewDataDictionaryExtensions.cs
@@ -25,6 +25,12 @@ public static class ViewDataDictionaryExtensions
 	public static void SetTitle(this ViewDataDictionary viewData, string title)
 		=> viewData["Title"] = title;
 
+	public static void SetCanonicalUrl(this ViewDataDictionary viewData, string canonicalUrl)
+		=> viewData["CanonicalUrl"] = canonicalUrl;
+
+	public static string? GetCanonicalUrl(this ViewDataDictionary viewData)
+		=> viewData["CanonicalUrl"]?.ToString();
+
 	public static string GetFavicon(this ViewDataDictionary viewData) => viewData["Favicon"]?.ToString() ?? "favicon.ico";
 
 	public static void UseGreenFavicon(this ViewDataDictionary viewData)

--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -1,13 +1,17 @@
 ﻿<!DOCTYPE html>
 <html>
+@{
+	var title = ViewData.GetTitle();
+	var canonicalUrl = ViewData.GetCanonicalUrl();
+}
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<environment include="Production">
 		<meta name="google-site-verification" content="dvluB-ypxKLVGmSQpqBmi9i1xo85I0OmRFD2GhJkTYw" />
 	</environment>
-	@{ var title = ViewData.GetTitle(); }
 	<title>@(title is not null ? title + " - " : "")TASVideos</title>
+	<link condition="!string.IsNullOrEmpty(canonicalUrl)" rel="canonical" href="@canonicalUrl" />
 
 	<link rel="shortcut icon" href="/@(ViewData.GetFavicon())" type="image/x-icon">
 	<link rel="stylesheet" href="/css/bootstrap.css" />
@@ -171,6 +175,7 @@
 		</row>
 	</footer>
 </div>
+	<script condition="!string.IsNullOrEmpty(canonicalUrl)" src="~/js/replace-url.js"></script>
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"
 			integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm"
 			crossorigin="anonymous"></script>

--- a/TASVideos/Pages/Wiki/Render.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Render.cshtml.cs
@@ -24,7 +24,7 @@ public class RenderModel(IWikiPages wikiPages, ApplicationDbContext db, ILogger<
 			}
 		}
 
-		if (!WikiHelper.IsValidWikiPageName(url))
+		if (!WikiHelper.IsValidWikiPageName(url, validateLoosely: true)) // allow wrong url casing to navigate to the wiki page, we will show a proper canonical url in the html, and rewrite the browser url with javascript
 		{
 			// Support legacy links like [adelikat] that should have been [user:adelikat]
 			if (await wikiPages.Exists(LinkConstants.HomePages + url))
@@ -46,6 +46,7 @@ public class RenderModel(IWikiPages wikiPages, ApplicationDbContext db, ILogger<
 			WikiPage = wikiPage;
 			ViewData.SetWikiPage(WikiPage);
 			ViewData.SetTitle(WikiPage.PageName);
+			ViewData.SetCanonicalUrl($"{Request.Scheme}://{Request.Host}{Request.PathBase}/{WikiPage.PageName}{Request.QueryString}");
 			return Page();
 		}
 

--- a/TASVideos/wwwroot/js/replace-url.js
+++ b/TASVideos/wwwroot/js/replace-url.js
@@ -1,0 +1,4 @@
+﻿const canonicalUrl = document.querySelector("link[rel='canonical']")?.href;
+if (canonicalUrl) {
+	history.replaceState(null, '', canonicalUrl + location.hash);
+}

--- a/tests/TASVideos.Core.Tests/Services/WikiHelperTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/WikiHelperTests.cs
@@ -89,29 +89,31 @@ public class WikiHelperTests
 	}
 
 	[TestMethod]
-	[DataRow(null, false)]
-	[DataRow("", false)]
-	[DataRow(" ", false)]
-	[DataRow("/", false)]
-	[DataRow("WikiPage/", false)]
-	[DataRow("WikiPage.html", false)]
-	[DataRow("/WikiPage", false)]
-	[DataRow("WikiPage", true)]
-	[DataRow("wikipage", false)]
-	[DataRow("WikiPage.html", false)]
-	[DataRow("WikiPage/Subpage", true)]
-	[DataRow("ProperCased", true)]
-	[DataRow("camelCased", false)]
-	[DataRow("Page With Spaces", false)]
-	[DataRow("HomePages/SomeUser", true)]
-	[DataRow("HomePages/user with Invalid Page name", true)]
-	[DataRow("HomePages/[^_^]", true)]
-	[DataRow("HomePages/user with Invalid Page name/Subpage", true)]
-	[DataRow("HomePages/user with Invalid Page name/Subpage that is invalid", false)]
-	public void IsValidWikiPageName(string pageName, bool expected)
+	[DataRow(null, false, false)]
+	[DataRow("", false, false)]
+	[DataRow(" ", false, false)]
+	[DataRow("/", false, false)]
+	[DataRow("WikiPage/", false, false)]
+	[DataRow("WikiPage.html", false, false)]
+	[DataRow("/WikiPage", false, false)]
+	[DataRow("WikiPage", true, true)]
+	[DataRow("wikipage", false, true)]
+	[DataRow("WikiPage.html", false, false)]
+	[DataRow("WikiPage/Subpage", true, true)]
+	[DataRow("ProperCased", true, true)]
+	[DataRow("camelCased", false, true)]
+	[DataRow("Page With Spaces", false, false)]
+	[DataRow("HomePages/SomeUser", true, true)]
+	[DataRow("HomePages/user with Invalid Page name", true, true)]
+	[DataRow("HomePages/[^_^]", true, true)]
+	[DataRow("HomePages/user with Invalid Page name/Subpage", true, true)]
+	[DataRow("HomePages/user with Invalid Page name/Subpage that is invalid", false, false)]
+	public void IsValidWikiPageName(string pageName, bool expectedStrict, bool expectedLoose)
 	{
-		var actual = WikiHelper.IsValidWikiPageName(pageName);
-		Assert.AreEqual(expected, actual);
+		var actualStrict = WikiHelper.IsValidWikiPageName(pageName, validateLoosely: false);
+		var actualLoose = WikiHelper.IsValidWikiPageName(pageName, validateLoosely: true);
+		Assert.AreEqual(expectedStrict, actualStrict);
+		Assert.AreEqual(expectedLoose, actualLoose);
 	}
 
 	[TestMethod]


### PR DESCRIPTION
Resolves #726 .

The whole reason why we don't want `/articleindex` to automatically lead to `/ArticleIndex` was to prevent search engines to index both page names, causing unneeded traffic.

From https://tasvideos.org/articleindex
> Please use the proper URL. Although the site handles URLs case-insensitively, if you use wrong-case URLs, search engines will have to index each and every one of those URLs individually, which is a resource loss for both this site and the search engines. It also hinders caching.

However, Google has an [explanation page](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls) on how to use the `<link rel="canonical">` to prevent exactly that. Even if the wrong casing is used, you can specify the proper url in the html.

So this PR allows wrong casing to trigger the correct wiki page, and then adds the canonical url with the correct casing in the html.
For convenience, it also adds a javascript that replaces the current browser's url with that canonical url, so that users can freely copy the now-corrected casing and link it somewhere.

In short:
- `/articleindex` now shows `/ArticleIndex` wiki page instead of error page
- the wiki page will have a canonical url html element for search engines
- the browser will execute a javascript to change the url in the browser from `/articleindex` to `/ArticleIndex` (no reload happens)