### PR TITLE
Add View Metrics to our main entities

### DIFF
--- a/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
@@ -12,7 +12,8 @@ public class IndexModel(
 	IForumService forumService,
 	IPointsService pointsService,
 	ITopicWatcher topicWatcher,
-	IWikiPages wikiPages)
+	IWikiPages wikiPages,
+	ITASVideosMetrics metrics)
 	: BaseForumModel
 {
 	[FromRoute]
@@ -84,6 +85,8 @@ public class IndexModel(
 		{
 			return NotFound();
 		}
+
+		metrics.AddForumTopicView(Id);
 
 		Topic = topic;
 		if (Topic.SubmissionId.HasValue)

--- a/TASVideos/Pages/Publications/View.cshtml.cs
+++ b/TASVideos/Pages/Publications/View.cshtml.cs
@@ -1,7 +1,7 @@
 ﻿namespace TASVideos.Pages.Publications;
 
 [AllowAnonymous]
-public class ViewModel(ApplicationDbContext db, IFileService fileService) : BasePageModel
+public class ViewModel(ApplicationDbContext db, IFileService fileService, ITASVideosMetrics metrics) : BasePageModel
 {
 	[FromRoute]
 	public int Id { get; set; }
@@ -18,6 +18,8 @@ public class ViewModel(ApplicationDbContext db, IFileService fileService) : Base
 		{
 			return NotFound();
 		}
+
+		metrics.AddPublicationView(Id);
 
 		Publication = publication;
 		return Page();

--- a/TASVideos/Pages/Submissions/View.cshtml.cs
+++ b/TASVideos/Pages/Submissions/View.cshtml.cs
@@ -5,7 +5,7 @@ using TASVideos.MovieParsers.Result;
 namespace TASVideos.Pages.Submissions;
 
 [AllowAnonymous]
-public class ViewModel(ApplicationDbContext db, IWikiPages wikiPages, IFileService fileService, IMovieParser parser)
+public class ViewModel(ApplicationDbContext db, IWikiPages wikiPages, IFileService fileService, IMovieParser parser, ITASVideosMetrics metrics)
 	: SubmitPageModelBase(parser, fileService)
 {
 	[FromRoute]
@@ -30,6 +30,8 @@ public class ViewModel(ApplicationDbContext db, IWikiPages wikiPages, IFileServi
 		{
 			return NotFound();
 		}
+
+		metrics.AddSubmissionView(Id);
 
 		Submission = submission;
 		var submissionPage = await wikiPages.SubmissionPage(Id);

--- a/TASVideos/Pages/UserFiles/Info.cshtml.cs
+++ b/TASVideos/Pages/UserFiles/Info.cshtml.cs
@@ -3,7 +3,7 @@
 namespace TASVideos.Pages.UserFiles;
 
 [AllowAnonymous]
-public class InfoModel(ApplicationDbContext db, IFileService fileService) : BasePageModel
+public class InfoModel(ApplicationDbContext db, IFileService fileService, ITASVideosMetrics metrics) : BasePageModel
 {
 	private static readonly string[] PreviewableExtensions = ["avs", "bat", "cfg", "conf", "lua", "sh", "uae", "wch", "xml"];
 
@@ -23,6 +23,8 @@ public class InfoModel(ApplicationDbContext db, IFileService fileService) : Base
 		{
 			return NotFound();
 		}
+
+		metrics.AddUserFileView(Id);
 
 		UserFile = file;
 

--- a/TASVideos/Pages/Wiki/Render.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Render.cshtml.cs
@@ -4,7 +4,7 @@ using TASVideos.Core.Services.Wiki;
 namespace TASVideos.Pages.Wiki;
 
 [AllowAnonymous]
-public class RenderModel(IWikiPages wikiPages, ApplicationDbContext db, ILogger<RenderModel> logger) : BasePageModel
+public class RenderModel(IWikiPages wikiPages, ApplicationDbContext db, ILogger<RenderModel> logger, ITASVideosMetrics metrics) : BasePageModel
 {
 	public IWikiPage WikiPage { get; set; } = null!;
 
@@ -47,6 +47,7 @@ public class RenderModel(IWikiPages wikiPages, ApplicationDbContext db, ILogger<
 			ViewData.SetWikiPage(WikiPage);
 			ViewData.SetTitle(WikiPage.PageName);
 			ViewData.SetCanonicalUrl($"{Request.Scheme}://{Request.Host}{Request.PathBase}/{WikiPage.PageName}{Request.QueryString}");
+			metrics.AddWikiPageView(WikiPage.PageName);
 			return Page();
 		}
 

--- a/TASVideos/Services/TASVideosMetrics.cs
+++ b/TASVideos/Services/TASVideosMetrics.cs
@@ -5,27 +5,75 @@ namespace TASVideos.Services;
 public interface ITASVideosMetrics
 {
 	public void AddUserAgent(string? userAgent);
+	public void AddPublicationView(int publicationId);
+	public void AddSubmissionView(int submissionId);
+	public void AddWikiPageView(string wikiPageName);
+	public void AddUserFileView(long userFileId);
+	public void AddForumTopicView(int forumTopicId);
 }
 
 public class NullMetrics : ITASVideosMetrics
 {
-	public void AddUserAgent(string? userAgent)
-	{
-	}
+	public void AddUserAgent(string? userAgent) { }
+
+	public void AddPublicationView(int publicationId) { }
+
+	public void AddSubmissionView(int submissionId) { }
+
+	public void AddWikiPageView(string wikiPageName) { }
+
+	public void AddUserFileView(long userFileId) { }
+
+	public void AddForumTopicView(int forumTopicId) { }
 }
 
 public class TASVideosMetrics : ITASVideosMetrics
 {
 	private readonly Counter<long> _userAgentCounter;
+	private readonly Counter<long> _publicationViews;
+	private readonly Counter<long> _submissionViews;
+	private readonly Counter<long> _wikiPageViews;
+	private readonly Counter<long> _userFileViews;
+	private readonly Counter<long> _forumTopicViews;
 
 	public TASVideosMetrics(IMeterFactory meterFactory)
 	{
 		var meter = meterFactory.Create("TASVideos");
 		_userAgentCounter = meter.CreateCounter<long>("tasvideos.useragent.count");
+		_publicationViews = meter.CreateCounter<long>("tasvideos.publication.views");
+		_submissionViews = meter.CreateCounter<long>("tasvideos.submission.views");
+		_wikiPageViews = meter.CreateCounter<long>("tasvideos.wikipage.views");
+		_userFileViews = meter.CreateCounter<long>("tasvideos.userfile.views");
+		_forumTopicViews = meter.CreateCounter<long>("tasvideos.forumtopic.views");
 	}
 
 	public void AddUserAgent(string? userAgent)
 	{
 		_userAgentCounter.Add(1, new KeyValuePair<string, object?>("user_agent", userAgent));
+	}
+
+	public void AddPublicationView(int publicationId)
+	{
+		_publicationViews.Add(1, new KeyValuePair<string, object?>("publication_id", publicationId));
+	}
+
+	public void AddSubmissionView(int submissionId)
+	{
+		_submissionViews.Add(1, new KeyValuePair<string, object?>("submission_id", submissionId));
+	}
+
+	public void AddWikiPageView(string wikiPageName)
+	{
+		_wikiPageViews.Add(1, new KeyValuePair<string, object?>("wikipage_name", wikiPageName));
+	}
+
+	public void AddUserFileView(long userFileId)
+	{
+		_userFileViews.Add(1, new KeyValuePair<string, object?>("userfile_id", userFileId));
+	}
+
+	public void AddForumTopicView(int forumTopicId)
+	{
+		_forumTopicViews.Add(1, new KeyValuePair<string, object?>("forumtopic_id", forumTopicId));
 	}
 }

--- a/tests/TASVideos.RazorPages.Tests/Pages/Forum/Topics/IndexModelTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Pages/Forum/Topics/IndexModelTests.cs
@@ -33,7 +33,8 @@ public class IndexModelTests : BasePageModelTests
 			forumService,
 			pointsService,
 			_topicWatcher,
-			_wikiPages)
+			_wikiPages,
+			new NullMetrics())
 		{
 			PageContext = TestPageContext()
 		};

--- a/tests/TASVideos.RazorPages.Tests/Pages/Publications/ViewModelTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Pages/Publications/ViewModelTests.cs
@@ -1,5 +1,6 @@
 ﻿using TASVideos.Core.Services;
 using TASVideos.Pages.Publications;
+using TASVideos.Services;
 using TASVideos.Tests.Base;
 
 namespace TASVideos.RazorPages.Tests.Pages.Publications;
@@ -13,7 +14,7 @@ public class ViewModelModelTests : TestDbBase
 	public ViewModelModelTests()
 	{
 		_fileService = Substitute.For<IFileService>();
-		_page = new ViewModel(_db, _fileService);
+		_page = new ViewModel(_db, _fileService, new NullMetrics());
 	}
 
 	[TestMethod]

--- a/tests/TASVideos.RazorPages.Tests/Pages/Submissions/ViewModelTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Pages/Submissions/ViewModelTests.cs
@@ -3,6 +3,7 @@ using TASVideos.Core.Services.Wiki;
 using TASVideos.Extensions;
 using TASVideos.MovieParsers;
 using TASVideos.Pages.Submissions;
+using TASVideos.Services;
 using TASVideos.Tests.Base;
 
 namespace TASVideos.RazorPages.Tests.Pages.Submissions;
@@ -18,7 +19,7 @@ public class ViewModelTests : TestDbBase
 	{
 		_wikiPages = Substitute.For<IWikiPages>();
 		_fileService = Substitute.For<IFileService>();
-		_page = new ViewModel(_db, _wikiPages, _fileService, Substitute.For<IMovieParser>());
+		_page = new ViewModel(_db, _wikiPages, _fileService, Substitute.For<IMovieParser>(), new NullMetrics());
 	}
 
 	[TestMethod]

--- a/tests/TASVideos.RazorPages.Tests/Pages/UserFiles/InfoModelTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Pages/UserFiles/InfoModelTests.cs
@@ -2,6 +2,7 @@
 using TASVideos.Core.Services;
 using TASVideos.Data.Entity.Game;
 using TASVideos.Pages.UserFiles;
+using TASVideos.Services;
 using TASVideos.Tests.Base;
 
 namespace TASVideos.RazorPages.Tests.Pages.UserFiles;
@@ -15,7 +16,7 @@ public class InfoModelTests : TestDbBase
 	public InfoModelTests()
 	{
 		_fileService = Substitute.For<IFileService>();
-		_page = new InfoModel(_db, _fileService);
+		_page = new InfoModel(_db, _fileService, new NullMetrics());
 	}
 
 	[TestMethod]

--- a/tests/TASVideos.RazorPages.Tests/Pages/Wiki/RenderModelTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Pages/Wiki/RenderModelTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging.Abstractions;
 using TASVideos.Core.Services.Wiki;
 using TASVideos.Pages.Wiki;
+using TASVideos.Services;
 
 namespace TASVideos.RazorPages.Tests.Pages.Wiki;
 
@@ -13,7 +14,7 @@ public class RenderModelTests : BasePageModelTests
 	public RenderModelTests()
 	{
 		_mockWikiPages = Substitute.For<IWikiPages>();
-		_model = new RenderModel(_mockWikiPages, _db, NullLogger<RenderModel>.Instance)
+		_model = new RenderModel(_mockWikiPages, _db, NullLogger<RenderModel>.Instance, new NullMetrics())
 		{
 			PageContext = TestPageContext()
 		};


### PR DESCRIPTION
Publications, Submissions, Wiki Pages, User Files, Forum Topics.
Why? Well, we do already have automatic route counts. But we only see e.g. there were 364581 hits on the `{id:int}S` route in the past 27 days, but not which exact submissions.

This PR adds counters so we can actually see the views on entities split up by ID.

And why do we want that? Well, we don't need it, but it could reveal some things we might improve performance on. Maybe some often-visited wiki pages execute a module that is very slow.