### PR TITLE
Revert "reduce memory allocations in wikiengine (#2178)"

### DIFF
--- a/TASVideos.WikiEngine/MakeBracketed.cs
+++ b/TASVideos.WikiEngine/MakeBracketed.cs
@@ -110,12 +110,9 @@ public static partial class Builtins
 
 	private static string NormalizeImageUrl(string text)
 	{
-		if (text[0] != '=')
-		{
-			return text;
-		}
-
-		return text[1] is '/' ? text[1..] : string.Concat("/", text.AsSpan(1));
+		return text[0] == '='
+			? text[1] is '/' ? text[1..] : $"/{text[1..]}"
+			: text;
 	}
 
 	private static string NormalizeUrl(string text)
@@ -127,12 +124,12 @@ public static partial class Builtins
 				return "/";
 			}
 
-			return NormalizeInternalLink(text[1] is '/' ? text[1..] : string.Concat("/", text.AsSpan(1)));
+			return NormalizeInternalLink(text[1] is '/' ? text[1..] : $"/{text[1..]}");
 		}
 
 		if (text.StartsWith("user:"))
 		{
-			return NormalizeInternalLink(string.Concat("/Users/Profile/", text.AsSpan(5)));
+			return NormalizeInternalLink("/Users/Profile/" + text[5..]);
 		}
 
 		return text;

--- a/TASVideos.WikiEngine/NodeImplementations/Element.cs
+++ b/TASVideos.WikiEngine/NodeImplementations/Element.cs
@@ -192,24 +192,7 @@ public partial class Element : INodeWithChildren
 
 	public string InnerText(IWriterHelper h)
 	{
-		if (Children.Count == 0)
-		{
-			return string.Empty;
-		}
-
-		if (Children.Count == 1)
-		{
-			return Children[0].InnerText(h);
-		}
-
-		// Use string.Concat with array to avoid excessive allocations
-		var texts = new string[Children.Count];
-		for (int i = 0; i < Children.Count; i++)
-		{
-			texts[i] = Children[i].InnerText(h);
-		}
-
-		return string.Concat(texts);
+		return string.Join("", Children.Select(c => c.InnerText(h)));
 	}
 
 	public void DumpContentDescriptive(TextWriter w, string padding)


### PR DESCRIPTION
This reverts commit 450791a134b2c3ef19a502e49e6dcca6ec3a930c.

It caused a wiki rendering bug in tabs, so @adelikat told me to revert it. :D
<img width="525" height="61" alt="image" src="https://github.com/user-attachments/assets/0b6e0fb2-8595-44bc-838c-aa5fa5b07cd3" />
