### PR TITLE
Improve PublicationsByPlatform module: show counts, hide empty, allow flags, and allow custom ordering

### DIFF
--- a/TASVideos/WikiModules/PublicationsByPlatform.cshtml
+++ b/TASVideos/WikiModules/PublicationsByPlatform.cshtml
@@ -4,7 +4,7 @@
 	{
 		<tr>
 			<td>@platformEntry.Platform</td>
-			<td><a href="/Movies-@platformEntry.PlatformCode">All Publications (@platformEntry.Groupings.Sum(c => c.PublicationCount))</a></td>
+			<td><a href="/Movies-@platformEntry.PlatformCode">All Publications (@platformEntry.Groupings.Where(c => c.IsClass).Sum(c => c.PublicationCount))</a></td>
 			@foreach (var grouping in Model.AllGroupings)
 			{
 				var classEntry = platformEntry.Groupings.FirstOrDefault(c => c.Link == grouping);

--- a/TASVideos/WikiModules/PublicationsByPlatform.cshtml
+++ b/TASVideos/WikiModules/PublicationsByPlatform.cshtml
@@ -1,13 +1,21 @@
 ﻿@model PublicationsByPlatform
 <standard-table>
-	@foreach (var platform in Model.Platforms.OrderBy(res => res.DisplayName))
+	@foreach (var platformEntry in Model.PlatformPublicationList)
 	{
 		<tr>
-			<td>@platform.DisplayName</td>
-			<td><a href="/Movies-@platform.Code">All Publications</a></td>
-			@foreach (var pubClass in Model.PubClasses.OrderBy(t => t.Id))
+			<td>@platformEntry.Platform</td>
+			<td><a href="/Movies-@platformEntry.PlatformCode">All Publications (@platformEntry.Groupings.Sum(c => c.PublicationCount))</a></td>
+			@foreach (var grouping in Model.AllGroupings)
 			{
-				<td><a href="/Movies-@platform.Code-@pubClass.Link">@pubClass.Name</a></td>
+				var classEntry = platformEntry.Groupings.FirstOrDefault(c => c.Link == grouping);
+				if (classEntry is not null)
+				{
+					<td><a href="/Movies-@platformEntry.PlatformCode-@classEntry.Link">@classEntry.Name (@classEntry.PublicationCount)</a></td>
+				}
+				else
+				{
+					<td></td>
+				}
 			}
 		</tr>
 	}

--- a/TASVideos/WikiModules/PublicationsByPlatform.cshtml.cs
+++ b/TASVideos/WikiModules/PublicationsByPlatform.cshtml.cs
@@ -3,49 +3,97 @@
 namespace TASVideos.WikiModules;
 
 [WikiModule(ModuleNames.PublicationsByPlatform)]
-public class PublicationsByPlatform(IGameSystemService platforms, IClassService classes) : WikiViewComponent
+public class PublicationsByPlatform(ApplicationDbContext db) : WikiViewComponent
 {
-	public IReadOnlyList<(string DisplayName, string Code)> Platforms { get; private set; } = null!;
+	public List<PlatformPublications> PlatformPublicationList { get; set; } = [];
+	public List<string> AllGroupings { get; set; } = [];
 
-	public IReadOnlyCollection<PublicationClass> PubClasses { get; set; } = null!;
-
-	public async Task<IViewComponentResult> InvokeAsync(IList<string> groupings)
+	public async Task<IViewComponentResult> InvokeAsync(IList<string> flags, IList<string> order)
 	{
-		var extant = (await platforms.GetAll()).ToList();
-		List<IReadOnlyList<SystemsResponse>> rows = [];
-		rows.AddRange(groupings
-			.Select(groupStr => ProcessGroup(extant, groupStr))
-			.OfType<List<SystemsResponse>>());
+		PlatformPublicationList = await db.Publications
+			.ThatAreCurrent()
+			.GroupBy(p => p.System)
+			.Select(g => new PlatformPublications
+			{
+				Platform = g.Key!.DisplayName,
+				PlatformCode = g.Key.Code,
+				Groupings = g
+					.GroupBy(p => p.PublicationClass)
+					.Select(gg => new PlatformPublications.Grouping
+					{
+						Name = gg.Key!.Name,
+						Link = gg.Key.Link,
+						PublicationCount = gg.Count(),
+					})
+					.ToList(),
+			})
+			.ToListAsync();
 
-		Platforms = extant
-			.Select(sys => (sys.DisplayName, sys.Code))
-			.Concat(rows.Select(row => (
-				DisplayName: string.Join(" / ", row.Select(sys => sys.DisplayName)),
-				Code: string.Join("-", row.Select(sys => sys.Code))
-			)))
-			.OrderBy(tuple => tuple.DisplayName)
-			.ToArray();
-		PubClasses = await classes.GetAll();
+		var flagPublications = await db.PublicationFlags
+			.Where(pf => flags.Contains(pf.Flag!.Token))
+			.Where(pf => pf.Publication!.ObsoletedById == null)
+			.GroupBy(pf => pf.Publication!.System)
+			.Select(g => new PlatformPublications
+			{
+				Platform = g.Key!.DisplayName,
+				PlatformCode = g.Key.Code,
+				Groupings = g
+					.GroupBy(p => p.Flag)
+					.Select(gg => new PlatformPublications.Grouping
+					{
+						Name = gg.Key!.Name,
+						Link = gg.Key.Token ?? "",
+						PublicationCount = gg.Count(),
+					})
+					.ToList()
+			})
+			.ToListAsync();
+
+		PlatformPublicationList = PlatformPublicationList // merge platforms and flags
+			.Concat(flagPublications)
+			.GroupBy(p => p.Platform)
+			.OrderBy(g => g.Key, StringComparer.InvariantCultureIgnoreCase)
+			.Select(g => new PlatformPublications
+			{
+				Platform = g.Key,
+				PlatformCode = g.First().PlatformCode,
+				Groupings = g
+					.SelectMany(p => p.Groupings)
+					.ToList()
+			})
+			.ToList();
+
+		AllGroupings = PlatformPublicationList
+			.SelectMany(p => p.Groupings.Select(c => c.Link))
+			.Distinct()
+			.OrderBy(g => g, StringComparer.InvariantCultureIgnoreCase)
+			.ToList();
+
+		int swapPosition = 0;
+		for (int i = 0; i < order.Count; i++)
+		{
+			var index = AllGroupings.FindIndex(g => g.Equals(order[i], StringComparison.InvariantCultureIgnoreCase));
+			if (index != -1 && index >= swapPosition)
+			{
+				(AllGroupings[swapPosition], AllGroupings[index]) = (AllGroupings[index], AllGroupings[swapPosition]);
+				swapPosition++;
+			}
+		}
 
 		return View();
 	}
 
-	private static List<SystemsResponse>? ProcessGroup(List<SystemsResponse> extant, string groupStr)
+	public class PlatformPublications
 	{
-		List<SystemsResponse> row = [];
-		foreach (var idStr in groupStr.Split('-'))
+		public string Platform { get; set; } = "";
+		public string PlatformCode { get; set; } = "";
+		public List<Grouping> Groupings { get; set; } = [];
+
+		public class Grouping
 		{
-			var found = extant.FirstOrDefault(sys => sys.Code.Equals(idStr, StringComparison.OrdinalIgnoreCase));
-			if (found is null)
-			{
-				// ignore, TODO log?
-				return null;
-			}
-
-			extant.Remove(found);
-			row.Add(found);
+			public string Name { get; set; } = "";
+			public string Link { get; set; } = "";
+			public int PublicationCount { get; set; }
 		}
-
-		return row;
 	}
 }

--- a/TASVideos/WikiModules/PublicationsByPlatform.cshtml.cs
+++ b/TASVideos/WikiModules/PublicationsByPlatform.cshtml.cs
@@ -21,6 +21,7 @@ public class PublicationsByPlatform(ApplicationDbContext db) : WikiViewComponent
 					.GroupBy(p => p.PublicationClass)
 					.Select(gg => new PlatformPublications.Grouping
 					{
+						IsClass = true,
 						Name = gg.Key!.Name,
 						Link = gg.Key.Link,
 						PublicationCount = gg.Count(),
@@ -41,6 +42,7 @@ public class PublicationsByPlatform(ApplicationDbContext db) : WikiViewComponent
 					.GroupBy(p => p.Flag)
 					.Select(gg => new PlatformPublications.Grouping
 					{
+						IsClass = false,
 						Name = gg.Key!.Name,
 						Link = gg.Key.Token ?? "",
 						PublicationCount = gg.Count(),
@@ -91,6 +93,7 @@ public class PublicationsByPlatform(ApplicationDbContext db) : WikiViewComponent
 
 		public class Grouping
 		{
+			public bool IsClass { get; set; }
 			public string Name { get; set; } = "";
 			public string Link { get; set; } = "";
 			public int PublicationCount { get; set; }


### PR DESCRIPTION
Resolves #1910 properly.
The `[module:PublicationsByPlatform]` module wasn't useful in its current form.
But now it should allow what @vadosnaprimer wanted in the opening post of that issue ticket.

- Hide empty links
- Show Stars even though it's now a flag not a class

As a bonus, we're already loading the counts, so why not display them too!

Here an example image where I used
`[module:PublicationsByPlatform|flags=commentary|order=standard,stars,commentary,alternative]`
(Note: In my DB `Stars` is still a class, and `Events` does not exist yet, so the example uses the `Commentary`  flag instead.)

Before | After
![image](https://github.com/user-attachments/assets/c06a67ce-c09e-4719-a7b9-a4cfa844f4b3)

The current `/Movies` page is ordered like `Standard|Stars|Alternative`, so when this PR is merged we can use the following line for a similar ordering:
`[module:PublicationsByPlatform|flags=stars|order=standard,stars,alternative,events]`