### PR TITLE
Exclude migrations from test coverage metrics

### DIFF
--- a/.runsettings
+++ b/.runsettings
@@ -1,5 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <Configuration>
+          <CodeCoverage>
+            <Sources>
+              <Exclude>
+                <Source>.*\\Migrations\\.*</Source>
+              </Exclude>
+            </Sources>
+          </CodeCoverage>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
   <TestRunParameters>
     <Parameter name="PostgresTestsConnection" value="Host=127.0.0.1;Port=5432;Database=TASVideosTests;User Id=postgres;Password=postgres;Include Error Detail=true" />
   </TestRunParameters>


### PR DESCRIPTION
Following up on https://github.com/TASVideos/tasvideos/pull/2187#issuecomment-3160080597.
There's an issue filed against EF Core to have its generators add `[ExcludeFromCodeCoverage]`, so I didn't bother with my earlier suggestion of generating new partials just to do that. Also excluding by path was way easier.