### PR TITLE
Add reactions to forum posts

### DIFF
--- a/TASVideos.Common/Constants.cs
+++ b/TASVideos.Common/Constants.cs
@@ -82,6 +82,8 @@ public static class SiteGlobalConstants
 	public const int YearsOfBanDisplayedAsIndefinite = 2;
 
 	public const string MainIvatarDomain = "seccdn.libravatar.org"; // keep in sync with profile-settings.js
+
+	public static readonly string[] AllowedReactions = ["👍", "👎", "😄", "😕", "❤️", "🎉", "🚀", "👀"];
 }
 
 public static class ForumConstants

--- a/TASVideos.Common/Constants.cs
+++ b/TASVideos.Common/Constants.cs
@@ -83,7 +83,7 @@ public static class SiteGlobalConstants
 
 	public const string MainIvatarDomain = "seccdn.libravatar.org"; // keep in sync with profile-settings.js
 
-	public static readonly string[] AllowedReactions = ["👍", "👎", "😄", "😕", "❤️", "🎉", "🚀", "👀"];
+	public static readonly string[] AllowedReactions = ["👍", "👎", "😄", "🎉", "😕", "❤️", "🚀", "👀"];
 }
 
 public static class ForumConstants

--- a/TASVideos.Data/ApplicationDbContext.cs
+++ b/TASVideos.Data/ApplicationDbContext.cs
@@ -69,6 +69,7 @@ public class ApplicationDbContext : IdentityDbContext<User, Role, int, UserClaim
 	public DbSet<Forum> Forums { get; set; } = null!;
 	public DbSet<ForumTopic> ForumTopics { get; set; } = null!;
 	public DbSet<ForumPost> ForumPosts { get; set; } = null!;
+	public DbSet<ForumPostReaction> ForumPostReactions { get; set; } = null!;
 	public DbSet<ForumPoll> ForumPolls { get; set; } = null!;
 	public DbSet<ForumPollOption> ForumPollOptions { get; set; } = null!;
 	public DbSet<ForumPollOptionVote> ForumPollOptionVotes { get; set; } = null!;

--- a/TASVideos.Data/Entity/Forum/ForumPost.cs
+++ b/TASVideos.Data/Entity/Forum/ForumPost.cs
@@ -31,6 +31,8 @@ public class ForumPost : BaseEntity
 
 	[JsonIgnore]
 	public NpgsqlTsVector SearchVector { get; set; } = null!;
+
+	public ICollection<ForumPostReaction> Reactions { get; init; } = [];
 }
 
 public static class ForumPostQueryableExtensions

--- a/TASVideos.Data/Entity/Forum/ForumPostReaction.cs
+++ b/TASVideos.Data/Entity/Forum/ForumPostReaction.cs
@@ -1,0 +1,15 @@
+namespace TASVideos.Data.Entity.Forum;
+
+[Index(nameof(PostId), nameof(UserId), IsUnique = true)]
+public class ForumPostReaction : BaseEntity
+{
+	public int Id { get; set; }
+
+	public int PostId { get; set; }
+	public ForumPost? Post { get; set; }
+
+	public int UserId { get; set; }
+	public User? User { get; set; }
+
+	public string Reaction { get; set; } = "";
+}

--- a/TASVideos.Data/Migrations/20260910163054_AddForumPostReactions.Designer.cs
+++ b/TASVideos.Data/Migrations/20260910163054_AddForumPostReactions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using TASVideos.Data;
 namespace TASVideos.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260910163054_AddForumPostReactions")]
+    partial class AddForumPostReactions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TASVideos.Data/Migrations/20260910163054_AddForumPostReactions.cs
+++ b/TASVideos.Data/Migrations/20260910163054_AddForumPostReactions.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace TASVideos.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddForumPostReactions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "forum_post_reactions",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    post_id = table.Column<int>(type: "integer", nullable: false),
+                    user_id = table.Column<int>(type: "integer", nullable: false),
+                    reaction = table.Column<string>(type: "citext", nullable: false),
+                    create_timestamp = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    last_update_timestamp = table.Column<DateTime>(type: "timestamp without time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_forum_post_reactions", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_forum_post_reactions_forum_posts_post_id",
+                        column: x => x.post_id,
+                        principalTable: "forum_posts",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_forum_post_reactions_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_forum_post_reactions_post_id_user_id",
+                table: "forum_post_reactions",
+                columns: new[] { "post_id", "user_id" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_forum_post_reactions_user_id",
+                table: "forum_post_reactions",
+                column: "user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "forum_post_reactions");
+        }
+    }
+}

--- a/TASVideos/Extensions/ViewDataDictionaryExtensions.cs
+++ b/TASVideos/Extensions/ViewDataDictionaryExtensions.cs
@@ -83,5 +83,7 @@ public static class ViewDataDictionaryExtensions
 		public bool UsesMoodPreview() => viewData["use-mood-preview"] is not null;
 		public void UseClientFileCompression() => viewData["use-client-file-compression"] = true;
 		public bool UsesClientFileCompression() => viewData["use-client-file-compression"] is not null;
+		public void UseForumReactions() => viewData["use-forum-reactions"] = true;
+		public bool UsesForumReactions() => viewData["use-forum-reactions"] is not null;
 	}
 }

--- a/TASVideos/Pages/Forum/Posts/Reactions.cshtml
+++ b/TASVideos/Pages/Forum/Posts/Reactions.cshtml
@@ -1,0 +1,16 @@
+@page "/Forum/Posts/{id:int}/Reactions"
+@model TASVideos.Pages.Forum.Posts.ReactionsModel
+@{
+	ViewData.SetTitle($"Reactions for Forum Post {Model.Id}");
+}
+
+<standard-table>
+	<table-head columns="User,Reaction"></table-head>
+	@foreach (var reaction in Model.Reactions)
+	{
+		<tr>
+			<td>@reaction.UserName</td>
+			<td>@reaction.Reaction</td>
+		</tr>
+	}
+</standard-table>

--- a/TASVideos/Pages/Forum/Posts/Reactions.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Reactions.cshtml.cs
@@ -1,0 +1,111 @@
+using TASVideos.Data.Entity.Forum;
+using static TASVideos.Pages.Forum.Topics.IndexModel.PostEntry;
+
+namespace TASVideos.Pages.Forum.Posts;
+
+[AllowAnonymous]
+public class ReactionsModel(ApplicationDbContext db) : BasePageModel
+{
+	[FromRoute]
+	public int Id { get; set; }
+
+	public List<ReactionEntry> Reactions { get; set; } = [];
+
+	public async Task<IActionResult> OnGet()
+	{
+		var userCanSeeRestricted = User.Has(PermissionTo.SeeRestrictedForums);
+
+		var post = await db.ForumPosts
+			.Include(p => p.Reactions)
+			.ThenInclude(r => r.User)
+			.ExcludeRestricted(userCanSeeRestricted)
+			.FirstOrDefaultAsync(p => p.Id == Id);
+
+		if (post is null)
+		{
+			return NotFound();
+		}
+
+		Reactions = post.Reactions
+			.OrderBy(r => r.LastUpdateTimestamp)
+			.Select(r => new ReactionEntry(r.User!.UserName, r.Reaction))
+			.ToList();
+
+		return Page();
+	}
+
+	public async Task<IActionResult> OnPost([FromBody] ReactionRequest? request)
+	{
+		if (!User.Has(PermissionTo.CreateForumPosts))
+		{
+			return AccessDenied();
+		}
+
+		var userCanSeeRestricted = User.Has(PermissionTo.SeeRestrictedForums);
+
+		var post = await db.ForumPosts
+			.Include(p => p.Reactions)
+			.ExcludeRestricted(userCanSeeRestricted)
+			.Where(p => p.PosterId != SiteGlobalConstants.TASVideoAgentId && p.PosterId != SiteGlobalConstants.TASVideosGrueId)
+			.FirstOrDefaultAsync(p => p.Id == Id);
+
+		if (post is null)
+		{
+			return NotFound();
+		}
+
+		var reaction = request?.Reaction;
+		if (!string.IsNullOrEmpty(reaction) && !SiteGlobalConstants.AllowedReactions.Contains(reaction))
+		{
+			return BadRequest("Invalid reaction.");
+		}
+
+		var existingReaction = post.Reactions.SingleOrDefault(r => r.UserId == User.GetUserId());
+
+		if (existingReaction is not null)
+		{
+			if (string.IsNullOrEmpty(reaction))
+			{
+				db.ForumPostReactions.Remove(existingReaction);
+			}
+			else
+			{
+				existingReaction.Reaction = reaction;
+			}
+		}
+		else
+		{
+			if (!string.IsNullOrEmpty(reaction))
+			{
+				var newReaction = new ForumPostReaction
+				{
+					UserId = User.GetUserId(),
+					PostId = post.Id,
+					Reaction = reaction
+				};
+				db.ForumPostReactions.Add(newReaction);
+			}
+		}
+
+		await db.SaveChangesAsync();
+
+		var updatedPost = await db.ForumPosts
+			.Include(p => p.Reactions)
+			.ThenInclude(r => r.User)
+			.ExcludeRestricted(userCanSeeRestricted)
+			.FirstAsync(p => p.Id == Id);
+
+		return Partial("/Pages/Forum/Topics/_ReactionBar.cshtml", new ReactionSummary
+		{
+			PostId = Id,
+			Reactions = updatedPost.Reactions.Select(r => new ReactionSummary.Entry()
+			{
+				UserName = r.User!.UserName,
+				Reaction = r.Reaction
+			}).ToList(),
+		});
+	}
+
+	public record ReactionEntry(string UserName, string Reaction);
+	public record ReactionRequest(string Reaction);
+}

--- a/TASVideos/Pages/Forum/Posts/User.cshtml
+++ b/TASVideos/Pages/Forum/Posts/User.cshtml
@@ -2,6 +2,10 @@
 @model UserModel
 @{
 	ViewData.SetTitle($"Posts for {Model.UserName}");
+	if (User.Has(PermissionTo.CreateForumPosts))
+	{
+		ViewData.UseForumReactions();
+	}
 }
 
 <partial Name="_ForumHeader" model="false" />

--- a/TASVideos/Pages/Forum/Posts/User.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/User.cshtml.cs
@@ -62,7 +62,18 @@ public class UserModel(ApplicationDbContext db, IAwards awards, IPointsService p
 				PosterMood = p.PosterMood,
 				PosterId = p.PosterId,
 				PostEditedTimestamp = p.PostEditedTimestamp,
-				TopicIsLocked = p.Topic!.IsLocked
+				TopicIsLocked = p.Topic!.IsLocked,
+				Reactions = new PostEntry.ReactionSummary
+				{
+					PostId = p.Id,
+					Reactions = p.Reactions
+						.Select(r => new PostEntry.ReactionSummary.Entry
+						{
+							UserName = r.User!.UserName,
+							Reaction = r.Reaction,
+						})
+						.ToList()
+				}
 			})
 			.PageOf(Search);
 

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml
@@ -31,6 +31,10 @@
 			Image = Model.Topic.TopicCreator!.GetCurrentAvatar()
 		});
 	}
+	if (User.Has(PermissionTo.CreateForumPosts))
+	{
+		ViewData.UseForumReactions();
+	}
 }
 
 @section PageTitle {

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml.cs
@@ -134,7 +134,18 @@ public class IndexModel(
 				PostEditedTimestamp = p.PostEditedTimestamp,
 				Subject = p.Subject,
 				Signature = p.Poster.Signature,
-				IsLastPost = p.Id == Topic.LastPostId
+				IsLastPost = p.Id == Topic.LastPostId,
+				Reactions = new PostEntry.ReactionSummary
+				{
+					PostId = p.Id,
+					Reactions = p.Reactions
+						.Select(r => new PostEntry.ReactionSummary.Entry
+						{
+							UserName = r.User!.UserName,
+							Reaction = r.Reaction
+						})
+						.ToList()
+				}
 			})
 			.OrderBy(p => p.CreateTimestamp)
 			.PageOf(Search);
@@ -364,6 +375,7 @@ public class IndexModel(
 		public string? Signature { get; set; }
 
 		public ICollection<AwardAssignmentSummary> Awards { get; set; } = [];
+		public ReactionSummary Reactions { get; set; } = new();
 
 		public bool EnableHtml { get; init; }
 		public bool EnableBbCode { get; init; }
@@ -400,6 +412,17 @@ public class IndexModel(
 					.Append(PosterPlayerRank)
 					.Where(s => !string.IsNullOrEmpty(s))
 					.Select(s => s!.Replace(' ', '\u00A0')));
+			}
+		}
+
+		public class ReactionSummary
+		{
+			public int PostId { get; init; }
+			public List<Entry> Reactions { get; init; } = [];
+			public class Entry
+			{
+				public string UserName { get; init; } = "";
+				public string Reaction { get; init; } = "";
 			}
 		}
 	}

--- a/TASVideos/Pages/Forum/Topics/_ReactionBar.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_ReactionBar.cshtml
@@ -1,0 +1,24 @@
+@model IndexModel.PostEntry.ReactionSummary
+@{
+	var reactionDictionary = Model.Reactions.GroupBy(r => r.Reaction).OrderByDescending(r => SiteGlobalConstants.AllowedReactions.IndexOf(r.Key)).Reverse().ToList();
+	var ownReaction = Model.Reactions.FirstOrDefault(r => r.UserName == User.Name())?.Reaction;
+}
+<div class="d-flex flex-wrap gap-1 mt-2 reaction-bar" data-id="reaction-bar" data-post-id="@Model.PostId" data-own-reaction="@ownReaction">
+	<button permission="@PermissionTo.CreateForumPosts" class="btn rounded-5 p-2 d-flex align-items-center border text-body-tertiary" data-id="reaction-toggle"><i class="fa-regular fa-face-smile"></i></button>
+	<div class="d-flex flex-wrap gap-1">
+		@foreach (var reaction in reactionDictionary)
+		{
+			<button class="btn rounded-5 px-2 py-1 d-flex align-items-center text-body @(ownReaction == reaction.Key ? "btn-outline-primary" : "border")" data-id="reaction-display" data-reaction="@reaction.Key">
+				<span>@reaction.Key</span>
+				<span class="ms-1 @(ownReaction == reaction.Key ? "fw-bold" : "")">@reaction.Count()</span>
+			</button>
+		}
+	</div>
+	<div class="d-none d-flex flex-wrap gap-1" data-id="reaction-choices">
+		@foreach (var reaction in SiteGlobalConstants.AllowedReactions)
+		{
+			<button class="btn rounded-5 px-2 py-1 d-flex align-items-center border" data-id="reaction-btn" data-reaction="@reaction">@reaction</button>
+		}
+	</div>
+</div>
+

--- a/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
@@ -101,6 +101,7 @@
 				<div class="mb-auto">
 					<forum-markup markup="@Model.Text" enable-html="@Model.EnableHtml" enable-bb-code="@Model.EnableBbCode"></forum-markup>
 				</div>
+				<partial name="_ReactionBar" model="Model.Reactions" condition="Model.PosterId != SiteGlobalConstants.TASVideoAgentId && Model.PosterId != SiteGlobalConstants.TASVideosGrueId" />
 				<div condition="!string.IsNullOrWhiteSpace(Model.Signature)" class="forum-signature mt-2 text-body-tertiary lh-sm d-none d-md-block">
 					<small>
 						<forum-markup markup="@Model.Signature" enable-html="false" enable-bb-code="true"></forum-markup>

--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -242,6 +242,8 @@
 	<script condition="ViewData.UsesDiff()" src="/js/diff_match_patch.js"></script>
 	<script condition="ViewData.UsesDiff()" src="/js/diff_view.js"></script>
 	<script condition="ViewData.UsesMoodPreview()" src="/js/mood-preview.js"></script>
+	<script condition="ViewData.UsesForumReactions()" src="/js/forum-reactions.js"></script>
+	<div condition="ViewData.UsesForumReactions()" class="d-none">@Html.AntiForgeryToken()</div>
 	<script src="/js/prevent-double-submit.js"></script>
 	@await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -735,3 +735,7 @@ top-button-bar {
 		padding-left: 1rem;
 	}
 }
+
+.reaction-bar {
+	--bs-btn-hover-bg: var(--bs-card-cap-bg);
+}

--- a/TASVideos/wwwroot/js/forum-reactions.js
+++ b/TASVideos/wwwroot/js/forum-reactions.js
@@ -1,0 +1,64 @@
+window.addEventListener('DOMContentLoaded', function () {
+	const token = document.querySelector('input[name="__RequestVerificationToken"]').value;
+	function registerReactionBars(parent) {
+		Array.from(parent.querySelectorAll('[data-id="reaction-toggle"]')).forEach(toggle => {
+			console.log(toggle);
+			toggle.addEventListener('click', function (e) {
+				const choices = toggle.closest('[data-id="reaction-bar"]').querySelector('[data-id="reaction-choices"]');
+				choices.classList.toggle('d-none');
+			});
+		});
+
+		Array.from(parent.querySelectorAll('[data-id="reaction-btn"]')).forEach(btn => {
+			btn.addEventListener('click', async function (e) {
+				const reaction = btn.dataset.reaction;
+				const bar = btn.closest('[data-id="reaction-bar"]');
+				const postId = bar.dataset.postId;
+
+				var response = await fetch(`/Forum/Posts/${postId}/Reactions`, {
+					method: 'POST',
+					body: JSON.stringify({ "Reaction": reaction }),
+					headers: {
+						'Content-Type': 'application/json',
+						'RequestVerificationToken': token,
+					}
+				});
+				await updateReactionBar(response, bar);
+			});
+		});
+
+		Array.from(parent.querySelectorAll('[data-id="reaction-display"]')).forEach(btn => {
+			btn.addEventListener('click', async function (e) {
+				const reaction = btn.dataset.reaction;
+				const bar = btn.closest('[data-id="reaction-bar"]');
+				const postId = bar.dataset.postId;
+				const isOwnReaction = bar.dataset.ownReaction === reaction;
+				const body = isOwnReaction ? null : JSON.stringify({ "Reaction": reaction });
+
+				var response = await fetch(`/Forum/Posts/${postId}/Reactions`, {
+					method: 'POST',
+					body: body,
+					headers: {
+						'Content-Type': 'application/json',
+						'RequestVerificationToken': token,
+					}
+				});
+				await updateReactionBar(response, bar);
+			});
+		});
+	}
+
+	registerReactionBars(document);
+
+	async function updateReactionBar(response, bar) {
+		if (response.ok) {
+			var newHtml = await response.text();
+
+			const template = document.createElement("template");
+			template.innerHTML = newHtml;
+			const newBar = template.content.firstElementChild;
+			bar.replaceWith(newBar);
+			registerReactionBars(newBar);
+		}
+	}
+});


### PR DESCRIPTION
This PR adds the usual reactions feature of modern social media.

- A user can react with any one of these: 👍👎😄🎉😕❤️🚀👀. (The same as GitHub reactions.)
- No moderation feature as of now.
- Reactions are not anonymous, and can be viewed on `/Forum/Posts/1234/Reactions`, but there is currently no direct link to that url.
- Posts by TASVideoAgent and TASVideosGrue can't be reacted to.
- Only supported with JavaScript enabled. It makes a server call, *and replaces the HTML with the returned HTML from the server*, for reactivity. This is dangerous so we need to be careful that this works as expected. Although since it's just a server request, I believe this is safe.

Images:
<img width="554" height="523" alt="image" src="https://github.com/user-attachments/assets/b179f6e5-0d50-4ebb-bf2a-105a75ede320" />
After clicking on the smiley icon:
<img width="709" height="457" alt="image" src="https://github.com/user-attachments/assets/f073a1b1-9afb-4553-afdd-a27eca863313" />
<img width="704" height="454" alt="image" src="https://github.com/user-attachments/assets/0fe81f29-b41d-48de-a909-e8f5f5ced3a6" />

