### PR TITLE
Change site timings to use 3 decimal places instead of 2

### DIFF
--- a/TASVideos.Common/ITimeable.cs
+++ b/TASVideos.Common/ITimeable.cs
@@ -27,27 +27,27 @@ public static class TimeableExtensions
 			return TimeSpan.MaxValue;
 		}
 
-		return TimeSpan.FromMilliseconds(Math.Round(timeable.Frames / timeable.FrameRate * 100, MidpointRounding.AwayFromZero) * 10);
+		return TimeSpan.FromMilliseconds(Math.Round(timeable.Frames / timeable.FrameRate * 1000, MidpointRounding.AwayFromZero));
 	}
 
 	public static string ToStringWithOptionalDaysAndHours(this TimeSpan timeSpan)
 	{
 		if (timeSpan.Days >= 1)
 		{
-			return timeSpan.ToString(@"d\:hh\:mm\:ss\.ff");
+			return timeSpan.ToString(@"d\:hh\:mm\:ss\.fff");
 		}
 
 		if (timeSpan.Hours >= 1)
 		{
-			return timeSpan.ToString(@"h\:mm\:ss\.ff");
+			return timeSpan.ToString(@"h\:mm\:ss\.fff");
 		}
 
-		if (timeSpan.TotalSeconds <= 0.01)
+		if (timeSpan.TotalSeconds <= 0.001)
 		{
-			return "00:00.01";
+			return "00:00.001";
 		}
 
-		return timeSpan.ToString(@"mm\:ss\.ff");
+		return timeSpan.ToString(@"mm\:ss\.fff");
 	}
 
 	public static string ToRelativeString(this TimeSpan relativeTime)

--- a/TASVideos/WikiModules/MovieStatistics.cshtml.cs
+++ b/TASVideos/WikiModules/MovieStatistics.cshtml.cs
@@ -110,7 +110,7 @@ public class MovieStatistics(ApplicationDbContext db) : WikiViewComponent
 						Title = p.Title,
 
 						// the hackiest of workarounds but just calling Time() makes it explode for hardly fathomable reasons
-						Value = TimeSpan.FromMilliseconds(Math.Round(p.Frames / p.SystemFrameRate!.FrameRate * 100, MidpointRounding.AwayFromZero) * 10)
+						Value = TimeSpan.FromMilliseconds(Math.Round(p.Frames / p.SystemFrameRate!.FrameRate * 1000, MidpointRounding.AwayFromZero))
 					});
 				break;
 


### PR DESCRIPTION
This PR increases the accuracy with which movie times are displayed from 2 decimal places to 3. This addresses a minor issue with #2212 where the parsed movie time is slightly less accurate than what is displayed in-game. Many other games measure times to the millisecond rather than the centisecond, so this could also prove useful if we were to add other IGT-based parsers in the future, especially for those games that can be optimised on a millisecond-by-millisecond basis (e.g. Mario Kart Wii).