### PR TITLE
Add flag emoji font

### DIFF
--- a/TASVideos/Extensions/ApplicationBuilderExtensions.cs
+++ b/TASVideos/Extensions/ApplicationBuilderExtensions.cs
@@ -65,7 +65,7 @@ public static class ApplicationBuilderExtensions
 		string[] cspDirectives = [
 			"base-uri 'none'", // neutralises the `<base/>` footgun
 			"default-src 'self'", // fallback for other `*-src` directives
-			"font-src 'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/", // CSS `font: url();` and `@font-face { src: url(); }` will be blocked unless they're from one of these domains (this also blocks nonstandard fonts installed on the system maybe)
+			"font-src 'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/", // CSS `font: url();` and `@font-face { src: url(); }` will be blocked unless they're from one of these domains (this also blocks nonstandard fonts installed on the system maybe)
 			"form-action 'self'", // domains allowed for `<form action/>` (POST target page)
 			"frame-src data: 'self' https://embed.nicovideo.jp/watch/ https://www.google.com/recaptcha/ https://www.youtube.com/embed/ https://archive.org/embed/", // allow these domains in <iframe/>
 			"img-src * data:", // allow hotlinking images from any domain in UGC (not great)

--- a/TASVideos/wwwroot/css/bootstrap.scss
+++ b/TASVideos/wwwroot/css/bootstrap.scss
@@ -1,3 +1,4 @@
+@use "sass:list";
 @import "../lib/bootstrap/scss/functions";
 
 $primary: #105cb6;
@@ -11,6 +12,8 @@ $warning: #ffa000;
 $custom-colors: ( "publication": #acd, "silver": #666 );
 $theme-colors: map-merge($theme-colors, $custom-colors);
 
+$font-family-sans-serif: list.join("Twemoji Country Flags", $font-family-sans-serif);
+$font-family-monospace: list.join("Twemoji Country Flags", $font-family-monospace);
 
 @import "../lib/bootstrap/scss/maps";
 $utilities-bg-subtle: map-merge( $utilities-bg-subtle, ( "publication-subtle": var(--bs-publication-bg-subtle)));

--- a/TASVideos/wwwroot/css/partials/_fonts.scss
+++ b/TASVideos/wwwroot/css/partials/_fonts.scss
@@ -1,0 +1,6 @@
+@font-face {
+    font-family: 'Twemoji Country Flags';
+    unicode-range: U+1F1E6-1F1FF, U+1F3F4, U+E0062-E0063, U+E0065, U+E0067, U+E006C, U+E006E, U+E0073-E0074, U+E0077, U+E007F;
+    src: url('https://cdn.jsdelivr.net/npm/country-flag-emoji-polyfill@0.1.8/dist/TwemojiCountryFlags.woff2') format('woff2');
+    font-display: swap;
+}

--- a/TASVideos/wwwroot/css/site.scss
+++ b/TASVideos/wwwroot/css/site.scss
@@ -5,6 +5,7 @@
 
 @import "partials/colors";
 @import "partials/variables";
+@import "partials/fonts";
 @import "partials/customizations";
 @import "partials/prism";
 @import "partials/prism-dark";


### PR DESCRIPTION
Basically, the problem is Windows not supporting flag emojis.
That's why e.g. the flag emoji `🇺🇸` appears as the text `US` instead of as `[graphical depiction of US flag]`.
- Firefox solves this problem by shipping their own emoji library.
- Chromium said that it does not plan to ship their own emoji library.

So the solution is to take the [emoji font from Mozilla](https://github.com/mozilla/twemoji-colr) and remove all but the flag emojis, and then use that font.

That's exactly what the package `country-flag-emoji-polyfill` does, and the font file is hosted at cdn.jsdelivr.net.
This PR uses this font and adds it to our bootstrap font-stack, and thus makes the flag emojis visible on all OSs and browser combinations that don't support flag emojis by themselves.

Before | After
<img width="394" height="279" alt="image" src="https://github.com/user-attachments/assets/53a2fb47-4219-4fab-9327-001e6161580e" />
