### PR TITLE
playground labels now use title override if they clash with movie (or other PG) labels

### DIFF
--- a/TASVideos/Pages/Games/Index.cshtml
+++ b/TASVideos/Pages/Games/Index.cshtml
@@ -123,24 +123,33 @@
 </div>
 <br />
 
-<div condition="Model.Game.PlaygroundGoals.Any()">
+<div condition="Model.PlaygroundGoals.Any()">
 	<h3>Playground</h3>
 	<ul class="nav nav-tabs" role="tablist">
-		@foreach (var goal in Model.Game.PlaygroundGoals)
+		@foreach (var goal in Model.PlaygroundGoals)
 		{
 			<li class="nav-item">
-				<a class="nav-link@(goal==Model.Game.PlaygroundGoals.First() ? " active" : "")"
+				<a class="nav-link@(goal==Model.PlaygroundGoals.First() ? " active" : "")"
 				   href="#tab-goal-@(goal.Id)"
-				   data-bs-toggle="tab">
-					"@(goal.Name)"
+                   data-bs-toggle="tab">
+                    @{
+                        bool goalClash = Model.Movies.Any(m => m.TabTitleBold == goal.Name || m.TabTitleRegular == goal.Name)
+                            || Model.PlaygroundGoals.Any(g => g != goal && g.Name == goal.Name);
+                    }
+                    <span condition="@(goalClash)">@goal.GameTitle </span>
+                    @(goal.Name == "(baseline)"
+                        ? goalClash
+                            ? ""
+                            : goal.Name
+                        : $"\"{goal.Name}\"")
 				</a>
 			</li>
 		}
 	</ul>
 	<div class="tab-content">
-		@foreach (var goal in Model.Game.PlaygroundGoals)
+		@foreach (var goal in Model.PlaygroundGoals)
 		{
-			<div id="tab-goal-@(goal.Id)" class="tab-pane fade@(goal==Model.Game.PlaygroundGoals.First() ? " active show" : "")">
+			<div id="tab-goal-@(goal.Id)" class="tab-pane fade@(goal==Model.PlaygroundGoals.First() ? " active show" : "")">
 				<ul>
 					@foreach (var sub in goal.Submissions)
 					{

--- a/TASVideos/Pages/Games/Index.cshtml.cs
+++ b/TASVideos/Pages/Games/Index.cshtml.cs
@@ -16,6 +16,7 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 	public List<TabMiniMovieModel> Movies { get; set; } = [];
 	public List<WatchFile> WatchFiles { get; set; } = [];
 	public List<TopicEntry> Topics { get; set; } = [];
+	public List<GoalEntry> PlaygroundGoals { get; set; } = [];
 
 	public async Task<IActionResult> OnGet()
 	{
@@ -42,17 +43,18 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 			ObsoletePublicationCount = g.Publications.Count(p => p.ObsoletedById != null),
 			SubmissionCount = g.Submissions.Count,
 			UserFilesCount = g.UserFiles.Count(uf => !uf.Hidden),
-			PlaygroundGoals = g.Submissions
-				.Where(s => s.Status == SubmissionStatus.Playground)
-				.GroupBy(s => s.GameGoal)
-				.OrderBy(gg => gg.Key!.DisplayName.Length)
-				.Select(gg => new GoalEntry(
-					gg.Key!.Id,
-					gg.Key!.DisplayName,
-					gg.OrderByDescending(ggs => ggs.Id)
-						.Select(ggs => new SubmissionEntry(ggs.Id, ggs.Title))
-						.ToList()))
-				.ToList(),
+			PlaygroundSubmissions = g.Submissions
+				.Where(s => s.Status == SubmissionStatus.Playground
+					&& s.GameName != null
+					&& s.GameVersion != null
+					&& s.GameGoal != null)
+				.Select(s => new PlaygroundSubmission(
+					s.Id,
+					s.Title,
+					s.GameVersion!.TitleOverride ?? s.GameName!,
+					s.GameGoal!,
+					s.GameVersion))
+				.ToList()
 		});
 
 		query = ParsedId > -2
@@ -77,16 +79,18 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 				p.Title,
 				Goal = p.GameGoal!.DisplayName,
 				Screenshot = p.Files
-				.Where(f => f.Type == FileType.Screenshot)
-				.Select(f => new DisplayMiniMovie.MiniMovieModel.ScreenshotFile
-				{
-					Path = f.Path,
-					Description = f.Description
-				})
-				.First(),
+					.Where(f => f.Type == FileType.Screenshot)
+					.Select(f => new DisplayMiniMovie.MiniMovieModel.ScreenshotFile
+					{
+						Path = f.Path,
+						Description = f.Description
+					})
+					.First(),
 				OnlineWatchingUrl = p.PublicationUrls
-				.First(u => u.Type == PublicationUrlType.Streaming).Url,
-				GameTitle = p.GameVersion != null && p.GameVersion.TitleOverride != null ? p.GameVersion.TitleOverride : p.Game!.DisplayName
+					.First(u => u.Type == PublicationUrlType.Streaming).Url,
+				GameTitle = p.GameVersion != null && p.GameVersion.TitleOverride != null
+					? p.GameVersion.TitleOverride
+					: p.Game!.DisplayName
 			})
 			.ToListAsync();
 
@@ -110,6 +114,29 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 				}))
 			.ToList();
 
+		if (Game.PlaygroundSubmissions != null)
+		{
+			PlaygroundGoals = Game.PlaygroundSubmissions
+				.GroupBy(s => new
+				{
+					s.Goal,
+					GameTitle = s.Version!.TitleOverride
+						?? s.GameTitle
+						?? "Unknown Game"
+				})
+				.OrderBy(gg => gg.Key!.Goal!.DisplayName.Length)
+				.Select(gg => new GoalEntry(
+					gg.Key!.Goal!.Id,
+					gg.Key!.Goal!.DisplayName == "baseline"
+						? "(baseline)"
+						: gg.Key!.Goal!.DisplayName,
+					gg.Key!.GameTitle,
+					gg.OrderByDescending(ggs => ggs.Id)
+						.Select(ggs => new SubmissionEntry(ggs.Id, ggs.SubmissionTitle))
+						.ToList()))
+				.ToList();
+		}
+
 		WatchFiles = await db.UserFiles
 			.ForGame(Game.Id)
 			.ThatArePublic()
@@ -127,8 +154,9 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 
 	public record WatchFile(long Id, string FileName);
 	public record TopicEntry(int Id, string Title);
-	public record GoalEntry(int Id, string Name, List<SubmissionEntry> Submissions);
 	public record SubmissionEntry(int Id, string Title);
+	public record GoalEntry(int Id, string Name, string GameTitle, List<SubmissionEntry> Submissions);
+	public record PlaygroundSubmission(int Id, string SubmissionTitle, string GameTitle, GameGoal Goal, GameVersion Version);
 
 	public class GameDisplay
 	{
@@ -141,7 +169,7 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 		public List<string> Genres { get; init; } = [];
 		public List<GameVersion> Versions { get; init; } = [];
 		public List<GameGroup> GameGroups { get; init; } = [];
-		public List<GoalEntry> PlaygroundGoals { get; set; } = [];
+		public List<PlaygroundSubmission> PlaygroundSubmissions { get; set; } = [];
 		public int PublicationCount { get; init; }
 		public int ObsoletePublicationCount { get; init; }
 		public int SubmissionCount { get; init; }
@@ -160,5 +188,14 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 		public record GameGroup(int Id, string Name);
 	}
 
-	public record TabMiniMovieModel(string TabTitleRegular, string TabTitleBold, DisplayMiniMovie.MiniMovieModel Movie);
+	/// <summary>
+	/// Tab for MiniMovieModel
+	/// </summary>
+	/// <param name="TabTitleRegular">for baseline and disambiguating the clashes</param>
+	/// <param name="TabTitleBold">for actual branch labels that appear in movie titles</param>
+	/// <param name="Movie">MiniMovieModel</param>
+	public record TabMiniMovieModel(
+		string TabTitleRegular,
+		string TabTitleBold,
+		DisplayMiniMovie.MiniMovieModel Movie);
 }


### PR DESCRIPTION
also display baseline label like it's displayed for movies: `(baseline)` instead of `"baseline"`

disambiguate between similar PG goals with different title overrides

overrides are only used to resolve such clashes, for cases when something is accepted under an existing goal label but as a different branch. for example if the version difference warrants it. so we don't have to determine whether an override is meant to be used under the same goal or a different one: it always implies the branch is different. so we spell out the version like we do for pub tabs.

PS: this was UNEXPECTEDLY TRICKY to figure out on the policies side but we did it!

screenshots AFTER:

baseline clash between pubs and PG
![9206358fe8378d92](https://github.com/user-attachments/assets/265d7191-53ed-48cf-8baf-aecc34aede80)

named branch clash
![8a0f27f19dbbeb30](https://github.com/user-attachments/assets/9679a00d-5bb6-4dfd-8a59-168cc5c53d5f)

different versions in PG
![cb18c9ebcac5ae76](https://github.com/user-attachments/assets/66ff424e-33bd-4a7c-8d77-55a3341666b6)
![56c6fe26151fb64a](https://github.com/user-attachments/assets/8730faf4-da15-4a03-95bc-9341bf8ae8eb)
