### PR TITLE
Deduplicate topics in our forum activity pages when multiple posts were made

### DIFF
--- a/TASVideos/Extensions/EntityExtensions.cs
+++ b/TASVideos/Extensions/EntityExtensions.cs
@@ -627,6 +627,5 @@ public static class EntityExtensions
 			p.Topic!.Title,
 			p.Topic.ForumId,
 			p.Topic!.Forum!.Name,
-			p.Text,
 			p.Poster!.UserName));
 }

--- a/TASVideos/Pages/Forum/Posts/Latest.cshtml
+++ b/TASVideos/Pages/Forum/Posts/Latest.cshtml
@@ -5,6 +5,7 @@
 }
 
 <partial Name="_ForumHeader" model="false" />
+<div class="text-muted">All topics with posts created in the last 3 days.</div>
 <div condition="@Model.Posts.Any()">
 	<partial name="_Pager" model="Model.Posts" />
 	<standard-table>
@@ -12,8 +13,8 @@
 			<tr>
 				<th class="d-none d-md-table-cell">Forum</th>
 				<th>Topic</th>
+				<th>Latest Post</th>
 				<th>Posted</th>
-				<th>Post</th>
 			</tr>
 		</thead>
 		@foreach (var post in Model.Posts)
@@ -22,18 +23,14 @@
 				<td class="d-none d-md-table-cell">
 					<a asp-page="/Forum/Subforum/Index" asp-route-id="@post.ForumId">@post.ForumName</a>
 				</td>
-				<td>
+				<td class="color-visited">
 					<a asp-page="/Forum/Topics/Index" asp-route-id="@post.TopicId">@post.TopicTitle</a>
 				</td>
 				<td>
-					<timezone-convert asp-for="@post.CreateTimestamp"/>
+					<a asp-page="/Forum/Posts/Index" asp-route-id="@post.Id"><i class="fa-regular fa-bookmark"></i> @post.PosterName</a>
 				</td>
 				<td>
-					<a asp-page="/Forum/Posts/Index" asp-route-id="@post.Id"><i class="fa-regular fa-bookmark"></i> @post.PosterName</a>
-					<br/>
-					<small class="d-none d-md-inline-block">
-						@post.Text.CapAndEllipse(50)
-					</small>
+					<timezone-convert asp-for="@post.CreateTimestamp" />
 				</td>
 			</tr>
 		}

--- a/TASVideos/Pages/Forum/Posts/Latest.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Latest.cshtml.cs
@@ -15,6 +15,13 @@ public class LatestModel(ApplicationDbContext db) : BasePageModel
 		Posts = await db.ForumPosts
 			.ExcludeRestricted(UserCanSeeRestricted)
 			.Since(DateTime.UtcNow.AddDays(-3))
+			.Select(p => p.TopicId)
+			.Distinct()
+			.Select(id => db.ForumPosts
+				.ExcludeRestricted(UserCanSeeRestricted)
+				.Where(p => p.TopicId == id)
+				.OrderByDescending(p => p.CreateTimestamp)
+				.First())
 			.OrderByDescending(p => p.CreateTimestamp)
 			.ToLatestPost()
 			.PageOf(Search);
@@ -27,6 +34,5 @@ public class LatestModel(ApplicationDbContext db) : BasePageModel
 		string TopicTitle,
 		int ForumId,
 		string ForumName,
-		string Text,
 		string PosterName);
 }

--- a/TASVideos/Pages/Forum/Posts/New.cshtml
+++ b/TASVideos/Pages/Forum/Posts/New.cshtml
@@ -5,6 +5,7 @@
 }
 
 <partial Name="_ForumHeader" model="false" />
+<div class="text-muted">All topics with posts since you last logged in.</div>
 <div condition="@Model.Posts.Any()">
 	<partial name="_Pager" model="Model.Posts" />
 	<standard-table>
@@ -12,8 +13,8 @@
 			<tr>
 				<th class="d-none d-md-table-cell">Forum</th>
 				<th>Topic</th>
+				<th>Latest Post</th>
 				<th>Posted</th>
-				<th>Post</th>
 			</tr>
 		</thead>
 		@foreach (var post in Model.Posts)
@@ -22,18 +23,14 @@
 				<td class="d-none d-md-table-cell">
 					<a asp-page="/Forum/Subforum/Index" asp-route-id="@post.ForumId">@post.ForumName</a>
 				</td>
-				<td>
+				<td class="color-visited">
 					<a asp-page="/Forum/Topics/Index" asp-route-id="@post.TopicId">@post.TopicTitle</a>
 				</td>
 				<td>
-					<timezone-convert asp-for="@post.CreateTimestamp"/>
+					<a asp-page="/Forum/Posts/Index" asp-route-id="@post.Id"><i class="fa-regular fa-bookmark"></i> @post.PosterName</a>
 				</td>
 				<td>
-					<a asp-page="/Forum/Posts/Index" asp-route-id="@post.Id"><i class="fa-regular fa-bookmark"></i> @post.PosterName</a>
-					<br/>
-					<small class="d-none d-md-inline-block">
-						@post.Text.CapAndEllipse(50)
-					</small>
+					<timezone-convert asp-for="@post.CreateTimestamp" />
 				</td>
 			</tr>
 		}

--- a/TASVideos/Pages/Forum/Posts/New.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/New.cshtml.cs
@@ -17,6 +17,14 @@ public class NewModel(ApplicationDbContext db, IUserManager userManager) : BaseP
 		Posts = await db.ForumPosts
 			.ExcludeRestricted(UserCanSeeRestricted)
 			.Since(user.LastLoggedInTimeStamp ?? DateTime.UtcNow)
+			.Select(p => p.TopicId)
+			.Distinct()
+			.Select(id => db.ForumPosts
+				.ExcludeRestricted(UserCanSeeRestricted)
+				.Since(user.LastLoggedInTimeStamp ?? DateTime.UtcNow)
+				.Where(p => p.TopicId == id)
+				.OrderByDescending(p => p.CreateTimestamp)
+				.First())
 			.OrderByDescending(p => p.CreateTimestamp)
 			.ToLatestPost()
 			.PageOf(Search);

--- a/TASVideos/Pages/Forum/Posts/Unanswered.cshtml
+++ b/TASVideos/Pages/Forum/Posts/Unanswered.cshtml
@@ -5,16 +5,17 @@
 }
 
 <partial Name="_ForumHeader" model="false" />
+<div class="text-muted">All topics with no replies beyond the opening post.</div>
 <partial name="_Pager" model="Model.Posts" />
 <standard-table>
-	<table-head columns="Forum,Topic,Author,Posted On"></table-head>
+	<table-head columns="Forum,Topic,Author,Posted"></table-head>
 	@foreach (var post in Model.Posts)
 	{
 		<tr>
 			<td>
 				<a asp-page="/Forum/Subforum/Index" asp-route-id="@post.ForumId">@post.ForumName</a>
 			</td>
-			<td>
+			<td class="color-visited">
 				<a asp-page="/Forum/Topics/Index" asp-route-id="@post.TopicId">@post.TopicName</a>
 			</td>
 			<td>

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -9,6 +9,7 @@
 	--bs-link-color-rgb: 13,110,253;
 	--bs-link-hover-color: #0a58ca;
 	--bs-link-hover-color-rgb: 10,88,202;
+	--bs-link-visited-color: #64a3ff;
 	--code-bg: var(--bs-body-bg);
 
 	.card {
@@ -36,6 +37,7 @@
 	--bs-body-color-rgb: 248,249,250;
 	--bs-link-color: #5099f1;
 	--bs-link-color-rgb: 80,153,241;
+	--bs-link-visited-color: #769bbe;
 
 	.card {
 		--bs-card-cap-bg: #212529;
@@ -80,6 +82,11 @@ a {
 	&[disabled] {
 		pointer-events: none;
 	}
+}
+.color-visited {
+    a:visited {
+        color: var(--bs-link-visited-color);
+    }
 }
 
 .page-title {


### PR DESCRIPTION
Instead of showing an entry for each post, we now only show the topic and the latest post.
This affects the pages behind the forum buttons "Latest Posts", "Posts since last visit", and "Unanswered Posts".

I also added visited styles for those pages. I actually don't know if we even want this.
But I assumed it would help knowing which topics a user visisted or never visisted. And the user might be interested in that because they visit those topic activity pages.

<img width="1338" height="509" alt="image" src="https://github.com/user-attachments/assets/8ef4161e-f45a-4bac-8235-a8286c6daf1e" />

Overall I'm unsure about this change lol. We can revert this PR if people are unsatisfied, but it's fine to merge for now.