### PR TITLE
Move BOM to the start of the layout file

### DIFF
--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -1,5 +1,5 @@
-@using Microsoft.AspNetCore.Http
-﻿@using Microsoft.Extensions.Hosting
+﻿@using Microsoft.AspNetCore.Http
+@using Microsoft.Extensions.Hosting
 @using TASVideos.Core.Services.Wiki
 @inject IHostEnvironment Env
 @inject IWikiPages WikiPages


### PR DESCRIPTION
Moves the BOM to the start of the file, which fixes the `<!DOCTYPE html>` missing in the html output, which put firefox into quirks mode, which broke layout.