### PR TITLE
Fix small bugs

### DIFF
--- a/TASVideos.Core/Paging/PageOf.cs
+++ b/TASVideos.Core/Paging/PageOf.cs
@@ -53,6 +53,6 @@ public class PagingModel : IRequest
 [AttributeUsage(AttributeTargets.Class)]
 public class PagingDefaultsAttribute : Attribute
 {
-	public int PageSize { get; set; }
+	public int PageSize { get; set; } = 25;
 	public string? Sort { get; set; }
 }

--- a/TASVideos.Core/Services/QueueService.cs
+++ b/TASVideos.Core/Services/QueueService.cs
@@ -342,6 +342,7 @@ internal class QueueService(
 
 		await tva.PostSubmissionUnpublished(publication.SubmissionId);
 		await db.SaveChangesAsync();
+		await wikiPages.Delete(WikiHelper.ToPublicationWikiPageName(publicationId));
 
 		foreach (var url in youtubeUrls)
 		{


### PR DESCRIPTION
When unpublishing a publication, we should delete its wiki page, like we do when a submission is deleted.

Also the page size was 0 on our `/Logs` page, because in the PagingDefaults attribute only the sort was given, and the int's default value is 0.
