### PR TITLE
Add embeds to Bluesky posts on submissions and publications

### DIFF
--- a/TASVideos.Core/Services/ExternalMediaPublisher/Post.cs
+++ b/TASVideos.Core/Services/ExternalMediaPublisher/Post.cs
@@ -48,6 +48,12 @@ public interface IPostable
 	/// Gets the person that posted the message.
 	/// </summary>
 	string User { get; }
+
+	byte[]? ImageData { get; }
+	string? ImageMimeType { get; }
+	int? ImageWidth { get; }
+	int? ImageHeight { get; }
+
 }
 
 /// <summary>
@@ -63,4 +69,9 @@ public class Post : IPostable
 	public string Group { get; init; } = "";
 	public string User { get; init; } = "";
 	public PostType Type { get; init; }
+
+	public byte[]? ImageData { get; init; }
+	public string? ImageMimeType { get; init; }
+	public int? ImageWidth { get; init; }
+	public int? ImageHeight { get; init; }
 }

--- a/TASVideos/Pages/Submissions/Submit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Submit.cshtml.cs
@@ -163,7 +163,26 @@ public class SubmitModel(
 		submission.TopicId = await tasVideoAgent.PostSubmissionTopic(submission.Id, submission.Title);
 		await db.SaveChangesAsync();
 		await dbTransaction.CommitAsync();
-		await publisher.AnnounceNewSubmission(submission);
+
+		byte[]? screenshotFile = null;
+		if (!string.IsNullOrEmpty(submission.EncodeEmbedLink))
+		{
+			try
+			{
+				var youtubeEmbedImageLink = "https://i.ytimg.com/vi/" + submission.EncodeEmbedLink.Split('/').Last() + "/hqdefault.jpg";
+				var client = new HttpClient();
+				var response = await client.GetAsync(youtubeEmbedImageLink);
+				if (response.IsSuccessStatusCode)
+				{
+					screenshotFile = await response.Content.ReadAsByteArrayAsync();
+				}
+			}
+			catch
+			{
+			}
+		}
+
+		await publisher.AnnounceNewSubmission(submission, screenshotFile, screenshotFile is not null ? "image/jpeg" : null, 480, 360);
 
 		return BaseRedirect($"/{submission.Id}S");
 	}

--- a/TASVideos/Pages/Submissions/Submit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Submit.cshtml.cs
@@ -165,11 +165,11 @@ public class SubmitModel(
 		await dbTransaction.CommitAsync();
 
 		byte[]? screenshotFile = null;
-		if (!string.IsNullOrEmpty(submission.EncodeEmbedLink))
+		if (youtubeSync.IsYoutubeUrl(submission.EncodeEmbedLink))
 		{
 			try
 			{
-				var youtubeEmbedImageLink = "https://i.ytimg.com/vi/" + submission.EncodeEmbedLink.Split('/').Last() + "/hqdefault.jpg";
+				var youtubeEmbedImageLink = "https://i.ytimg.com/vi/" + submission.EncodeEmbedLink!.Split('/').Last() + "/hqdefault.jpg";
 				var client = new HttpClient();
 				var response = await client.GetAsync(youtubeEmbedImageLink);
 				if (response.IsSuccessStatusCode)

--- a/TASVideos/Services/ExternalMediaPublisher.cs
+++ b/TASVideos/Services/ExternalMediaPublisher.cs
@@ -78,7 +78,7 @@ public static class ExternalMediaPublisherExtensions
 		});
 	}
 
-	public static async Task AnnounceNewSubmission(this ExternalMediaPublisher publisher, Submission submission)
+	public static async Task AnnounceNewSubmission(this ExternalMediaPublisher publisher, Submission submission, byte[]? imageData = null, string? imageMimeType = null, int? imageWidth = null, int? imageHeight = null)
 	{
 		await publisher.Send(new Post
 		{
@@ -88,7 +88,11 @@ public static class ExternalMediaPublisherExtensions
 			Title = $"New Submission! Go and see {submission.Title}",
 			FormattedTitle = $"New Submission! Go and see [{submission.Title}]({{0}})",
 			Body = "",
-			Link = publisher.ToAbsolute($"{submission.Id}S")
+			Link = publisher.ToAbsolute($"{submission.Id}S"),
+			ImageData = imageData,
+			ImageMimeType = imageMimeType,
+			ImageWidth = imageWidth,
+			ImageHeight = imageHeight
 		});
 	}
 
@@ -118,7 +122,7 @@ public static class ExternalMediaPublisherExtensions
 		});
 	}
 
-	public static async Task AnnounceNewPublication(this ExternalMediaPublisher publisher, Publication publication)
+	public static async Task AnnounceNewPublication(this ExternalMediaPublisher publisher, Publication publication, byte[]? imageData = null, string? imageMimeType = null, int? imageWidth = null, int? imageHeight = null)
 	{
 		await publisher.Send(new Post
 		{
@@ -128,7 +132,11 @@ public static class ExternalMediaPublisherExtensions
 			Title = $"New movie published! Go and see {publication.Title}",
 			FormattedTitle = $"New movie published! Go and see [{publication.Title}]({{0}})",
 			Body = "",
-			Link = publisher.ToAbsolute($"{publication.Id}M")
+			Link = publisher.ToAbsolute($"{publication.Id}M"),
+			ImageData = imageData,
+			ImageMimeType = imageMimeType,
+			ImageWidth = imageWidth,
+			ImageHeight = imageHeight
 		});
 	}
 


### PR DESCRIPTION
As mentioned in PR #2057 that added Bluesky support, adding embed support is a lot more difficult and can be done at a later time.

This is the later time.

The challenge is that unlike Discord (and Twitter back when Twitter was a thing), Bluesky does not automatically show our open graph meta tags as an embed.
Instead, we have to manually upload an image to Bluesky before making a post, and then use the returned reference blob in the post creation.
This creates the issue that we have to actually have the image data in a byte array to send to Bluesky. This is fine for publications. But for submissions, we have to take the user-submitted encode embed link and make a http request to youtube.

Additionally, Bluesky recommends sending the aspect ratio of the image for proper display. For submissions the youtube embed is always 480x360. For publications we don't send any aspect ratio information, because that would require parsing the image bytes, and that is complicated and maybe even dangerous. Sadly, this means for publications Bluesky will display the image in the default 1x1 aspect ratio box (see image below). It isn't pretty, but it's fine.

**IMPORTANT:** We make a request to a URL based on user data. This is dangerous and needs to be reviewed properly. The link is always prepended with `https://i.ytimg.com/vi/`, so I'm unaware of anything that can be abused here.

<hr>

Examples:

![image](https://github.com/user-attachments/assets/bd23580d-02eb-47fd-bb7f-48fae8399630)

![image](https://github.com/user-attachments/assets/a85ef44b-561e-4f57-bd20-f5cdd71c3278)
