### PR TITLE
Make Verison link to github /commits instead of /commit

### DIFF
--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -167,7 +167,7 @@
 					@{
 						var (version, sha) = Versioning.GetVersion();
 					}
-					<a class="btn btn-silver btn-sm mb-2" href="https://github.com/TASVideos/tasvideos/commit/@(sha)">&copy; @DateTime.UtcNow.Year - TASVideos v@(version)</a>
+					<a class="btn btn-silver btn-sm mb-2" href="https://github.com/TASVideos/tasvideos/commits/@(sha)">&copy; @DateTime.UtcNow.Year - TASVideos v@(version)</a>
 					<a class="btn btn-info btn-sm mb-2" href="/SiteRules">Terms</a>
 					<a class="btn btn-info btn-sm mb-2" href="/api">API</a>
 					@{

--- a/tests/TASVideos.IntegrationTests/VersionIntegrationTests.cs
+++ b/tests/TASVideos.IntegrationTests/VersionIntegrationTests.cs
@@ -32,7 +32,7 @@ public class VersionIntegrationTests
 		response.EnsureSuccessStatusCode("Home page should load successfully");
 
 		// Check that the version link href contains a valid commit SHA
-		var footerLink = await response.QuerySelectorAsync("a[href*='github.com/TASVideos/tasvideos/commit/']");
+		var footerLink = await response.QuerySelectorAsync("a[href*='github.com/TASVideos/tasvideos/commits/']");
 		Assert.IsNotNull(footerLink, "Version link should be present in footer");
 
 		var href = footerLink.GetAttribute("href");
@@ -43,8 +43,8 @@ public class VersionIntegrationTests
 			footerText.Contains("TASVideos v"),
 			$"Footer should contain 'TASVideos v' but got: {footerText}");
 
-		// Extract SHA from URL (e.g., "https://github.com/TASVideos/tasvideos/commit/e2f009c7e95aa93b732b9c7d59c00fcd30fbd0b4")
-		var shaMatch = Regex.Match(href, "/commit/([a-f0-9]+)$");
+		// Extract SHA from URL (e.g., "https://github.com/TASVideos/tasvideos/commits/e2f009c7e95aa93b732b9c7d59c00fcd30fbd0b4")
+		var shaMatch = Regex.Match(href, "/commits/([a-f0-9]+)$");
 		Assert.IsTrue(shaMatch.Success, $"Could not extract SHA from link href: {href}");
 
 		var sha = shaMatch.Groups[1].Value;


### PR DESCRIPTION
Clicking on our version button at the bottom of each page currently links to e.g.
https://github.com/TASVideos/tasvideos/commit/022dc006fc5d0341b80aec911cd91179a5e8e061 (that is `https://github.com/TASVideos/tasvideos/commit/022dc006fc5d0341b80aec911cd91179a5e8e061` without the Github reformatting)
but with this PR it links to e.g.
https://github.com/TASVideos/tasvideos/commits/022dc006fc5d0341b80aec911cd91179a5e8e061

The first one is a direct link to the commit itself, with the file changes and such.
The second one is a list of the commit and all its parents.

I personally think the full list is a better way of showing people what exactly is included in the version.