### PR TITLE
Correction. Use lossless not s4 (retains detail while compressing).

### DIFF
--- a/TASVideos/wwwroot/awards/automation/Step 2 (Compress).bat
+++ b/TASVideos/wwwroot/awards/automation/Step 2 (Compress).bat
@@ -1,2 +1,2 @@
 @echo if you have an older version of pingo use -s9.
-FOR %%i in (*.png) DO pingo.exe -s4 -strip "%%i"
+FOR %%i in (*.png) DO pingo.exe -lossless -strip "%%i"


### PR DESCRIPTION
Forgot that pingo works a bit differently now, especially if you're more up to date, this would avoid any "future" errors if anyone stumbles on it (even tho there's technically no detail changes on the award images, but hey who knows what the future has).