### PR TITLE
Trim spaces in `[user: UserName]` links

### DIFF
--- a/TASVideos.WikiEngine/MakeBracketed.cs
+++ b/TASVideos.WikiEngine/MakeBracketed.cs
@@ -132,7 +132,7 @@ public static partial class Builtins
 
 		if (text.StartsWith("user:"))
 		{
-			return NormalizeInternalLink(string.Concat("/Users/Profile/", text.AsSpan(5)));
+			return NormalizeInternalLink(string.Concat("/Users/Profile/", text.AsSpan(5).Trim()));
 		}
 
 		return text;


### PR DESCRIPTION
This was harmless when rendering wiki pages (since `/Users/Profile/%20UserName` resolves for some reason), but broke RSS.