### PR TITLE
Fix bug when user changes email before confirming their initial one

### DIFF
--- a/TASVideos/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/TASVideos/Pages/Account/ConfirmEmail.cshtml.cs
@@ -34,12 +34,17 @@ public class ConfirmEmailModel(
 			return RedirectToPage("/Error");
 		}
 
+		await FirstTimeConfirmation(user, userManager, signInManager, publisher, userMaintenanceLogger, tasVideoAgent, IpAddress);
+		return Page();
+	}
+
+	public static async Task FirstTimeConfirmation(User user, IUserManager userManager, ISignInManager signInManager, IExternalMediaPublisher publisher, IUserMaintenanceLogger userMaintenanceLogger, ITASVideoAgent tasVideoAgent, string ipAddress)
+	{
 		await userManager.AddStandardRoles(user.Id);
 		await userManager.AddUserPermissionsToClaims(user);
 		await signInManager.SignIn(user, isPersistent: false);
 		await publisher.SendUserManagement($"User [{user.UserName}]({{0}}) activated", user.UserName);
-		await userMaintenanceLogger.Log(user.Id, $"User activated from {IpAddress}");
+		await userMaintenanceLogger.Log(user.Id, $"User activated from {ipAddress}");
 		await tasVideoAgent.SendWelcomeMessage(user.Id);
-		return Page();
 	}
 }


### PR DESCRIPTION
Previously, changing emails on an unconfirmed account would skip all the first-time steps like assigning the Default User role, causing the user to be unable to do anything, even though they verified their email.
Now a regular confirmation, and a change-confirmation both execute first-time steps if the email wasn't confirmed before.