### PR TITLE
Merge "Home" and logo in navbar

### DIFF
--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -43,7 +43,7 @@
 				</picture>
 			</div>
 			<a id="icon" asp-page="/Index">
-				<picture>
+				<picture title="To Homepage">
 					<source srcset="/images/logo-light.webp .5x,
 							/images/logo-light-2x.webp 1x,
 							/images/logo-light-4x.webp 2x"
@@ -53,7 +53,7 @@
 							/images/logo-light-2x.png 1x,
 							/images/logo-light-4x.png 2x" loading="lazy">
 				</picture>
-				<picture>
+				<picture title="To Homepage">
 					<source srcset="/images/logo-dark.webp .5x,
 							/images/logo-dark-2x.webp 1x,
 							/images/logo-dark-4x.webp 2x"
@@ -64,7 +64,7 @@
 							/images/logo-dark-4x.png 2x" loading="lazy">
 				</picture>
 			</a>
-			<a id="mantra" asp-page="/Index">
+			<a id="mantra" asp-page="/Index" title="To Homepage">
 				<div id="brand">TASVideos</div>
 				<div id="mantra-1">Tool-assisted game movies</div>
 				<div id="mantra-2">When human skills are just not enough</div>

--- a/TASVideos/Pages/Shared/_NavBarPartial.cshtml
+++ b/TASVideos/Pages/Shared/_NavBarPartial.cshtml
@@ -1,7 +1,4 @@
 <navbar class="flex-wrap me-2 me-md-0 fw-bold">
-	<nav-item activate="Home">
-		<a class="nav-link" href="/">Home</a>
-	</nav-item>
 	<nav-item activate="Games">
 		<a class="nav-link" asp-page="/Games/List">Games</a>
 	</nav-item>


### PR DESCRIPTION
This link is redundant with the logo and wordmark to its immediate left. Removing it frees a bit of space for the other items—in my testing here it eliminated the third row at specific narrow widths, but that was done on the live site i.e. without https://github.com/TASVideos/tasvideos/commit/67a91a7f2e3b55c6f014d8c24bb4fa5da350f6b9.
Obviously the red boxes aren't part of the site, I'm just showing the clickable regions for comparison.
before
after
![comparison](https://github.com/user-attachments/assets/461557b4-88f9-4d31-837f-05c05dcdc8ea)

Cherry-picked from #2148.