### PR TITLE
Add indexing to the AutoHistory table

### DIFF
--- a/TASVideos.Data/ApplicationDbContext.cs
+++ b/TASVideos.Data/ApplicationDbContext.cs
@@ -474,6 +474,13 @@ public class ApplicationDbContext : IdentityDbContext<User, Role, int, UserClaim
 		{
 			entity.HasIndex(e => e.FileExtension).IsUnique();
 		});
+
+		builder.Entity<AutoHistoryEntry>(entity =>
+		{
+			entity.HasIndex(e => e.RowId);
+			entity.HasIndex(e => e.TableName);
+			entity.HasIndex(e => e.UserId);
+		});
 	}
 
 	private void PerformTrackingUpdates()

--- a/TASVideos.Data/Migrations/20250510112754_AddIndicesToAutoHistory.Designer.cs
+++ b/TASVideos.Data/Migrations/20250510112754_AddIndicesToAutoHistory.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using TASVideos.Data;
 namespace TASVideos.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250510112754_AddIndicesToAutoHistory")]
+    partial class AddIndicesToAutoHistory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TASVideos.Data/Migrations/20250510112754_AddIndicesToAutoHistory.cs
+++ b/TASVideos.Data/Migrations/20250510112754_AddIndicesToAutoHistory.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TASVideos.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIndicesToAutoHistory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_auto_history_row_id",
+                table: "auto_history",
+                column: "row_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_auto_history_table_name",
+                table: "auto_history",
+                column: "table_name");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_auto_history_user_id",
+                table: "auto_history",
+                column: "user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_auto_history_row_id",
+                table: "auto_history");
+
+            migrationBuilder.DropIndex(
+                name: "ix_auto_history_table_name",
+                table: "auto_history");
+
+            migrationBuilder.DropIndex(
+                name: "ix_auto_history_user_id",
+                table: "auto_history");
+        }
+    }
+}


### PR DESCRIPTION
Since we now have a page dedicated to showing the data of the autohistory table (`/Logs`), we should add indices to it so that loading is faster. Loading the page took 3 seconds before, and after this PR it takes only 2 ms.

- The indices on TableName and RowId make sense because we have a page like `/Logs/Publications/6540` where we query on both columns.
- The index on UserId makes sense because we join with the users table. Usually this would be a foreign key, and EF Core automatically puts an index on foreign keys. However, we don't want a foreign key in this table because it serves as a log. If a user is removed, we don't want to lose the log of everything they did. So we just manually add an index.