### PR TITLE
Set `<html lang/>`, and prevent autotranslation breaking preview panes

### DIFF
--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html>
-<html>
+<html lang="en">
 @{
 	var title = ViewData.GetTitle();
 	var canonicalUrl = ViewData.GetCanonicalUrl();

--- a/TASVideos/TagHelpers/PreviewTagHelper.cs
+++ b/TASVideos/TagHelpers/PreviewTagHelper.cs
@@ -15,6 +15,7 @@ public class PreviewTagHelper : TagHelper
 	{
 		output.TagName = "div";
 		output.Attributes.Add("id", "preview-container");
+		output.Attributes.Add("translate", "no"); // the user typed it so they don't need it translated, and at least Firefox' translator does weird things
 		output.Attributes.Add("data-path", PreviewPath);
 		output.AddCssClass("d-none");
 		output.Content.AppendHtml(


### PR DESCRIPTION
Bare minimum from #2109: Sets the page language globally per a Lighthouse diagnostic.
This PR does not attempt to mark translated wiki pages with their correct language, nor posts in the non-English subfora.
Any text within a page which is not English prose and should not be translated (MDN's example is wordmarks, so "TASVideos", but maybe usernames and game names) can be given the attribute `translate="no"`. I did this for the forum preview pane, since I noticed Firefox' built-in translator erasing a clause where I'd code-switched to the source language. A user would never need that translated anyway; it's their own words.