### PR TITLE
Hack in support for `Accept-Encoding: zstd`

### DIFF
--- a/TASVideos.Core/Settings/AppSettings.cs
+++ b/TASVideos.Core/Settings/AppSettings.cs
@@ -6,6 +6,7 @@ public class AppSettings
 {
 	public string BaseUrl { get; set; } = "";
 	public bool EnableGzipCompression { get; set; }
+	public bool EnableZstdCompression { get; set; }
 
 	public CacheSetting CacheSettings { get; set; } = new();
 

--- a/TASVideos/Extensions/ApplicationBuilderExtensions.cs
+++ b/TASVideos/Extensions/ApplicationBuilderExtensions.cs
@@ -25,7 +25,7 @@ public static class ApplicationBuilderExtensions
 
 	public static IApplicationBuilder UseGzipCompression(this IApplicationBuilder app, AppSettings settings)
 	{
-		if (settings.EnableGzipCompression)
+		if (settings.EnableGzipCompression || settings.EnableZstdCompression)
 		{
 			app.UseResponseCompression();
 		}

--- a/TASVideos/Extensions/ServiceCollectionExtensions.cs
+++ b/TASVideos/Extensions/ServiceCollectionExtensions.cs
@@ -76,7 +76,29 @@ public static class ServiceCollectionExtensions
 			{
 				options.Level = CompressionLevel.Fastest;
 			});
-			services.AddResponseCompression(options => options.EnableForHttps = true);
+		}
+
+		if (settings.EnableZstdCompression)
+		{
+			services.Configure<ZstdCompressionProvider.ZstdOptions>(options => options.Level = 5);
+		}
+
+		if (settings.EnableGzipCompression || settings.EnableZstdCompression)
+		{
+			services.AddResponseCompression(options =>
+			{
+				if (settings.EnableGzipCompression)
+				{
+					options.Providers.Add<GzipCompressionProvider>();
+				}
+
+				if (settings.EnableZstdCompression)
+				{
+					options.Providers.Add<ZstdCompressionProvider>();
+				}
+
+				options.EnableForHttps = true;
+			});
 		}
 
 		return services;

--- a/TASVideos/Services/ZstdCompressionProvider.cs
+++ b/TASVideos/Services/ZstdCompressionProvider.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.Extensions.Options;
+
+using ZstdSharp;
+
+namespace TASVideos.Services;
+
+/// <summary>Implements stream compression via ZstdSharp, for use by the <see cref="ResponseCompressionMiddleware"/></summary>
+/// <remarks>To the extent that this shim is eligible for copyright, it's taken from this GPLv2-licensed source: <see href="https://github.com/rgueldenpfennig/Squidlr/commit/07ab9aaec37a0b24bc9ff3af84a3d61b150d59f9"/></remarks>
+public sealed class ZstdCompressionProvider(IOptions<ZstdCompressionProvider.ZstdOptions> options) : ICompressionProvider
+{
+	public sealed class ZstdOptions : IOptions<ZstdOptions>
+	{
+		public int Level { get; set; } = 1;
+
+		public ZstdOptions Value
+			=> this;
+	}
+
+	public string EncodingName
+		=> "zstd";
+
+	public bool SupportsFlush
+		=> true;
+
+	public Stream CreateStream(Stream outputStream)
+		=> new CompressionStream(outputStream, options.Value.Level, leaveOpen: true);
+}

--- a/TASVideos/appsettings.Production.json
+++ b/TASVideos/appsettings.Production.json
@@ -1,6 +1,7 @@
 {
   "BaseUrl": "https://tasvideos.org",
   "EnableGzipCompression": "False",
+  "EnableZstdCompression": "False",
   "MinimumHoursBeforeJudgment": 72,
   "SubmissionRate": {
     "Submissions": 3,

--- a/TASVideos/appsettings.json
+++ b/TASVideos/appsettings.json
@@ -1,6 +1,7 @@
 ﻿{
   "StartupStrategy": "Minimal",
   "EnableGzipCompression": "True",
+  "EnableZstdCompression": "True",
   "CacheSettings": {
     "CacheType": "Memory",
     "CacheDurationInSeconds": "3600"


### PR DESCRIPTION
Per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept-Encoding#browser_compatibility) this is supported in Chrome >= 123 (and thus in most browsers), as well as FF >= 126, but not Safari. Browsers which don't support Zstandard simply won't ask for it in `Accept-Encoding`, and will get either gzip or no compression.
There's no chance of this making it into .NET 10, but it's only 20 LOC to do it ourselves. The ZstdSharp library was already included transitively.