### PR TITLE
Upgrade packages and fix warnings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,52 +2,54 @@
   <ItemGroup>
     <PackageVersion Include="AspNetCore.ReCaptcha" Version="1.8.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="EFCore.NamingConventions" Version="10.0.0" />
+    <PackageVersion Include="EFCore.NamingConventions" Version="10.0.1" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="IPAddressRange" Version="6.3.0" />
-    <PackageVersion Include="JavaScriptEngineSwitcher.V8" Version="3.29.1" />
+    <PackageVersion Include="JavaScriptEngineSwitcher.V8" Version="3.35.2" />
     <PackageVersion Include="LigerShark.WebOptimizer.Core" Version="3.0.477" />
-    <PackageVersion Include="LigerShark.WebOptimizer.Sass" Version="3.0.143" />
-    <PackageVersion Include="MailKit" Version="4.16.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.ClearScript.Complete" Version="7.5.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageVersion Include="LigerShark.WebOptimizer.Sass" Version="3.0.147" />
+    <PackageVersion Include="MailKit" Version="4.17.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.ClearScript.Complete" Version="7.5.1.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
     <!-- version tied to SDK/compiler version, this one must not be higher than SDK supports -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.15.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.9.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.9.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.22.0" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-    <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
+    <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="3.0.114" />
     <PackageVersion Include="MSTest" Version="3.11.1" />
-    <PackageVersion Include="Nager.Country" Version="4.3.5" />
-    <PackageVersion Include="Namotion.Reflection" Version="3.4.3" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="Nager.Country" Version="4.7.1" />
+    <PackageVersion Include="Namotion.Reflection" Version="3.5.1" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
+    <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.9.0-beta.2" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
-    <PackageVersion Include="SharpCompress" Version="0.40.0" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.10.1" />
+    <PackageVersion Include="SharpCompress" Version="0.50.4" />
+    <PackageVersion Include="StackExchange.Redis" Version="3.1.31" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.0" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.2" />
-    <PackageVersion Include="AngleSharp" Version="1.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.57.0" />
-    <PackageVersion Include="Microsoft.Playwright.MSTest" Version="1.57.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.2" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.3" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.12" />
+    <PackageVersion Include="AngleSharp" Version="1.8.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.62.0" />
+    <PackageVersion Include="Microsoft.Playwright.MSTest" Version="1.62.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.12" />
   </ItemGroup>
 </Project>

--- a/TASVideos.Core/Services/FileService.cs
+++ b/TASVideos.Core/Services/FileService.cs
@@ -62,7 +62,7 @@ internal class FileService(ApplicationDbContext db) : IFileService
 	public async Task<byte[]> CopyZip(byte[] zipBytes, string fileName)
 	{
 		await using var submissionFileStream = new MemoryStream(zipBytes);
-		using var submissionZipArchive = SharpZipArchive.Open(submissionFileStream);
+		using var submissionZipArchive = SharpZipArchive.OpenArchive(submissionFileStream);
 		var entries = submissionZipArchive.Entries.ToList();
 		var single = entries.First();
 
@@ -77,11 +77,11 @@ internal class FileService(ApplicationDbContext db) : IFileService
 	public async Task<byte[]> ZipFile(byte[] fileBytes, string fileName)
 	{
 		await using var outStream = new MemoryStream();
-		using (var archive = SharpZipArchive.Create())
+		using (var archive = SharpZipArchive.CreateArchive())
 		{
 			await using var inStream = new MemoryStream(fileBytes, writable: false);
-			archive.AddEntry(fileName, inStream, inStream.Length);
-			archive.SaveTo(outStream);
+			archive.AddEntry(fileName, inStream, closeStream: false, inStream.Length);
+			archive.SaveTo(outStream, new(SharpCompress.Common.CompressionType.Deflate));
 		}
 
 		return outStream.ToArray();

--- a/TASVideos.Core/Services/Publications.cs
+++ b/TASVideos.Core/Services/Publications.cs
@@ -381,7 +381,7 @@ public record UpdatePublicationRequest(
 	string? ExternalAuthors,
 	List<string> Authors,
 	OptimizationMetric Metric,
-	string MetricValue,
+	string? MetricValue,
 	List<int> SelectedFlags,
 	List<int> SelectedTags,
 	List<PermissionTo> UserPermissions,

--- a/TASVideos.Core/Services/QueueService.cs
+++ b/TASVideos.Core/Services/QueueService.cs
@@ -1024,7 +1024,7 @@ public record SubmitRequest(
 	IList<string> Authors,
 	string? ExternalAuthors,
 	OptimizationMetric Metric,
-	string MetricValue,
+	string? MetricValue,
 	string Markup,
 	byte[] MovieFile,
 	IParseResult ParseResult,

--- a/TASVideos.Parsers/Extensions/Extensions.cs
+++ b/TASVideos.Parsers/Extensions/Extensions.cs
@@ -151,7 +151,7 @@ internal static class Extensions
 			}
 
 			ms.Seek(0, SeekOrigin.Begin);
-			return SharpZipArchive.Open(ms);
+			return (SharpZipArchive)SharpZipArchive.OpenArchive(ms);
 		}
 
 		public async Task<SharpTarArchive?> OpenTarGzArchiveRead()
@@ -173,7 +173,7 @@ internal static class Extensions
 			}
 
 			ms.Seek(0, SeekOrigin.Begin);
-			using var gzipArchive = SharpGZipArchive.Open(ms);
+			using var gzipArchive = SharpGZipArchive.OpenArchive(ms);
 			var gzipArchiveEntry = gzipArchive.Entries.SingleOrDefault();
 			if (gzipArchiveEntry == null)
 			{
@@ -196,7 +196,7 @@ internal static class Extensions
 			}
 
 			gzipMs.Seek(0, SeekOrigin.Begin);
-			return SharpTarArchive.Open(gzipMs);
+			return (SharpTarArchive)SharpTarArchive.OpenArchive(gzipMs);
 		}
 	}
 

--- a/TASVideos.Parsers/Parsers/Ltm.cs
+++ b/TASVideos.Parsers/Parsers/Ltm.cs
@@ -33,7 +33,7 @@ internal class Ltm : Parser, IParser
 		double? lengthNanoseconds = null;
 		var isVariableFramerate = false;
 
-		using var reader = ReaderFactory.Open(file);
+		using var reader = ReaderFactory.OpenReader(file);
 		while (reader.MoveToNextEntry())
 		{
 			if (reader.Entry.IsDirectory)

--- a/tests/TASVideos.MovieParsers.Tests/BaseParserTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/BaseParserTests.cs
@@ -21,15 +21,15 @@ public abstract class BaseParserTests
 		// in the real site will always be from within a zip file.
 		var ms = new MemoryStream();
 
-		using (var zip = SharpZipArchive.Create())
+		using (var zip = SharpZipArchive.CreateArchive())
 		{
-			zip.AddEntry("foobar", input, input.Length);
-			zip.SaveTo(ms);
+			zip.AddEntry("foobar", input, closeStream: false, input.Length);
+			zip.SaveTo(ms, new(SharpCompress.Common.CompressionType.Deflate));
 		}
 
 		ms.Position = 0;
 
-		var zip2 = SharpZipArchive.Open(ms);
+		var zip2 = SharpZipArchive.OpenArchive(ms);
 		var movieFile = zip2.Entries.First();
 		var movieFileStream = movieFile.OpenEntryStream();
 		return movieFileStream;


### PR DESCRIPTION
There were some packages that kept outputting warnings due to vulnerabilities (that didn't affect us).
Biggest one was SharpCompress which has many breaking changes and NO migration document. I guess that's what we get for using a package with a 0.x version.

I'm making this initial PR to see if all tests pass.